### PR TITLE
Possible solution for #7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
+        "ext-sqlite3": "*",
         "calebporzio/sushi": "^2.1",
         "myclabs/deep-copy": "^1.10",
         "spatie/data-transfer-object": "^2.8"


### PR DESCRIPTION
Your environment should have `sqlite` installed for this application to run, so having part of your `"require"` in `composer.json` could clear up confusion