### PR TITLE
fix: Resolved issue of shared states across different canvases

### DIFF
--- a/packages/docs/components/issues/SharedState.tsx
+++ b/packages/docs/components/issues/SharedState.tsx
@@ -1,29 +1,33 @@
 "use client";
 
-import { Application, coreNodeProvider } from "@data-story/core";
+import { Application, coreNodeProvider, DiagramBuilder,nodes } from "@data-story/core";
 import { DataStory } from "@data-story/ui";
 import '@data-story/ui/dist/data-story.css';
 
 export default function SharedState() {
+  const app = new Application();
+  app.register(coreNodeProvider);
+  const diagram = new DiagramBuilder()
+  .add(nodes['Concatenate'])
+  .get()
+  app.boot();
+
+  console.log('app --- app1')
+  const diagram1 = new DiagramBuilder().get();
   const app1 = new Application();
-  const app2 = new Application();
-
   app1.register(coreNodeProvider);
-  app2.register(coreNodeProvider);
-
   app1.boot();
-  app2.boot();
 
   return <div className="">
     <p>Drag or add a node to see how these diagrams share state - that is not intended.</p>
     <p>It can also be reproduced by navigating between tabs/sections.</p>
     <p>Probable solution in <a className="text-blue-500" href="https://reactflow.dev/docs/examples/misc/provider/">reactflow docs</a></p>   
     <div className="mt-2 h-96" >
-      <DataStory server={{ type: 'JS', app: app1 }}
+      <DataStory server={{ type: 'JS', app }} diagram={diagram}
       />
     </div>
     <div className="mt-2 h-96">
-      <DataStory server={{ type: 'JS', app: app2 }}
+      <DataStory server={{ type: 'JS', app: app1 }} diagram={diagram1}
       />
     </div>
   </div>

--- a/packages/docs/components/issues/SharedState.tsx
+++ b/packages/docs/components/issues/SharedState.tsx
@@ -12,7 +12,6 @@ export default function SharedState() {
   .get()
   app.boot();
 
-  console.log('app --- app1')
   const diagram1 = new DiagramBuilder().get();
   const app1 = new Application();
   app1.register(coreNodeProvider);

--- a/packages/ui/src/components/DataStory/DataStory.tsx
+++ b/packages/ui/src/components/DataStory/DataStory.tsx
@@ -1,22 +1,25 @@
 import { Diagram } from "@data-story/core";
 import { Workbench } from "./Workbench";
 import { ServerConfig } from "./clients/ServerConfig";
+import { DataStoryProvider } from "./store/store";
 
 export const DataStory = ({
-  server,
-  diagram,
-  callback,
-  hideToolbar = false,
-}: {
+                            server,
+                            diagram,
+                            callback,
+                            hideToolbar = false,
+                          }: {
   server?: ServerConfig
   diagram?: Diagram
   hideToolbar?: boolean
   callback?: (options: any) => void
 }) => {
-  return <Workbench
-    server={server}
-    diagram={diagram}
-    callback={callback}
-    hideToolbar={hideToolbar}
-  />
+  return <DataStoryProvider>
+    <Workbench
+      server={ server }
+      diagram={ diagram }
+      callback={ callback }
+      hideToolbar={ hideToolbar }
+    />
+  </DataStoryProvider>
 };

--- a/packages/ui/src/components/DataStory/Workbench.tsx
+++ b/packages/ui/src/components/DataStory/Workbench.tsx
@@ -1,6 +1,6 @@
 import 'reactflow/dist/style.css';
 import { DataStoryControls } from './dataStoryControls';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import ReactFlow, { Background, BackgroundVariant, ReactFlowInstance, ReactFlowProvider } from 'reactflow';
 import DataStoryNodeComponent from '../Node/DataStoryNodeComponent';
 import { RunModal } from './modals/runModal';
@@ -28,11 +28,11 @@ const getReactFlowId = () => {
 }
 
 export const Workbench = ({
-                            server,
-                            diagram,
-                            callback,
-                            hideToolbar = false,
-                          }: {
+                             server,
+                             diagram,
+                             callback,
+                             hideToolbar = false,
+                           }: {
   server?: ServerConfig
   diagram?: Diagram
   callback?: (options: any) => void
@@ -50,24 +50,12 @@ export const Workbench = ({
     traverseNodes: state.traverseNodes,
   });
 
-  const {
-    connect,
-    nodes,
-    edges,
-    onNodesChange,
-    onEdgesChange,
-    onInit,
-    openNodeModalId,
-    setOpenNodeModalId,
-    traverseNodes
-  } = useStore(selector, shallow);
+  const { connect, nodes, edges, onNodesChange, onEdgesChange, onInit, openNodeModalId, setOpenNodeModalId, traverseNodes } = useStore(selector, shallow);
 
   const [ id ] = useState(getReactFlowId);
-  const [ showConfigModal, setShowConfigModal ] = useState(false);
-  const [ showRunModal, setShowRunModal ] = useState(false);
-  const [ showAddNodeModal, setShowAddNodeModal ] = useState(false);
-
-  console.log(diagram, 'diagram ?? 111', nodes, 'nodes ?? 111');
+  const [showConfigModal, setShowConfigModal] = useState(false);
+  const [showRunModal, setShowRunModal] = useState(false);
+  const [showAddNodeModal, setShowAddNodeModal] = useState(false);
 
   useHotkeys({
     nodes,
@@ -87,43 +75,44 @@ export const Workbench = ({
         <ReactFlow
           id={id}
           className="bg-gray-50"
-          nodes={ nodes }
-          edges={ edges }
-          nodeTypes={ nodeTypes }
-          onNodesChange={ onNodesChange }
-          onEdgesChange={ onEdgesChange }
-          onConnect={ connect }
-          onInit={ (rfInstance: ReactFlowInstance<any, any>) => {
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={connect}
+          onInit={(rfInstance: ReactFlowInstance<any, any>) => {
             onInit({
               rfInstance,
               server,
               diagram,
               callback
             })
-          } }
-          minZoom={ 0.25 }
-          maxZoom={ 8 }
-          fitView={ true }
-          fitViewOptions={ {
+          }}
+          minZoom={0.25}
+          maxZoom={8}
+          fitView={true}
+          fitViewOptions = {{
             padding: 0.25,
             // minZoom: 0.3,
             // maxZoom: 2,
             // duration: 5,
-          } }
+          }}
         >
-          { !hideToolbar && <DataStoryControls
-            setShowRunModal={ setShowRunModal }
-            setShowAddNodeModal={ setShowAddNodeModal }
-            setShowConfigModal={ setShowConfigModal }
-          /> }
-        <Background color="#E7E7E7" variant={BackgroundVariant.Lines} />
+          {!hideToolbar && <DataStoryControls
+            setShowRunModal={setShowRunModal}
+            setShowAddNodeModal={setShowAddNodeModal}
+            setShowConfigModal={setShowConfigModal}
+          />}
+          <Background color="#E7E7E7" variant={BackgroundVariant.Lines} />
         </ReactFlow>
       </ReactFlowProvider>
-      {/* Modals */ }
-      { showConfigModal && <ConfigModal setShowModal={ setShowConfigModal }/> }
-      { showRunModal && <RunModal setShowModal={ setShowRunModal }/> }
-      { showAddNodeModal && <AddNodeModal setShowModal={ setShowAddNodeModal }/> }
-      { openNodeModalId && <NodeSettingsModal/> }
+
+      {/* Modals */}
+      {showConfigModal && <ConfigModal setShowModal={setShowConfigModal}/>}
+      {showRunModal && <RunModal setShowModal={setShowRunModal}/>}
+      {showAddNodeModal && <AddNodeModal setShowModal={setShowAddNodeModal}/>}
+      {openNodeModalId && <NodeSettingsModal/>}
     </>
   );
 }

--- a/packages/ui/src/components/DataStory/Workbench.tsx
+++ b/packages/ui/src/components/DataStory/Workbench.tsx
@@ -1,7 +1,7 @@
 import 'reactflow/dist/style.css';
 import { DataStoryControls } from './dataStoryControls';
-import { useEffect, useState } from 'react';
-import ReactFlow, { Background, BackgroundVariant, ReactFlowInstance } from 'reactflow';
+import { useState } from 'react';
+import ReactFlow, { Background, BackgroundVariant, ReactFlowInstance, ReactFlowProvider } from 'reactflow';
 import DataStoryNodeComponent from '../Node/DataStoryNodeComponent';
 import { RunModal } from './modals/runModal';
 import { ConfigModal } from './modals/configModal';
@@ -22,12 +22,17 @@ const nodeTypes = {
   // dataStoryOutputNodeComponent: DataStoryNodeComponent,
 };
 
+let ReactFlowId = 1;
+const getReactFlowId = () => {
+  return 'data_story_id_' + (ReactFlowId++);
+}
+
 export const Workbench = ({
-  server,
-  diagram,
-  callback,
-  hideToolbar = false,
-}: {
+                            server,
+                            diagram,
+                            callback,
+                            hideToolbar = false,
+                          }: {
   server?: ServerConfig
   diagram?: Diagram
   callback?: (options: any) => void
@@ -45,65 +50,80 @@ export const Workbench = ({
     traverseNodes: state.traverseNodes,
   });
 
-  const { connect, nodes, edges, onNodesChange, onEdgesChange, onInit, openNodeModalId, setOpenNodeModalId, traverseNodes } = useStore(selector, shallow);  
+  const {
+    connect,
+    nodes,
+    edges,
+    onNodesChange,
+    onEdgesChange,
+    onInit,
+    openNodeModalId,
+    setOpenNodeModalId,
+    traverseNodes
+  } = useStore(selector, shallow);
 
-  const [showConfigModal, setShowConfigModal] = useState(false);
-  const [showRunModal, setShowRunModal] = useState(false);
-  const [showAddNodeModal, setShowAddNodeModal] = useState(false);
+  const [ id ] = useState(getReactFlowId);
+  const [ showConfigModal, setShowConfigModal ] = useState(false);
+  const [ showRunModal, setShowRunModal ] = useState(false);
+  const [ showAddNodeModal, setShowAddNodeModal ] = useState(false);
+
+  console.log(diagram, 'diagram ?? 111', nodes, 'nodes ?? 111');
 
   useHotkeys({
-    nodes, 
-    openNodeModalId, 
+    nodes,
+    openNodeModalId,
     setShowRunModal,
-    setOpenNodeModalId, 
-    showConfigModal, 
-    showRunModal, 
+    setOpenNodeModalId,
+    showConfigModal,
+    showRunModal,
     showAddNodeModal,
     traverseNodes,
     setShowAddNodeModal,
   })
-  
+
   return (
     <>
-      <ReactFlow
-        className="bg-gray-50"
-        nodes={nodes}
-        edges={edges}
-        nodeTypes={nodeTypes}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
-        onConnect={connect}
-        onInit={(rfInstance: ReactFlowInstance<any, any>) => {
-          onInit({
-            rfInstance,
-            server,
-            diagram,
-            callback
-          })
-        }}
-        minZoom={0.25}
-        maxZoom={8}
-        fitView={true}
-        fitViewOptions = {{
-          padding: 0.25,
-          // minZoom: 0.3,
-          // maxZoom: 2,
-          // duration: 5,
-        }}
-      >     
-        {!hideToolbar && <DataStoryControls
-          setShowRunModal={setShowRunModal}
-          setShowAddNodeModal={setShowAddNodeModal}
-          setShowConfigModal={setShowConfigModal}
-        />}
+      <ReactFlowProvider>
+        <ReactFlow
+          id={id}
+          className="bg-gray-50"
+          nodes={ nodes }
+          edges={ edges }
+          nodeTypes={ nodeTypes }
+          onNodesChange={ onNodesChange }
+          onEdgesChange={ onEdgesChange }
+          onConnect={ connect }
+          onInit={ (rfInstance: ReactFlowInstance<any, any>) => {
+            onInit({
+              rfInstance,
+              server,
+              diagram,
+              callback
+            })
+          } }
+          minZoom={ 0.25 }
+          maxZoom={ 8 }
+          fitView={ true }
+          fitViewOptions={ {
+            padding: 0.25,
+            // minZoom: 0.3,
+            // maxZoom: 2,
+            // duration: 5,
+          } }
+        >
+          { !hideToolbar && <DataStoryControls
+            setShowRunModal={ setShowRunModal }
+            setShowAddNodeModal={ setShowAddNodeModal }
+            setShowConfigModal={ setShowConfigModal }
+          /> }
         <Background color="#E7E7E7" variant={BackgroundVariant.Lines} />
-      </ReactFlow>
-
-      {/* Modals */}
-      {showConfigModal && <ConfigModal setShowModal={setShowConfigModal}/>}
-      {showRunModal && <RunModal setShowModal={setShowRunModal}/>}
-      {showAddNodeModal && <AddNodeModal setShowModal={setShowAddNodeModal}/>}    
-      {openNodeModalId && <NodeSettingsModal/>}
+        </ReactFlow>
+      </ReactFlowProvider>
+      {/* Modals */ }
+      { showConfigModal && <ConfigModal setShowModal={ setShowConfigModal }/> }
+      { showRunModal && <RunModal setShowModal={ setShowRunModal }/> }
+      { showAddNodeModal && <AddNodeModal setShowModal={ setShowAddNodeModal }/> }
+      { openNodeModalId && <NodeSettingsModal/> }
     </>
   );
 }

--- a/packages/ui/src/components/DataStory/store/store.tsx
+++ b/packages/ui/src/components/DataStory/store/store.tsx
@@ -129,23 +129,23 @@ export const createStore = () => create<StoreSchema>((set, get) => ({
 
     // Calculate input schema for the target node
     const targetNode = get().nodes.find(node => node.id === connection.target)
-    if (targetNode) {
+    if(targetNode) {
       get().calculateInputSchema(targetNode)
     }
   },
   addNode: (node: DataStoryNode) => {
     set({
-      nodes: [ ...get().nodes.map(node => {
+      nodes: [...get().nodes.map(node => {
         // When adding a node, deselect all other nodes
         node.selected = false
         return node
-      }), node ],
+      }), node],
     })
   },
   updateNode: (node: DataStoryNode) => {
     set({
       nodes: get().nodes.map(existingNode => {
-        if (existingNode.id === node.id) {
+        if(existingNode.id === node.id) {
           return node
         }
 
@@ -155,14 +155,14 @@ export const createStore = () => create<StoreSchema>((set, get) => ({
   },
   setNodes: (nodes: DataStoryNode[]) => {
     set({
-      nodes: [ ...nodes ],
+      nodes: [...nodes],
     })
   },
   refreshNodes: () => {
     console.log(get().nodes)
 
     set({
-      nodes: [ ...get().nodes ],
+      nodes: [...get().nodes],
     })
   },
   setEdges(edges: Edge[]) {
@@ -184,14 +184,14 @@ export const createStore = () => create<StoreSchema>((set, get) => ({
     set({ rfInstance: options.rfInstance })
     get().onInitServer(get().serverConfig)
 
-    if (options.diagram) {
+    if(options.diagram) {
       const flow = reactFlowFromDiagram(options.diagram)
 
       get().setNodes(flow.nodes)
       get().setEdges(flow.edges)
     }
 
-    if (options.callback) {
+    if(options.callback) {
       const run = () => {
         get().server?.run(
           // TODO it seems this does not await setNodes/setEdges?
@@ -208,7 +208,7 @@ export const createStore = () => create<StoreSchema>((set, get) => ({
     )
   },
   onInitServer: (serverConfig: ServerConfig) => {
-    if (serverConfig.type === 'JS') {
+    if(serverConfig.type === 'JS') {
       const server = new JsClient(
         get().setAvailableNodes,
         get().updateEdgeCounts,
@@ -222,7 +222,7 @@ export const createStore = () => create<StoreSchema>((set, get) => ({
       server.init()
     }
 
-    if (serverConfig.type === 'SOCKET') {
+    if(serverConfig.type === 'SOCKET') {
       const server = new SocketClient(
         get().setAvailableNodes,
         get().updateEdgeCounts,
@@ -239,14 +239,14 @@ export const createStore = () => create<StoreSchema>((set, get) => ({
     set({ availableNodes })
   },
   updateEdgeCounts: (edgeCounts: Record<string, number>) => {
-    for (const [ id, count ] of Object.entries(edgeCounts)) {
+    for(const [id, count] of Object.entries(edgeCounts)) {
       const edge = get().edges.find(edge => edge.id === id)
-      if (edge) edge.label = count
+      if(edge) edge.label = count
     }
 
     const newEdges = get().edges.map((edge: Edge) => {
-      Object.entries(edgeCounts).forEach(([ id, count ]) => {
-        if (edge.id === id) {
+      Object.entries(edgeCounts).forEach(([id, count]) => {
+        if(edge.id === id) {
           edge.label = count
           edge.labelBgStyle = {
             opacity: 0.6,
@@ -274,12 +274,12 @@ export const createStore = () => create<StoreSchema>((set, get) => ({
   onSave: () => {
     let name = get().flowName
 
-    if (name === "untitled" || name === "" || name === undefined) {
+    if(name === "untitled" || name === "" || name === undefined) {
       alert("Please choose a name before saving.")
       return
     }
 
-    if (!name.endsWith(".json")) name = name + ".json"
+    if(!name.endsWith(".json")) name = name + ".json"
 
     get().server!.save(
       name,
@@ -292,10 +292,10 @@ export const createStore = () => create<StoreSchema>((set, get) => ({
     const selectedNodes = get().nodes.filter(node => node.selected)
 
     // If multiple nodes are selected we cant navigate
-    if (selectedNodes.length > 1) return
+    if(selectedNodes.length > 1) return
 
     // If no nodes are selected, select the first node
-    if (selectedNodes.length === 0 && get().nodes.length > 0) {
+    if(selectedNodes.length === 0 && get().nodes.length > 0) {
       const firstNode = get().nodes.at(0)!
       firstNode.selected = true
       get().updateNode(firstNode)
@@ -303,22 +303,22 @@ export const createStore = () => create<StoreSchema>((set, get) => ({
     }
 
     // // If one node is selected, navigate
-    if (selectedNodes.length === 1 && get().nodes.length > 0) {
+    if(selectedNodes.length === 1 && get().nodes.length > 0) {
       const node = selectedNodes.at(0)!
       const otherNodes = get().nodes.filter(otherNode => otherNode.id !== node.id)
 
       // Find the closest node in the direction
-      if (direction === 'up') {
+      if(direction === 'up') {
         const closestNode = otherNodes.reduce((closest, otherNode) => {
-          if (otherNode.position.y < node.position.y) {
-            if (closest === null) return otherNode
-            if (otherNode.position.y > closest.position.y) return otherNode
+          if(otherNode.position.y < node.position.y) {
+            if(closest === null) return otherNode
+            if(otherNode.position.y > closest.position.y) return otherNode
           }
 
           return closest
         }, null as DataStoryNode | null)
 
-        if (closestNode) {
+        if(closestNode) {
           node.selected = false
           get().updateNode(node)
           closestNode.selected = true
@@ -326,17 +326,17 @@ export const createStore = () => create<StoreSchema>((set, get) => ({
         }
       }
 
-      if (direction === 'down') {
+      if(direction === 'down') {
         const closestNode = otherNodes.reduce((closest, otherNode) => {
-          if (otherNode.position.y > node.position.y) {
-            if (closest === null) return otherNode
-            if (otherNode.position.y < closest.position.y) return otherNode
+          if(otherNode.position.y > node.position.y) {
+            if(closest === null) return otherNode
+            if(otherNode.position.y < closest.position.y) return otherNode
           }
 
           return closest
         }, null as DataStoryNode | null)
 
-        if (closestNode) {
+        if(closestNode) {
           node.selected = false
           get().updateNode(node)
           closestNode.selected = true
@@ -344,17 +344,17 @@ export const createStore = () => create<StoreSchema>((set, get) => ({
         }
       }
 
-      if (direction === 'left') {
+      if(direction === 'left') {
         const closestNode = otherNodes.reduce((closest, otherNode) => {
-          if (otherNode.position.x < node.position.x) {
-            if (closest === null) return otherNode
-            if (otherNode.position.x > closest.position.x) return otherNode
+          if(otherNode.position.x < node.position.x) {
+            if(closest === null) return otherNode
+            if(otherNode.position.x > closest.position.x) return otherNode
           }
 
           return closest
         }, null as DataStoryNode | null)
 
-        if (closestNode) {
+        if(closestNode) {
           node.selected = false
           get().updateNode(node)
           closestNode.selected = true
@@ -362,17 +362,17 @@ export const createStore = () => create<StoreSchema>((set, get) => ({
         }
       }
 
-      if (direction === 'right') {
+      if(direction === 'right') {
         const closestNode = otherNodes.reduce((closest, otherNode) => {
-          if (otherNode.position.x > node.position.x) {
-            if (closest === null) return otherNode
-            if (otherNode.position.x < closest.position.x) return otherNode
+          if(otherNode.position.x > node.position.x) {
+            if(closest === null) return otherNode
+            if(otherNode.position.x < closest.position.x) return otherNode
           }
 
           return closest
         }, null as DataStoryNode | null)
 
-        if (closestNode) {
+        if(closestNode) {
           node.selected = false
           get().updateNode(node)
           closestNode.selected = true
@@ -387,11 +387,11 @@ export const createStore = () => create<StoreSchema>((set, get) => ({
 
     links.forEach(link => {
       const sourceNode = get().nodes.find(node => node.id === link.source)
-      if (!sourceNode) return
+      if(!sourceNode) return
 
       const sourcePortName = sourceNode.data.outputs.find(output => output.id === link.sourceHandle)?.name
       const targetPortName = node.data.inputs.find(input => input.id === link.targetHandle)?.name
-      if (!sourcePortName || !targetPortName) return;
+      if(!sourcePortName || !targetPortName) return;
 
       const outputSchema = sourceNode.data.outputs.find(output => output.id === link.sourceHandle)?.schema
 
@@ -411,13 +411,13 @@ export const DataStoryContext = React.createContext<ReturnType<typeof createStor
 export const useStore: UseBoundStore<StoreApi<StoreSchema>> = (...params) => {
   const store = React.useContext(DataStoryContext);
   if(!store) throw new Error('useStore must be used within a DataStoryProvider');
-  // @ts-ignore
+// @ts-ignore
   return store(...params);
 };
 
 
 export const DataStoryProvider = ({ children }: { children: React.ReactNode }) => {
-  const [ useLocalStore ] = useState(() => createStore());
+  const [useLocalStore] = useState(() => createStore());
 
   return <DataStoryContext.Provider value={ useLocalStore }>
     { children }


### PR DESCRIPTION
## fix: Resolved issue of shared states across different canvases

Issue 1: When switching between different pages, the ShareState page retains the node states from the previous page.
before:
https://github.com/ajthinking/data-story/assets/20497176/d0a078fd-82a6-4529-bc39-102184cef59a
after:
https://github.com/ajthinking/data-story/assets/20497176/b956c2c8-212f-4190-8880-85c51e33ad4b

Issue 2: When multiple canvases exist on a single page, the addition of nodes and the scaling of the canvas occur simultaneously.
before:
https://github.com/ajthinking/data-story/assets/20497176/faa93823-6b7e-435e-96e9-3576968fa7cb
after:
https://github.com/ajthinking/data-story/assets/20497176/e4a21c2a-d8d6-4792-a66f-2ca6052ac676

There are three key modifications that resolved this issue:

1.Each DataStory now possesses its own unique diagram and app instance.
2. Zustand serves as a global state management library. By encapsulating useContext within the DataStoryProvider, the state is shared exclusively among the DataStoryProvider component and its child components.
3. In cases where multiple canvases exist on a single page, each ReactFlow component must be wrapped with a ReactFlowProvider, and an unique ID should be assigned to each ReactFlow. https://github.com/wbkd/react-flow/issues/2745#issuecomment-1378696831

