### PR TITLE
Properly rendered markdown

### DIFF
--- a/packages/docs/components/demos/Hero.tsx
+++ b/packages/docs/components/demos/Hero.tsx
@@ -41,12 +41,14 @@ export default () => {
   //   .link('Signal.2.output', 'Merge.1.suppliers')
   //   .get()
 
+  const welcomeMarkdown = '### Welcome to DataStory 👋'
+
   const diagram = new DiagramBuilder()
     .add({...Signal, label: 'Realtime'}, { period: 20, count: 100000})
     .add({...Map, label: 'Automation'})
     .add({...ConsoleLog, label: 'for React & NodeJS'})
 
-    .above('Signal.1').add(Comment, { content: '### Welcome to DataStory!'})
+    .above('Signal.1').add(Comment, { content: welcomeMarkdown})
     .get()
 
   return (

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,11 +18,13 @@
     "@data-story/core": "*",
     "clsx": "^2.0.0",
     "concurrently": "^8.2.1",
+    "markdown-it": "^13.0.2",
     "reactflow": "^11.8.1"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.10",
     "@types/glob": "^8.1.0",
+    "@types/markdown-it": "^13.0.6",
     "@types/node": "18.14.2",
     "@types/react": "18.0.28",
     "@types/react-dom": "18.0.11",

--- a/packages/ui/src/components/Node/DataStoryCommentNodeComponent.tsx
+++ b/packages/ui/src/components/Node/DataStoryCommentNodeComponent.tsx
@@ -2,6 +2,9 @@ import React, { memo } from 'react';
 import { StoreSchema, useStore } from '../DataStory/store/store';
 import { shallow } from 'zustand/shallow';
 import { DataStoryNodeData } from './DataStoryNode';
+import MarkdownIt from 'markdown-it';
+
+const markdown = new MarkdownIt();
 
 const DataStoryCommentNodeComponent = ({ id, data }: {
   id: string,
@@ -15,14 +18,15 @@ const DataStoryCommentNodeComponent = ({ id, data }: {
 
   const contentParam = data.params.find((param) => param.name === 'content')!
 
+  const htmlContent = markdown.render(contentParam.inputMode.value as string);
+
   return (
     (
       <div
         className="max-w-xl prose prose-slate font-mono bg-gray-50 p-4 rounded shadow-xl"
         onDoubleClick={() => setOpenNodeModalId(id)}
-      >
-        {contentParam.inputMode.value as string}
-      </div>
+        dangerouslySetInnerHTML={{ __html: htmlContent }}
+      />
     )
   );
 };

--- a/packages/ui/tailwind.config.js
+++ b/packages/ui/tailwind.config.js
@@ -18,7 +18,7 @@ module.exports = {
     },
   },
   plugins: [
-    require('@tailwindcss/typography'),    
+    require('@tailwindcss/typography'),
   ],
   variants: {
     extend: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,6 +101,7 @@ __metadata:
     "@data-story/core": "npm:*"
     "@tailwindcss/typography": "npm:^0.5.10"
     "@types/glob": "npm:^8.1.0"
+    "@types/markdown-it": "npm:^13.0.6"
     "@types/node": "npm:18.14.2"
     "@types/react": "npm:18.0.28"
     "@types/react-dom": "npm:18.0.11"
@@ -110,6 +111,7 @@ __metadata:
     clsx: "npm:^2.0.0"
     concurrently: "npm:^8.2.1"
     css-loader: "npm:^6.8.1"
+    markdown-it: "npm:^13.0.2"
     nodemon: "npm:^2.0.21"
     postcss: "npm:^8.4.21"
     react-hook-form: "npm:^7.43.8"
@@ -1368,6 +1370,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/linkify-it@npm:*":
+  version: 3.0.5
+  resolution: "@types/linkify-it@npm:3.0.5"
+  checksum: fac28f41a6e576282300a459d70ea0d33aab70dbb77c3d09582bb0335bb00d862b6de69585792a4d590aae4173fbab0bf28861e2d90ca7b2b1439b52688e9ff6
+  languageName: node
+  linkType: hard
+
+"@types/markdown-it@npm:^13.0.6":
+  version: 13.0.6
+  resolution: "@types/markdown-it@npm:13.0.6"
+  dependencies:
+    "@types/linkify-it": "npm:*"
+    "@types/mdurl": "npm:*"
+  checksum: 6fb05ccebc5936ffad3011a3a2d0c7bd00d012791f7f3e16d38820f70eb0d9bef425af04997426e76d1e743cb84f758f53deae353693c973ce752b13658544f2
+  languageName: node
+  linkType: hard
+
 "@types/mdast@npm:^3.0.0":
   version: 3.0.15
   resolution: "@types/mdast@npm:3.0.15"
@@ -1383,6 +1402,13 @@ __metadata:
   dependencies:
     "@types/unist": "npm:*"
   checksum: 6d2d8f00ffaff6663dd67ea9ab999a5e52066c001432a9b99947fa9e76bccba819dfca40e419588a637a70d42cd405071f5b76efd4ddeb1dc721353b7cc73623
+  languageName: node
+  linkType: hard
+
+"@types/mdurl@npm:*":
+  version: 1.0.5
+  resolution: "@types/mdurl@npm:1.0.5"
+  checksum: e8e872e8da8f517a9c748b06cec61c947cb73fd3069e8aeb0926670ec5dfac5d30549b3d0f1634950401633e812f9b7263f2d5dbe7e98fce12bcb2c659aa4b21
   languageName: node
   linkType: hard
 
@@ -3427,6 +3453,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"entities@npm:~3.0.1":
+  version: 3.0.1
+  resolution: "entities@npm:3.0.1"
+  checksum: 3706e0292ea3f3679720b3d3b1ed6290b164aaeb11116691a922a3acea144503871e0de2170b47671c3b735549b8b7f4741d0d3c2987e8f985ccaa0dd3762eba
+  languageName: node
+  linkType: hard
+
 "env-paths@npm:^2.2.0":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
@@ -5378,6 +5411,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"linkify-it@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "linkify-it@npm:4.0.1"
+  dependencies:
+    uc.micro: "npm:^1.0.1"
+  checksum: d0a786d2e3f02f46b6f4a9b466af9eb936fb68e86b7cd305933d5457b12fdc53a4d0e0b697b02dc2e7d84a51d2425d719598bb7b47af7e01911e492e07a97957
+  languageName: node
+  linkType: hard
+
 "lint-staged@npm:^15.0.2":
   version: 15.1.0
   resolution: "lint-staged@npm:15.1.0"
@@ -5593,6 +5635,21 @@ __metadata:
   version: 1.1.1
   resolution: "markdown-extensions@npm:1.1.1"
   checksum: 8a6dd128be1c524049ea6a41a9193715c2835d3d706af4b8b714ff2043a82786dbcd4a8f1fa9ddd28facbc444426c97515aef2d1f3dd11d5e2d63749ba577b1e
+  languageName: node
+  linkType: hard
+
+"markdown-it@npm:^13.0.2":
+  version: 13.0.2
+  resolution: "markdown-it@npm:13.0.2"
+  dependencies:
+    argparse: "npm:^2.0.1"
+    entities: "npm:~3.0.1"
+    linkify-it: "npm:^4.0.1"
+    mdurl: "npm:^1.0.1"
+    uc.micro: "npm:^1.0.5"
+  bin:
+    markdown-it: bin/markdown-it.js
+  checksum: 4f48271bbd44d16502efd4148d7c05ca1fb4b50719a07d34c91e8d16f8d065c558fed0fafe07cd13ca5958096bfe295b37cd4f042add7ec49f73c70154e75f58
   languageName: node
   linkType: hard
 
@@ -5860,6 +5917,13 @@ __metadata:
   dependencies:
     "@types/mdast": "npm:^3.0.0"
   checksum: fafe201c12a0d412a875fe8540bf70b4360f3775fb7f0d19403ba7b59e50f74f730e3b405c72ad940bc8a3ec1ba311f76dfca61c4ce585dce1ccda2168ec244f
+  languageName: node
+  linkType: hard
+
+"mdurl@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "mdurl@npm:1.0.1"
+  checksum: ada367d01c9e81d07328101f187d5bd8641b71f33eab075df4caed935a24fa679e625f07108801d8250a5e4a99e5cd4be7679957a11424a3aa3e740d2bb2d5cb
   languageName: node
   linkType: hard
 
@@ -8921,6 +8985,13 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 5659316360b5cc2d6f5931b346401fa534107b68b60179cf14970e27978f0936c1d5c46f4b5b8175f8cba0430f522b3ce355b4b724c0ea36ce6c0347fab25afd
+  languageName: node
+  linkType: hard
+
+"uc.micro@npm:^1.0.1, uc.micro@npm:^1.0.5":
+  version: 1.0.6
+  resolution: "uc.micro@npm:1.0.6"
+  checksum: 6898bb556319a38e9cf175e3628689347bd26fec15fc6b29fa38e0045af63075ff3fea4cf1fdba9db46c9f0cbf07f2348cd8844889dd31ebd288c29fe0d27e7a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
```html
<article class="prose lg:prose-xl">
  {{ markdown }}
</article>

```

`markdown` here is not markdown, it must be html. So we add a package to fix that