### PR TITLE
fix: resolving the warning issues when the project is launched in the development environment.

### DIFF
--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -20,6 +20,7 @@ module.exports = {
         enforce: 'pre',
         use: ['source-map-loader'],
       });
+      baseConfig.ignoreWarnings = [/Failed to parse source map/];
     }
 
     return baseConfig;

--- a/packages/ui/src/components/DataStory/Workbench.tsx
+++ b/packages/ui/src/components/DataStory/Workbench.tsx
@@ -1,6 +1,6 @@
 import 'reactflow/dist/style.css';
 import { DataStoryControls } from './dataStoryControls';
-import { useEffect, useState } from 'react';
+import { useId, useState } from 'react';
 import ReactFlow, { Background, BackgroundVariant, ReactFlowInstance, ReactFlowProvider } from 'reactflow';
 import DataStoryNodeComponent from '../Node/DataStoryNodeComponent';
 import { RunModal } from './modals/runModal';
@@ -21,12 +21,7 @@ const nodeTypes = {
   // dataStoryOutputNodeComponent: DataStoryNodeComponent,
 };
 
-let ReactFlowId = 1;
-const getReactFlowId = () => {
-  return 'data_story_id_' + (ReactFlowId++);
-};
-
-export const Workbench = ({ 
+export const Workbench = ({
   server,
   diagram,
   callback,
@@ -51,7 +46,7 @@ export const Workbench = ({
 
   const { connect, nodes, edges, onNodesChange, onEdgesChange, onInit, openNodeModalId, setOpenNodeModalId, traverseNodes } = useStore(selector, shallow);
 
-  const [ id ] = useState(getReactFlowId);
+  const id = useId()
   const [showConfigModal, setShowConfigModal] = useState(false);
   const [showRunModal, setShowRunModal] = useState(false);
   const [showAddNodeModal, setShowAddNodeModal] = useState(false);

--- a/packages/ui/src/components/DataStory/store/store.tsx
+++ b/packages/ui/src/components/DataStory/store/store.tsx
@@ -1,4 +1,6 @@
-import { create, StoreApi, UseBoundStore } from 'zustand';
+import { StoreApi, UseBoundStore } from 'zustand';
+import { createWithEqualityFn } from 'zustand/traditional'
+
 import {
   Connection,
   Edge,
@@ -75,7 +77,7 @@ export type StoreSchema = {
   setFlowName: (name: string) => void;
 };
 
-export const createStore = () => create<StoreSchema>((set, get) => ({
+export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) => ({
   // DEFAULTS
   serverConfig: { type: 'SOCKET', url: 'ws://localhost:3100' },
   flowName: 'untitled',


### PR DESCRIPTION
fix: ignore webpack warnings by source-map-loader
fix: updating the zustand API to eliminate the corresponding warnings.
https://github.com/pmndrs/zustand/discussions/1937
fix: server and client id is different
https://react.dev/reference/react/useId#useid
https://nextjs.org/docs/messages/react-hydration-error

| Before | After |
| ------ | ----- |
| ❌      | ✅     |
|![image](https://github.com/ajthinking/data-story/assets/20497176/590258a2-596f-4740-8a3b-904d5609fb54) ![image](https://github.com/ajthinking/data-story/assets/20497176/932378a7-51b3-4d19-a826-620e8e1939b3) |![image](https://github.com/ajthinking/data-story/assets/20497176/11b4a67f-df66-4492-9975-4156b61dc291)|
