### PR TITLE
Add Fake node

### DIFF
--- a/packages/core/src/DiagramBuilder.ts
+++ b/packages/core/src/DiagramBuilder.ts
@@ -5,6 +5,7 @@ import { Link } from './types/Link';
 import { PositionGuesser } from './PositionGuesser';
 import { Port, PortName } from './types/Port';
 import { ComputerConfig } from './types/ComputerConfig';
+import { Fake } from './computers/Fake/Fake';
 
 export class DiagramBuilder {
   diagram: Diagram
@@ -132,7 +133,7 @@ export class DiagramBuilder {
     return this
   }
 
-  addJitter(jitter = {x: 50, y: 25 }) {
+  jiggle(jitter = {x: 50, y: 25 }) {
 
     for(const node of this.diagram.nodes) {
       node.position!.x += (0.5 - Math.random()) * jitter.x
@@ -140,6 +141,40 @@ export class DiagramBuilder {
     }
 
     return this
+  }
+
+  linkByLabel(fromLabelDotOutput: string, toLabelDotInput: string) {
+    const fromNode = this.diagram.nodes.find(node => node.label === fromLabelDotOutput.split('.')[0])
+    const toNode = this.diagram.nodes.find(node => node.label === toLabelDotInput.split('.')[0])
+
+    if(!fromNode) throw new Error(`Bad from label: ${fromLabelDotOutput}. Node not found`)
+    if(!toNode) throw new Error(`Bad to label: ${toLabelDotInput}. Node not found`)
+
+    const fromPort = fromNode.outputs.find(output => output.name === fromLabelDotOutput.split('.')[1])
+    const toPort = toNode.inputs.find(input => input.name === toLabelDotInput.split('.')[1])
+
+    if(!fromPort) throw new Error(`Bad from label: ${fromLabelDotOutput}. Port not found`)
+    if(!toPort) throw new Error(`Bad to label: ${toLabelDotInput}. Port not found`)
+
+    return this.link(fromPort.id!, toPort.id!)
+  }
+
+  addFake({
+    label,
+    inputs = [],
+    outputs = [],
+  
+  }: {
+    label: string,
+    inputs?: string[],
+    outputs?: string[],
+  }) {
+    return this.add({
+      ...Fake,
+      label,
+      inputs: inputs.map((name) => ({ name, schema: { type: 'object' } })),
+      outputs: outputs.map((name) => ({ name, schema: { type: 'object' } })),
+    })
   }
 
   get() {

--- a/packages/core/src/computers/Fake/Fake.ts
+++ b/packages/core/src/computers/Fake/Fake.ts
@@ -1,0 +1,54 @@
+
+import { ComputerConfig } from '../../types/ComputerConfig';
+import { sleep } from '../../utils/sleep';
+
+export const Fake: ComputerConfig = {
+  name: 'Fake',
+  label: 'Fake',
+  params: [],
+
+  canRun({
+    isAvailable,
+    input,
+  }) {
+    return isAvailable();
+  },
+
+  async *run({ input, output, params, node }) {
+    const isCreatorNode = node.inputs.length === 0
+
+    console.log(node.inputs)
+
+    while(true) {
+      if(isCreatorNode) {
+        await sleep(50)
+
+        node.outputs.forEach(outputPort => {
+          output.pushTo(outputPort.name, [
+            {}
+          ])
+        })
+
+        yield;
+      }
+      
+      if(!isCreatorNode) {
+        node.inputs.forEach(inputPort => {
+          try {
+            const [ item ] = input.pullFrom(inputPort.name, 1)
+          } catch(e) {
+            // ignoring
+          }
+        })
+
+        await sleep(50)        
+
+        node.outputs.forEach(outputPort => {
+          output.pushTo(outputPort.name, [{}])
+        })
+
+        yield;
+      }
+    }
+  },
+};

--- a/packages/core/src/computers/Fake/index.ts
+++ b/packages/core/src/computers/Fake/index.ts
@@ -1,0 +1,1 @@
+export { Fake } from './Fake'

--- a/packages/core/src/computers/index.ts
+++ b/packages/core/src/computers/index.ts
@@ -5,6 +5,7 @@ export { ConsoleLog } from './ConsoleLog'
 export { CreateJson } from './CreateJson'
 // export { Dump } from './Dump';
 // export { Eval } from './Eval';
+export { Fake } from './Fake'
 export { Filter } from './Filter';
 export { Ignore } from './Ignore'
 export { InstantThrow } from './InstantThrow';

--- a/packages/docs/components/demos/DocsFlow.tsx
+++ b/packages/docs/components/demos/DocsFlow.tsx
@@ -31,7 +31,7 @@ export default () => {
     .add({...Ignore, label: 'Actions'})
     .from('Pass.1.output').below('Ignore.1').add({...Pass, label: 'APIs'})
     .add({...Ignore, label: 'Storage'})
-    .addJitter({x: 60, y: 25})
+    .jiggle({x: 60, y: 25})
     .above('Signal.1').add(Comment, { content: prettyMarkdown`
       ### DataStory 🔥
       Combine data sources, transforms, actions, APIs, storage and more. Create custom nodes for your business logic.

--- a/packages/docs/components/demos/HeroFlow.tsx
+++ b/packages/docs/components/demos/HeroFlow.tsx
@@ -38,7 +38,7 @@ export default () => {
     .add({...Ignore, label: 'for React & NodeJS'})
     .above('Signal.1').add(Comment, { content: welcomeMarkdown})
     .from('Signal.1.output').below('Pass.1').add({...Ignore, label: 'in Your App'})
-    .addJitter({x: 60, y: 25})
+    .jiggle({x: 60, y: 25})
     .get()
 
   // Good for mobile
@@ -47,7 +47,7 @@ export default () => {
     .add({...Ignore, label: 'Automation'})
     .above('Signal.1').add(Comment, { content: welcomeMarkdown})
     .from('Signal.1.output').below('Ignore.1').add({...Ignore, label: 'in Your App'})
-    .addJitter({x: 60, y: 25})    
+    .jiggle({x: 60, y: 25})    
     .get()
 
   return (


### PR DESCRIPTION
Enable demo of non-existing nodes:

```ts
  const diagram = new DiagramBuilder() 
    .addFake({
      label: 'Lime.persons',
      outputs: ['persons', 'error']
    })
    .addFake({
      label: 'qualifyPersons',
      inputs: ['persons'],
      outputs: ['passed', 'failed']
    })
    .get()
```