### PR TITLE
fix: resolved the issue of the disappearing styles

### DIFF
--- a/packages/docs/globals.css
+++ b/packages/docs/globals.css
@@ -1,4 +1,3 @@
-@import '@data-story/ui/data-story.css';
 
 @tailwind base;
 @tailwind components;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -59,6 +59,7 @@
     "axios": "^1.3.4",
     "css-loader": "^6.8.1",
     "postcss": "^8.4.21",
+    "postcss-loader": "^7.3.3",
     "react-hook-form": "^7.43.8",
     "style-loader": "^3.3.3",
     "tailwindcss": "^3.2.7",

--- a/packages/ui/src/components/DataStory/DataStory.tsx
+++ b/packages/ui/src/components/DataStory/DataStory.tsx
@@ -1,3 +1,4 @@
+import './../../styles/globals.css';
 import { Diagram } from '@data-story/core';
 import { Workbench } from './Workbench';
 import { ServerConfig } from './clients/ServerConfig';

--- a/packages/ui/src/components/DropDown/index.tsx
+++ b/packages/ui/src/components/DropDown/index.tsx
@@ -1,3 +1,4 @@
+import '../../styles/globals.css';
 import { useState } from 'react';
 import { useEscapeKey } from '../DataStory/hooks/useEscapeKey';
 

--- a/packages/ui/webpack.config.js
+++ b/packages/ui/webpack.config.js
@@ -16,6 +16,10 @@ module.exports = {
         test: /\.tsx?$/,
         use: 'ts-loader',
         exclude: '/node_modules/'
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader', 'postcss-loader']
       }
     ]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -234,6 +234,7 @@ __metadata:
     css-loader: "npm:^6.8.1"
     markdown-it: "npm:^13.0.2"
     postcss: "npm:^8.4.21"
+    postcss-loader: "npm:^7.3.3"
     react-hook-form: "npm:^7.43.8"
     reactflow: "npm:^11.8.1"
     style-loader: "npm:^3.3.3"
@@ -3581,7 +3582,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cosmiconfig@npm:8.3.6":
+"cosmiconfig@npm:8.3.6, cosmiconfig@npm:^8.2.0":
   version: 8.3.6
   resolution: "cosmiconfig@npm:8.3.6"
   dependencies:
@@ -7082,7 +7083,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jiti@npm:^1.19.1":
+"jiti@npm:^1.18.2, jiti@npm:^1.19.1":
   version: 1.21.0
   resolution: "jiti@npm:1.21.0"
   bin:
@@ -9738,6 +9739,20 @@ __metadata:
     postcss:
       optional: true
   checksum: f5519426707a7c31baaabcedf4aea0376dfdef517b69895db2ce274811ee609d0bd566a3170bf477703bd1c910f09163a299112a3d07b4537552037c8257a4c5
+  languageName: node
+  linkType: hard
+
+"postcss-loader@npm:^7.3.3":
+  version: 7.3.3
+  resolution: "postcss-loader@npm:7.3.3"
+  dependencies:
+    cosmiconfig: "npm:^8.2.0"
+    jiti: "npm:^1.18.2"
+    semver: "npm:^7.3.8"
+  peerDependencies:
+    postcss: ^7.0.0 || ^8.0.1
+    webpack: ^5.0.0
+  checksum: 743a4286db68169d271bef31e6e9351874bcf2dfa408b82c648c2d5bfba9c862cbfe3004494d927469654d6ac8b82fe647f2b80a186c1dbd44d81632eec1e838
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- problem: It appears that Nextra has a global stylesheet that interferes with other stylesheets.  [Global stylesheet breaks Amplify · Issue #2442 · shuding/nextra](https://github.com/shuding/nextra/issues/2442)

- temporary solution: by bundling with style-loader, the priority of the styles in the UI layer has been elevated, which can temporarily mask this problem. 

- potential risk： other Project A is utilizing data-story/ui, and it also incorporates tailwind as its styling framework. If both A and ui use the default class names of tailwind, their styles might conflict. The final rendering effect depends on which project's style tag is inserted later, as the style inserted later has a higher priority.

| Before | After |
| ------ | ----- |
| ❌      | ✅    |
|![image](https://github.com/ajthinking/data-story/assets/20497176/4ca73ea1-a647-4f58-87b4-2d2ec3b68da4)|![image](https://github.com/ajthinking/data-story/assets/20497176/2c8bbc8b-9775-4f41-83fa-a2cb5d0ff09a)|
