### PR TITLE
Pagination for Peek node

### DIFF
--- a/packages/core/src/computers/Peek/Peek.ts
+++ b/packages/core/src/computers/Peek/Peek.ts
@@ -8,15 +8,13 @@ export const Peek: ComputerConfig = {
   inputs: ['input'],
 
   async *run({ input, hooks, params: rawParams, node }) {
-    const [ first ] = input.pull(1) as ItemWithParams[]
-
-    hooks.register({
-      type: 'PEEK',
-      args: [ node.id, first.value ]
-    })    
-
     while(true) {
-      input.pull()
+      const incoming = input.pull()
+
+      hooks.register({
+        type: 'PEEK',
+        args: [ node.id, incoming.map(i => i.value) ]
+      })
 
       yield;
     }

--- a/packages/ui/src/components/DataStory/clients/JsClient.tsx
+++ b/packages/ui/src/components/DataStory/clients/JsClient.tsx
@@ -11,7 +11,7 @@ export class JsClient implements ServerClient {
   constructor(
     private setAvailableNodes: (nodes: NodeDescription[]) => void,
     private updateEdgeCounts: (edgeCounts: Record<string, number>) => void,
-    private setPeek: (key: string, peek: any) => void,
+    private addPeekItems: (key: string, peek: any[]) => void,
     private setNodes: (nodes: any) => void,
     private setEdges: (edges: any) => void,
     // private setViewport: (viewport: any) => void,
@@ -45,8 +45,8 @@ export class JsClient implements ServerClient {
               if(hook.type === 'CONSOLE_LOG') {
                 console.log(...hook.args)
               } else if(hook.type === 'PEEK') {
-                const [ nodeId, item ] = hook.args
-                this.setPeek(nodeId, item)
+                const [ nodeId, items ] = hook.args
+                this.addPeekItems(nodeId, items)
               } else {
                 const userHook = this.app.hooks.get(hook.type)
   

--- a/packages/ui/src/components/DataStory/clients/SocketClient.tsx
+++ b/packages/ui/src/components/DataStory/clients/SocketClient.tsx
@@ -11,7 +11,7 @@ export class SocketClient implements ServerClient {
   constructor(
     protected setAvailableNodes: (nodes: NodeDescription[]) => void,
     protected updateEdgeCounts: (edgeCounts: Record<string, number>) => void,
-    protected setPeek: (key: string, peek: any) => void,    
+    protected addPeekItems: (key: string, peek: any[]) => void,    
     protected setNodes: (nodes: any) => void,
     protected setEdges: (edges: any) => void,
     // private setViewport: (viewport: any) => void,
@@ -64,8 +64,8 @@ export class SocketClient implements ServerClient {
           if(hook.type === 'CONSOLE_LOG') {
             console.log(...hook.args)
           } else if(hook.type === 'PEEK') {
-            const [ nodeId, item ] = hook.args
-            this.setPeek(nodeId, item)
+            const [ nodeId, items ] = hook.args
+            this.addPeekItems(nodeId, items)
           } else if(hook.type === 'UPDATES') {
             const providedCallback = (...data: any) => {
               console.log('THIS IS THE UPDATE HOOK!')

--- a/packages/ui/src/components/DataStory/store/store.tsx
+++ b/packages/ui/src/components/DataStory/store/store.tsx
@@ -42,8 +42,8 @@ export type StoreSchema = {
   onNodesChange: OnNodesChange;
   setNodes: (nodes: DataStoryNode[]) => void;
   traverseNodes: (direction: 'up' | 'down' | 'left' | 'right') => void;
-  peeks: Record<string, any>;
-  setPeek: (key: string, peek: any) => void;
+  peeks: Record<string, any[]>;
+  addPeekItems: (key: string, peekItems: any[]) => void;
 
   /** The Edges */
   edges: Edge[];
@@ -231,11 +231,17 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
       nodes: [...nodes],
     })
   },
-  setPeek: (key: string, peek: any) => {
+  addPeekItems: (key: string, peekItems: any[]) => {
+    const all = get().peeks
+    const existingAtKey = all[key] ?? []
+
     set({
       peeks: {
-        ...get().peeks,
-        [key]: peek,
+        ...all,
+        [key]: [
+          ...existingAtKey,
+          ...peekItems
+        ],
       },
     })
   },
@@ -316,6 +322,7 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
     }
   },
   onRun: () => {
+    set({ peeks: {}})
     get().server!.run(
       get().toDiagram()
     )
@@ -325,7 +332,7 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
       const server = new JsClient(
         get().setAvailableNodes,
         get().updateEdgeCounts,
-        get().setPeek,
+        get().addPeekItems,
         (nodes) => set({ nodes }),
         (edges) => set({ edges }),
         // (viewport) => set({ viewport }),
@@ -340,7 +347,7 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
       const server = new SocketClient(
         get().setAvailableNodes,
         get().updateEdgeCounts,
-        get().setPeek,        
+        get().addPeekItems,        
         (nodes) => set({ nodes }),
         (edges) => set({ edges }),
         // (viewport) => set({ viewport }),

--- a/packages/ui/src/components/Node/DataStoryPeekNodeComponent.tsx
+++ b/packages/ui/src/components/Node/DataStoryPeekNodeComponent.tsx
@@ -1,18 +1,16 @@
-import React, { memo } from 'react';
+import React, { memo, useEffect } from 'react';
 import { StoreSchema, useStore } from '../DataStory/store/store';
 import { shallow } from 'zustand/shallow';
 import { DataStoryNodeData } from './DataStoryNode';
-import MarkdownIt from 'markdown-it';
 import { Handle, Position } from 'reactflow';
 
-const markdown = new MarkdownIt();
 
 const DataStoryPeekNodeComponent = ({ id, data, selected }: {
   id: string,
   data: DataStoryNodeData,
   selected: boolean
 }) => {
-  const [minimized, setMinimized] = React.useState(false);
+  const [peekIndex, setPeekIndex] = React.useState(0);
 
   const selector = (state: StoreSchema) => ({
     peeks: state.peeks,
@@ -22,16 +20,29 @@ const DataStoryPeekNodeComponent = ({ id, data, selected }: {
 
   const input = data.inputs[0]
 
-  const peek = peeks[id]
+  const peek = peeks[id] && peeks[id][peekIndex];
+
+  const forward = () => {
+    setPeekIndex(Math.min(peekIndex + 1, peeks[id].length - 1));
+  }
+
+  const backward = () => {
+    setPeekIndex(Math.max(peekIndex - 1, 0));
+  }
+
+  // Ensure that the peek index is not out of bounds
+  useEffect(() => {
+    if (peeks[id] && peekIndex >= peeks[id].length) {
+      setPeekIndex(peeks[id].length - 1); // Set to last valid index
+    } else if (!peeks[id] || peeks[id].length === 0) {
+      setPeekIndex(0); // Reset to 0 if no peeks are available
+    }
+  }, [peeks, id, peekIndex]); 
 
   return (
     (
       <div
         className="shadow-xl bg-gray-50 rounded border border-gray-300 overflow-hidden"
-        onClick={() => {
-          if(minimized) setMinimized(false);
-        }}
-        onDoubleClick={() => setMinimized(!minimized)}
       >
         <div className="absolute z-30">
           <div className="absolute">
@@ -42,23 +53,34 @@ const DataStoryPeekNodeComponent = ({ id, data, selected }: {
               className="relative"
               type="target"
               position={Position.Left}
-              style={{ opacity: 0, backgroundColor: 'red', position: 'relative', height: 12, width: 12, top: 0, right: 0}}
+              style={{ opacity: 0, backgroundColor: 'red', position: 'relative', height: 1, width: 1, top: 0, right: 0}}
               id={input.id}
               isConnectable={true}
             />
           </div>
         </div>       
-        {!minimized && <div className="p-2 bg-gray-50 text-gray-600 font-mono text-xxxs">
-          <pre>
-            {peek && JSON.stringify(peek, null, 2)}
-            {!peek && '🕒'}
-          </pre>
-        </div>}
-
-        {minimized && <div className="p-2 bg-gray-50 text-gray-600 font-mono text-xxxs">
-          <pre>
-          🙈
-          </pre>
+        {<div className="bg-gray-50 text-gray-600 font-mono text-xxxs">
+          <div
+            className="flex justify-end w-full py-0.5 border-b space-x-1 px-2"
+          >
+            <div
+              className="hover:bg-gray-100 cursor-pointer"
+              onClick={backward}
+            >‹</div>            
+            <div>
+              {peek && `#${peekIndex + 1}`}
+              {!peek && 'PEEK'}
+            </div>
+            <div
+              className="hover:bg-gray-100 cursor-pointer"
+              onClick={forward}
+            >›</div>
+          </div>
+          <div className="w-full px-1 py-1">
+            <pre className="" style={{ paddingLeft: '0', paddingRight: '0' }}>
+              {peek && JSON.stringify(peek, null, 2)}
+            </pre>
+          </div>
         </div>}
       </div>
     )


### PR DESCRIPTION
Add ability to step through outputs

<img width="1059" alt="image" src="https://github.com/ajthinking/data-story/assets/3457668/3233b259-72b8-4932-b3a0-45aa755f73fd">

### Follow ups
* While this is nice, it is optimized. There might be issues for peeks with 100K+ items. Currently all items will be saved in the store. Maybe we should consider having a cache layer and letting the server provide the previews on demand.
* The node id is used as key in store. This is a problem if Peek.1 is deleted and recreated, then it will have old items attached.