### PR TITLE
fix: corrected the core release to resolve output errors

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,11 +50,11 @@
   },
   "dependencies": {
     "@data-story/hjson": "workspace:*",
-    "@types/node": "18.14.2",
     "axios": "^1.3.4",
     "dotenv": "^16.0.3"
   },
   "devDependencies": {
+    "@types/node": "18.14.2",
     "ts-node": "^10.9.1",
     "typescript": "4.9.5",
     "vite": "^5.0.10",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-story/core",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "main": "dist/main/index.js",
   "type": "commonjs",
   "types": "dist/main/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,8 +27,7 @@
     }
   },
   "files": [
-    "dist/main",
-    "dist/vite"
+    "dist/**/*"
   ],
   "scripts": {
     "build-vite": "vite build",

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-story/nodejs",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "main": "dist/index.js",
   "type": "commonjs",
   "types": "dist/index.d.ts",

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@data-story/core": "workspace:*",
-    "@types/node": "18.14.2",
     "axios": "^1.3.4",
     "dotenv": "^16.0.3",
     "openai": "^3.2.1",
@@ -37,6 +36,7 @@
   },
   "devDependencies": {
     "@types/glob": "^8.1.0",
+    "@types/node": "18.14.2",
     "@types/ws": "^8.5.4",
     "nodemon": "^2.0.21",
     "ts-node": "^10.9.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-story/ui",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "main": "./dist/bundle.js",
   "types": "./dist/src/index.d.ts",
   "exports": {


### PR DESCRIPTION
- clear the cache in turbo 
     -  If you encounter any problem with the output (dist) files when running the `yarn build` command in the root directory, you can try the following command.
   `rm -rf node_modules/.cache/turbo/`
- build and pack the correct content output in core and nodejs

| Before | After |
| ------ | ----- |
| ❌      | ✅    |
|![image](https://github.com/ajthinking/data-story/assets/20497176/f6ca7443-0dfa-4e3c-b97d-8ae283175023)|![image](https://github.com/ajthinking/data-story/assets/20497176/3583cab2-757d-48fd-8e97-24fbf582345c)|

- Ensure it works properly in datastory-desktop repo

![image](https://github.com/ajthinking/data-story/assets/20497176/86184a54-ef1f-44d6-8738-a1e1361106a8)
