### PR TITLE
feat: add toast to docs and desktop project

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,6 @@ module.exports = {
       'single'
     ],
     '@stylistic/eol-last': 'off',
-    '@stylistic/space-infix-ops': ['error', { 'int32Hint': false }]
+    '@stylistic/space-infix-ops': ['warn', { 'int32Hint': false }]
   }
 };

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -47,6 +47,7 @@
     "electron-squirrel-startup": "^1.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-toastify": "^10.0.4",
     "vitest": "^1.1.3"
   }
 }

--- a/packages/desktop/src/common.ts
+++ b/packages/desktop/src/common.ts
@@ -1,3 +1,5 @@
+import { Bounce, toast, ToastOptions } from 'react-toastify';
+
 export const getCoreVersion = () => {
   const { version } = require('@data-story/core/package.json');
   return version;
@@ -17,3 +19,24 @@ export const tryParseJSON = (data: string) => {
     }
   }
 }
+
+const toastConfig: ToastOptions = {
+  position: 'top-right',
+  autoClose: 2000,
+  hideProgressBar: true,
+  closeOnClick: true,
+  pauseOnHover: false,
+  draggable: false,
+  theme: 'light',
+  transition: Bounce,
+}
+export function errorToast(content: string): void {
+  toast.error(content, toastConfig);
+}
+export function successToast(content: string): void {
+  toast.success(content, toastConfig);
+}
+
+
+
+

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -2,16 +2,16 @@
 // https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
 // preload.js
 import { contextBridge, ipcRenderer } from 'electron';
-import { LocalDiagram } from './types';
+import { IpcResult } from './types';
 
 
 contextBridge.exposeInMainWorld('electron', {
 
-  saveDiagram: (data: string): Promise<void> => {
+  saveDiagram: (data: string): Promise<IpcResult> => {
     return ipcRenderer.invoke('save-diagram', data);
   },
 
-  openFileDialog: (): Promise<LocalDiagram> => {
+  openFileDialog: (): Promise<IpcResult> => {
     return ipcRenderer.invoke('open-diagram');
   },
 

--- a/packages/desktop/src/save.tsx
+++ b/packages/desktop/src/save.tsx
@@ -1,6 +1,6 @@
 import { ControlButton } from 'reactflow';
-import React from 'react';
-import { SaveIcon, useDataStoryControls, OpenIcon } from '@data-story/ui';
+import React, { useEffect } from 'react';
+import { SaveIcon, useDataStoryControls, OpenIcon, eventManager, DataStoryEvents } from '@data-story/ui';
 import { Diagram } from '@data-story/core';
 import { IpcResult, LocalDiagram } from './types';
 import { tryParseJSON, getCoreVersion, errorToast, successToast } from './common';
@@ -51,9 +51,28 @@ export const loadDiagram = async (): Promise<LocalDiagram> => {
   return initDiagram;
 }
 
+const initToast = () => {
+  return eventManager.on(event  => {
+    if (event.type === DataStoryEvents.RUN_SUCCESS) {
+      successToast('Diagram executed successfully!');
+    }
+
+    if (event.type === DataStoryEvents.RUN_ERROR) {
+      errorToast('Diagram execution failed!');
+    }
+  })
+};
+
 
 export const SaveComponent = () => {
   const { getDiagram, updateDiagram } = useDataStoryControls()
+
+  useEffect(() => {
+    const subscription = initToast();
+    return () => {
+      subscription.unsubscribe();
+    }
+  }, []);
 
   const handleOpenFile = async () => {
     const diagramInfo = await loadDiagram();

--- a/packages/desktop/src/save.tsx
+++ b/packages/desktop/src/save.tsx
@@ -1,13 +1,20 @@
 import { ControlButton } from 'reactflow';
 import React from 'react';
-import { SaveIcon, useDataStoryControls, OpenIcon, eventManager, DataStoryEvents, useDataStoryEvent } from '@data-story/ui';
+import {
+  DataStoryEvents,
+  DataStoryEventType,
+  OpenIcon,
+  SaveIcon,
+  useDataStoryControls,
+  useDataStoryEvent
+} from '@data-story/ui';
 import { Diagram } from '@data-story/core';
 import { IpcResult, LocalDiagram } from './types';
-import { tryParseJSON, getCoreVersion, errorToast, successToast } from './common';
+import { errorToast, getCoreVersion, successToast, tryParseJSON } from './common';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
-const saveDiagram = async (diagram: Diagram) => {
+const saveDiagram = async(diagram: Diagram) => {
 
   const diagramJSON = JSON.stringify({
     type: 'save',
@@ -25,7 +32,7 @@ const saveDiagram = async (diagram: Diagram) => {
 };
 
 
-export const loadDiagram = async (): Promise<LocalDiagram> => {
+export const loadDiagram = async(): Promise<LocalDiagram> => {
   const initDiagram: LocalDiagram = {
     type: 'load',
     version: getCoreVersion(),
@@ -33,14 +40,14 @@ export const loadDiagram = async (): Promise<LocalDiagram> => {
   }
 
   const file: IpcResult = await window.electron.openFileDialog();
-  if(!file || file.isSuccess === false){
+  if (!file || file.isSuccess === false) {
     errorToast('Could not open file!');
     console.warn('Could not open file', file);
     return initDiagram;
   }
 
   const { valid, result } = tryParseJSON(file.data);
-  if(!valid){
+  if (!valid) {
     errorToast('Could not parse JSON!');
     console.warn('Could not parse JSON', result);
     return initDiagram;
@@ -51,16 +58,14 @@ export const loadDiagram = async (): Promise<LocalDiagram> => {
   return initDiagram;
 }
 
-const initToast = () => {
-  return eventManager.on(event  => {
-    if (event.type === DataStoryEvents.RUN_SUCCESS) {
-      successToast('Diagram executed successfully!');
-    }
+const initToast = (event: DataStoryEventType) => {
+  if (event.type === DataStoryEvents.RUN_SUCCESS) {
+    successToast('Diagram executed successfully!');
+  }
 
-    if (event.type === DataStoryEvents.RUN_ERROR) {
-      errorToast('Diagram execution failed!');
-    }
-  })
+  if (event.type === DataStoryEvents.RUN_ERROR) {
+    errorToast('Diagram execution failed!');
+  }
 };
 
 
@@ -68,10 +73,10 @@ export const SaveComponent = () => {
   const { getDiagram, updateDiagram } = useDataStoryControls()
 
   useDataStoryEvent(initToast);
-  const handleOpenFile = async () => {
+  const handleOpenFile = async() => {
     const diagramInfo = await loadDiagram();
 
-    if(updateDiagram && diagramInfo.diagram){
+    if (updateDiagram && diagramInfo.diagram) {
       updateDiagram(diagramInfo.diagram);
       successToast('Diagram loaded successfully!');
     }
@@ -92,9 +97,9 @@ export const SaveComponent = () => {
         title="Open"
         aria-label="Open"
         onClick={handleOpenFile}>
-        <OpenIcon />
+        <OpenIcon/>
       </ControlButton>
-      <ToastContainer />
+      <ToastContainer/>
     </>
   );
 }

--- a/packages/desktop/src/save.tsx
+++ b/packages/desktop/src/save.tsx
@@ -1,6 +1,6 @@
 import { ControlButton } from 'reactflow';
-import React, { useEffect } from 'react';
-import { SaveIcon, useDataStoryControls, OpenIcon, eventManager, DataStoryEvents } from '@data-story/ui';
+import React from 'react';
+import { SaveIcon, useDataStoryControls, OpenIcon, eventManager, DataStoryEvents, useDataStoryEvent } from '@data-story/ui';
 import { Diagram } from '@data-story/core';
 import { IpcResult, LocalDiagram } from './types';
 import { tryParseJSON, getCoreVersion, errorToast, successToast } from './common';
@@ -67,13 +67,7 @@ const initToast = () => {
 export const SaveComponent = () => {
   const { getDiagram, updateDiagram } = useDataStoryControls()
 
-  useEffect(() => {
-    const subscription = initToast();
-    return () => {
-      subscription.unsubscribe();
-    }
-  }, []);
-
+  useDataStoryEvent(initToast);
   const handleOpenFile = async () => {
     const diagramInfo = await loadDiagram();
 

--- a/packages/desktop/src/types.d.ts
+++ b/packages/desktop/src/types.d.ts
@@ -5,3 +5,8 @@ export interface LocalDiagram {
   version: string;
   diagram: Diagram;
 }
+
+export interface IpcResult {
+  data: string;
+  isSuccess: boolean;
+}

--- a/packages/docs/components/Playground.tsx
+++ b/packages/docs/components/Playground.tsx
@@ -1,7 +1,7 @@
 import { Application, coreNodeProvider, Diagram } from '@data-story/core';
 import React from 'react';
 import { DataStory } from '@data-story/ui';
-import { loadDiagram, LocalStorageKey, SaveComponent } from './Save';
+import { loadDiagram, LocalStorageKey,  SaveComponent } from './Save';
 
 export default ({ mode }: {mode?: 'js' | 'node'}) => {
   const app = new Application()

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -10,7 +10,7 @@ module.exports = {
   images: {
     unoptimized: true,
   },
-
+  experimental: { esmExternals: false },
   webpack: (config, context) => {
     const baseConfig = nextraConfig.webpack(config, context);
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -27,7 +27,8 @@
     "nextra": "latest",
     "nextra-theme-docs": "latest",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-toastify": "^10.0.4"
   },
   "devDependencies": {
     "@types/node": "*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,6 +45,7 @@
     "concurrently": "^8.2.1",
     "markdown-it": "^13.0.2",
     "reactflow": "^11.8.1",
+    "rxjs": "^7.8.1",
     "zustand": "^4.3.9"
   },
   "devDependencies": {

--- a/packages/ui/src/components/DataStory/clients/JsClient.tsx
+++ b/packages/ui/src/components/DataStory/clients/JsClient.tsx
@@ -1,5 +1,7 @@
 import { Application, Diagram, Executor, NodeDescription, NullStorage, } from '@data-story/core';
 import { ServerClient } from './ServerClient';
+import { eventManager } from '../events/eventManager';
+import { Types } from '../events/eventTypes';
 
 export class JsClient implements ServerClient {
   constructor(
@@ -54,11 +56,17 @@ export class JsClient implements ServerClient {
             // Then wait for the next one
             handleUpdates(iterator);
           } else {
-            console.log('Execution complete 💫')
+            console.log('Execution complete 💫');
+            eventManager.emit({
+              type: Types.RUN_SUCCESS
+            });
           }
         })
         .catch((error: any) => {
-          alert('There was an error! Review console!')
+          eventManager.emit({
+            type: Types.RUN_ERROR,
+            payload: error
+          });
           console.log('Error', error)
         })
     }

--- a/packages/ui/src/components/DataStory/clients/JsClient.tsx
+++ b/packages/ui/src/components/DataStory/clients/JsClient.tsx
@@ -1,7 +1,7 @@
 import { Application, Diagram, Executor, NodeDescription, NullStorage, } from '@data-story/core';
 import { ServerClient } from './ServerClient';
 import { eventManager } from '../events/eventManager';
-import { DataStoryEvents } from '../events/eventTypes';
+import { DataStoryEvents } from '../events/dataStoryEventType';
 
 export class JsClient implements ServerClient {
   constructor(

--- a/packages/ui/src/components/DataStory/clients/JsClient.tsx
+++ b/packages/ui/src/components/DataStory/clients/JsClient.tsx
@@ -1,7 +1,7 @@
 import { Application, Diagram, Executor, NodeDescription, NullStorage, } from '@data-story/core';
 import { ServerClient } from './ServerClient';
 import { eventManager } from '../events/eventManager';
-import { Types } from '../events/eventTypes';
+import { DataStoryEvents } from '../events/eventTypes';
 
 export class JsClient implements ServerClient {
   constructor(
@@ -58,13 +58,13 @@ export class JsClient implements ServerClient {
           } else {
             console.log('Execution complete 💫');
             eventManager.emit({
-              type: Types.RUN_SUCCESS
+              type: DataStoryEvents.RUN_SUCCESS
             });
           }
         })
         .catch((error: any) => {
           eventManager.emit({
-            type: Types.RUN_ERROR,
+            type: DataStoryEvents.RUN_ERROR,
             payload: error
           });
           console.log('Error', error)

--- a/packages/ui/src/components/DataStory/clients/SocketClient.tsx
+++ b/packages/ui/src/components/DataStory/clients/SocketClient.tsx
@@ -2,7 +2,7 @@ import { Diagram, NodeDescription } from '@data-story/core';
 import { ServerClient } from './ServerClient';
 import { Hook } from '@data-story/core';
 import { eventManager } from '../events/eventManager';
-import { Types } from '../events/eventTypes';
+import { DataStoryEvents } from '../events/eventTypes';
 
 export class SocketClient implements ServerClient {
   protected socket?: WebSocket;
@@ -83,7 +83,7 @@ export class SocketClient implements ServerClient {
       if(parsed.type === 'ExecutionResult') {
         console.log('Execution complete 💫')
         eventManager.emit({
-          type: Types.RUN_SUCCESS
+          type: DataStoryEvents.RUN_SUCCESS
         });
         return
       }
@@ -93,7 +93,7 @@ export class SocketClient implements ServerClient {
           history: parsed.history,
         })
         eventManager.emit({
-          type: Types.RUN_ERROR,
+          type: DataStoryEvents.RUN_ERROR,
           payload: parsed
         });
 

--- a/packages/ui/src/components/DataStory/clients/SocketClient.tsx
+++ b/packages/ui/src/components/DataStory/clients/SocketClient.tsx
@@ -2,7 +2,7 @@ import { Diagram, NodeDescription } from '@data-story/core';
 import { ServerClient } from './ServerClient';
 import { Hook } from '@data-story/core';
 import { eventManager } from '../events/eventManager';
-import { DataStoryEvents } from '../events/eventTypes';
+import { DataStoryEvents } from '../events/dataStoryEventType';
 
 export class SocketClient implements ServerClient {
   protected socket?: WebSocket;

--- a/packages/ui/src/components/DataStory/clients/SocketClient.tsx
+++ b/packages/ui/src/components/DataStory/clients/SocketClient.tsx
@@ -92,12 +92,11 @@ export class SocketClient implements ServerClient {
         console.error('Execution failed: ', {
           history: parsed.history,
         })
+
         eventManager.emit({
           type: DataStoryEvents.RUN_ERROR,
           payload: parsed
         });
-
-        setTimeout(() => alert(parsed.message), 100)
 
         return
       }

--- a/packages/ui/src/components/DataStory/clients/SocketClient.tsx
+++ b/packages/ui/src/components/DataStory/clients/SocketClient.tsx
@@ -1,6 +1,8 @@
 import { Diagram, NodeDescription } from '@data-story/core';
 import { ServerClient } from './ServerClient';
 import { Hook } from '@data-story/core';
+import { eventManager } from '../events/eventManager';
+import { Types } from '../events/eventTypes';
 
 export class SocketClient implements ServerClient {
   protected socket?: WebSocket;
@@ -80,7 +82,9 @@ export class SocketClient implements ServerClient {
 
       if(parsed.type === 'ExecutionResult') {
         console.log('Execution complete 💫')
-
+        eventManager.emit({
+          type: Types.RUN_SUCCESS
+        });
         return
       }
 
@@ -88,6 +92,11 @@ export class SocketClient implements ServerClient {
         console.error('Execution failed: ', {
           history: parsed.history,
         })
+        eventManager.emit({
+          type: Types.RUN_ERROR,
+          payload: parsed
+        });
+
         setTimeout(() => alert(parsed.message), 100)
 
         return

--- a/packages/ui/src/components/DataStory/events/dataStoryEventType.ts
+++ b/packages/ui/src/components/DataStory/events/dataStoryEventType.ts
@@ -6,9 +6,9 @@ export enum DataStoryEvents {
   'SAVE_SUCCESS' = 'SAVE_SUCCESS',
 }
 
-export type EventTypes = {
+export type DataStoryEventType = {
   type: DataStoryEvents;
   payload?: any;
 }
 
-export type EventHandler = Partial<Observer<EventTypes>> | ((value: EventTypes) => void);
+export type EventHandler = Partial<Observer<DataStoryEventType>> | ((value: DataStoryEventType) => void);

--- a/packages/ui/src/components/DataStory/events/eventManager.ts
+++ b/packages/ui/src/components/DataStory/events/eventManager.ts
@@ -1,5 +1,6 @@
 import { asyncScheduler, observeOn, Subject } from 'rxjs';
 import { EventHandler, EventTypes } from './eventTypes';
+import { useEffect } from 'react';
 
 class EventManager {
   private subject: Subject<unknown>;
@@ -17,7 +18,7 @@ class EventManager {
   /**
    * subscribe event
    */
-  on(handler: ((value: EventTypes) => void)) {
+  on(handler: EventHandler) {
 
     return this.subject.pipe(
       observeOn(asyncScheduler)
@@ -29,3 +30,14 @@ class EventManager {
  * global singleton event manager
  */
 export const eventManager = new EventManager();
+
+/**
+ * use hook to subscribe event
+ * @param {EventHandler} handler
+ */
+export const useDataStoryEvent = (handler: EventHandler) => {
+  useEffect(() => {
+    const subscription = eventManager.on(handler);
+    return () => subscription.unsubscribe();
+  }, [handler]);
+}

--- a/packages/ui/src/components/DataStory/events/eventManager.ts
+++ b/packages/ui/src/components/DataStory/events/eventManager.ts
@@ -1,58 +1,31 @@
-import { Subject } from 'rxjs';
+import { asyncScheduler, observeOn, Subject } from 'rxjs';
 import { EventHandler, EventTypes } from './eventTypes';
-import type { Observer } from 'rxjs';
 
-// EventManager 类负责创建 Subject 并管理事件的发布和订阅
 class EventManager {
   private subject: Subject<unknown>;
   constructor() {
     this.subject = new Subject();
   }
 
-  // 发布事件
+  /**
+   * emit event
+   */
   emit(event: EventTypes) {
     this.subject.next(event);
   }
 
-  // 订阅事件
-  on(handler: Partial<Observer<EventTypes>> | ((value: EventTypes) => void)) {
-    return this.subject.subscribe(handler);
+  /**
+   * subscribe event
+   */
+  on(handler: ((value: EventTypes) => void)) {
+
+    return this.subject.pipe(
+      observeOn(asyncScheduler)
+    ).subscribe(handler as unknown as ((value: unknown) => void));
   }
 }
 
-// 实例化 EventManager
+/**
+ * global singleton event manager
+ */
 export const eventManager = new EventManager();
-
-// 项目 A：抛出事件
-function projectA() {
-  // ... 一些逻辑
-  eventManager.emit({ type: 'EVENT_TYPE', payload: 'Some Data' });
-  // ... 其他逻辑
-}
-
-// 项目 B：监听事件并处理
-function projectB() {
-  eventManager.on(event => {
-    if (event.type === 'EVENT_TYPE') {
-      console.log('Project B handled:', event.payload);
-      // ... 处理事件
-    }
-  });
-}
-
-// 项目 C：监听事件并处理
-function projectC() {
-  eventManager.on(event => {
-    if (event.type === 'EVENT_TYPE') {
-      console.log('Project C handled:', event.payload);
-      // ... 处理事件
-    }
-  });
-}
-
-// 启动监听
-projectB();
-projectC();
-
-// 触发事件
-projectA();

--- a/packages/ui/src/components/DataStory/events/eventManager.ts
+++ b/packages/ui/src/components/DataStory/events/eventManager.ts
@@ -1,0 +1,58 @@
+import { Subject } from 'rxjs';
+import { EventHandler, EventTypes } from './eventTypes';
+import type { Observer } from 'rxjs';
+
+// EventManager 类负责创建 Subject 并管理事件的发布和订阅
+class EventManager {
+  private subject: Subject<unknown>;
+  constructor() {
+    this.subject = new Subject();
+  }
+
+  // 发布事件
+  emit(event: EventTypes) {
+    this.subject.next(event);
+  }
+
+  // 订阅事件
+  on(handler: Partial<Observer<EventTypes>> | ((value: EventTypes) => void)) {
+    return this.subject.subscribe(handler);
+  }
+}
+
+// 实例化 EventManager
+export const eventManager = new EventManager();
+
+// 项目 A：抛出事件
+function projectA() {
+  // ... 一些逻辑
+  eventManager.emit({ type: 'EVENT_TYPE', payload: 'Some Data' });
+  // ... 其他逻辑
+}
+
+// 项目 B：监听事件并处理
+function projectB() {
+  eventManager.on(event => {
+    if (event.type === 'EVENT_TYPE') {
+      console.log('Project B handled:', event.payload);
+      // ... 处理事件
+    }
+  });
+}
+
+// 项目 C：监听事件并处理
+function projectC() {
+  eventManager.on(event => {
+    if (event.type === 'EVENT_TYPE') {
+      console.log('Project C handled:', event.payload);
+      // ... 处理事件
+    }
+  });
+}
+
+// 启动监听
+projectB();
+projectC();
+
+// 触发事件
+projectA();

--- a/packages/ui/src/components/DataStory/events/eventManager.ts
+++ b/packages/ui/src/components/DataStory/events/eventManager.ts
@@ -1,5 +1,5 @@
 import { asyncScheduler, observeOn, Subject } from 'rxjs';
-import { EventHandler, EventTypes } from './eventTypes';
+import { EventHandler, DataStoryEventType } from './dataStoryEventType';
 import { useEffect } from 'react';
 
 class EventManager {
@@ -11,7 +11,7 @@ class EventManager {
   /**
    * emit event
    */
-  emit(event: EventTypes) {
+  emit(event: DataStoryEventType) {
     this.subject.next(event);
   }
 

--- a/packages/ui/src/components/DataStory/events/eventTypes.ts
+++ b/packages/ui/src/components/DataStory/events/eventTypes.ts
@@ -1,0 +1,13 @@
+import { Observer } from 'rxjs';
+
+export enum Types {
+  'RUN_SUCCESS' = 'RUN_SUCCESS',
+  'RUN_ERROR' = 'RUN_ERROR',
+  'SAVE_SUCCESS' = 'SAVE_SUCCESS',
+}
+export type EventTypes = {
+  type: Types;
+  payload?: any;
+}
+
+export type EventHandler = Partial<Observer<EventTypes>> | ((value: EventTypes) => void);

--- a/packages/ui/src/components/DataStory/events/eventTypes.ts
+++ b/packages/ui/src/components/DataStory/events/eventTypes.ts
@@ -1,12 +1,13 @@
 import { Observer } from 'rxjs';
 
-export enum Types {
+export enum DataStoryEvents {
   'RUN_SUCCESS' = 'RUN_SUCCESS',
   'RUN_ERROR' = 'RUN_ERROR',
   'SAVE_SUCCESS' = 'SAVE_SUCCESS',
 }
+
 export type EventTypes = {
-  type: Types;
+  type: DataStoryEvents;
   payload?: any;
 }
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,4 +3,7 @@ export { DropDown } from './components/DropDown';
 export { SaveIcon } from './components/DataStory/icons/saveIcon'
 export { OpenIcon } from './components/DataStory/icons/openIcon'
 export { useDataStoryControls } from './components/DataStory/dataStoryControls';
+export { eventManager } from './components/DataStory/events/eventManager'
+export { DataStoryEvents, type EventTypes } from './components/DataStory/events/eventTypes'
+
 export { default as DataStoryNodeComponent } from './components/Node/DataStoryNodeComponent';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,6 +4,6 @@ export { SaveIcon } from './components/DataStory/icons/saveIcon'
 export { OpenIcon } from './components/DataStory/icons/openIcon'
 export { useDataStoryControls } from './components/DataStory/dataStoryControls';
 export { eventManager, useDataStoryEvent } from './components/DataStory/events/eventManager'
-export { DataStoryEvents, type EventTypes } from './components/DataStory/events/eventTypes'
+export { DataStoryEvents, type DataStoryEventType } from './components/DataStory/events/dataStoryEventType'
 
 export { default as DataStoryNodeComponent } from './components/Node/DataStoryNodeComponent';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,7 +3,7 @@ export { DropDown } from './components/DropDown';
 export { SaveIcon } from './components/DataStory/icons/saveIcon'
 export { OpenIcon } from './components/DataStory/icons/openIcon'
 export { useDataStoryControls } from './components/DataStory/dataStoryControls';
-export { eventManager } from './components/DataStory/events/eventManager'
+export { eventManager, useDataStoryEvent } from './components/DataStory/events/eventManager'
 export { DataStoryEvents, type EventTypes } from './components/DataStory/events/eventTypes'
 
 export { default as DataStoryNodeComponent } from './components/Node/DataStoryNodeComponent';

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -20,7 +20,7 @@
     "jsx": "react-jsx",
     "allowSyntheticDefaultImports": true,
     "incremental": true,
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "types": ["node", "react", "cypress"],
     "sourceMap": true
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -298,6 +298,7 @@ __metadata:
     postcss-loader: "npm:^7.3.3"
     react-hook-form: "npm:^7.43.8"
     reactflow: "npm:^11.8.1"
+    rxjs: "npm:^7.8.1"
     style-loader: "npm:^3.3.3"
     tailwindcss: "npm:^3.2.7"
     ts-node: "npm:^10.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13887,7 +13887,7 @@ __metadata:
   peerDependencies:
     react: ">=16"
     react-dom: ">=16"
-  checksum: 57f4d0032bf328381bdfeb78ab5efa988d425627a61ffa43b0caa184633a0ea44253a349d6b967247fa3d480ad82a2bbaa9063ce3f89be9550eb9b30398a6837
+  checksum: 10/57f4d0032bf328381bdfeb78ab5efa988d425627a61ffa43b0caa184633a0ea44253a349d6b967247fa3d480ad82a2bbaa9063ce3f89be9550eb9b30398a6837
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -167,6 +167,7 @@ __metadata:
     node-loader: "npm:^2.0.0"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
+    react-toastify: "npm:^10.0.4"
     style-loader: "npm:^3.0.0"
     ts-loader: "npm:^9.2.2"
     ts-node: "npm:^10.0.0"
@@ -4900,7 +4901,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^2.0.0":
+"clsx@npm:^2.0.0, clsx@npm:^2.1.0":
   version: 2.1.0
   resolution: "clsx@npm:2.1.0"
   checksum: 10/2e0ce7c3b6803d74fc8147c408f88e79245583202ac14abd9691e2aebb9f312de44270b79154320d10bb7804a9197869635d1291741084826cff20820f31542b
@@ -13873,6 +13874,18 @@ __metadata:
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
   checksum: 10/200cd65bf2e0be7ba6055f647091b725a45dd2a6abef03bf2380ce701fd5edccee40b49b9d15edab7ac08a762bf83cb4081e31ec2673a5bfb549a36ba21570df
+  languageName: node
+  linkType: hard
+
+"react-toastify@npm:^10.0.4":
+  version: 10.0.4
+  resolution: "react-toastify@npm:10.0.4"
+  dependencies:
+    clsx: "npm:^2.1.0"
+  peerDependencies:
+    react: ">=16"
+    react-dom: ">=16"
+  checksum: 57f4d0032bf328381bdfeb78ab5efa988d425627a61ffa43b0caa184633a0ea44253a349d6b967247fa3d480ad82a2bbaa9063ce3f89be9550eb9b30398a6837
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -194,6 +194,7 @@ __metadata:
     postcss: "npm:^8.4.31"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
+    react-toastify: "npm:^10.0.4"
     source-map-loader: "npm:^4.0.1"
     tailwindcss: "npm:^3.3.3"
     ts-node: "npm:^10.9.1"


### PR DESCRIPTION
- feat: add toast to docs project

https://github.com/ajthinking/data-story/assets/20497176/57bce9b1-f425-4160-a130-fc35bb6b41f3

- feat: add toast to desktop project

https://github.com/ajthinking/data-story/assets/20497176/ac9dd9f7-0db8-473b-b778-0e2cfcd54726


- feat: add eventManager in UI project

The eventManager functions like an event bus, where the ui can publish events (such as: run result) using the eventManager.emit() method, and modules can subscribe to these events using the eventManager.on() method.