### PR TITLE
feat: reimplement the repeatable component

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@data-story/core": "workspace:*",
     "@tanstack/react-table": "^8.11.7",
+    "ahooks": "^3.7.10",
     "clsx": "^2.0.0",
     "concurrently": "^8.2.1",
     "markdown-it": "^13.0.2",

--- a/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
@@ -132,8 +132,7 @@ export function RepeatableComponent({
   form,
   param,
   node,
-}: RepeatableInputProps & {
-}) {
+}: RepeatableInputProps) {
   const { fields, append, remove, swap} = useFieldArray({
     control: form.control,
     name: `params.${param.name}`,

--- a/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
@@ -1,10 +1,9 @@
 import { Param, RepeatableParam } from '@data-story/core';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback } from 'react';
 import {
   useFieldArray,
   UseFormReturn,
 } from 'react-hook-form';
-import { StringableInput } from './StringableInput';
 import { PortSelectionInput } from '../modals/nodeSettingsModal/tabs/Params/PortSelectionInput';
 import { StringableWithConfig } from '../modals/nodeSettingsModal/tabs/Params';
 import { ReactFlowNode } from '../../Node/ReactFlowNode';
@@ -15,41 +14,36 @@ import { Row } from '@tanstack/react-table';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 
 function RepeatableCell({
-  column,
+  paramColumn,
   form,
   name,
   rowIndex,
   node,
-  row
 }: {
-  column: Param,
+  paramColumn: Param,
   form: UseFormReturn<{[p: string]: any}, any>,
   name: any,
   columnIndex: number,
   rowIndex: number,
   node: ReactFlowNode,
-  row:any
 }) {
 
-  const paramCol = column
-
-  console.log('paramCol', paramCol, 'row', row, form, 'form');
   return <td
     scope="row"
     className="border font-medium whitespace-nowrap bg-gray-50 align-top"
   >
-    {paramCol.type === 'StringableParam' && <StringableWithConfig
+    {paramColumn.type === 'StringableParam' && <StringableWithConfig
       form={form}
-      param={paramCol}
-      {...paramCol}
-      name={`params.${name}.${rowIndex}.${paramCol.name}`}
+      param={paramColumn}
+      {...paramColumn}
+      name={`params.${name}.${rowIndex}.${paramColumn.name}`}
       node={node}
     />}
-    {paramCol.type === 'PortSelectionParam' && <PortSelectionInput
+    {paramColumn.type === 'PortSelectionParam' && <PortSelectionInput
       form={form}
-      param={paramCol}
-      {...paramCol}
-      name={`params.${name}.${rowIndex}.${paramCol.name}`}
+      param={paramColumn}
+      {...paramColumn}
+      name={`params.${name}.${rowIndex}.${paramColumn.name}`}
       node={node}
     />}
   </td>;
@@ -63,6 +57,8 @@ function RepeatableDraggableRow(props: RepeatableInputProps & {
 }) {
   const { form, param,  node, row, rowIndex, reorderRow, deleteRow } = props;
   const name = param.name;
+  const paramRow = param.row;
+
   const [, dropRef] = useDrop({
     accept: 'row',
     drop: (draggedRow: Row<unknown>) => reorderRow(draggedRow.index, rowIndex),
@@ -75,8 +71,6 @@ function RepeatableDraggableRow(props: RepeatableInputProps & {
     item: () => ({ index: rowIndex, ...row}),
     type: 'row',
   });
-
-  const paramRow = param.row;
 
   function handleDeleteRow() {
     deleteRow(rowIndex);
@@ -95,9 +89,14 @@ function RepeatableDraggableRow(props: RepeatableInputProps & {
       </button>
     </td>
     {
-      param.row.map((column: Param, columnIndex: number) => (<RepeatableCell key={`${paramRow[columnIndex].name}-${columnIndex}`}
-        column={column} form={form} name={name} rowIndex={rowIndex} row={row}
-        columnIndex={columnIndex} node={node} />))
+      param.row.map((column: Param, columnIndex: number) => (
+        <RepeatableCell
+          key={`${paramRow[columnIndex].name}-${columnIndex}`}
+          paramColumn={column} form={form}
+          name={name} rowIndex={rowIndex}
+          columnIndex={columnIndex} node={node}
+        />
+      ))
     }
     <td className="border font-medium whitespace-nowrap bg-gray-50 align-top">
       <button
@@ -116,7 +115,6 @@ interface RepeatableInputProps {
   }, any>;
   param: RepeatableParam<Param[]>;
   node: ReactFlowNode;
-
 }
 
 const defaultRowData = (row: Param[]) => {
@@ -141,12 +139,9 @@ export function RepeatableComponent({
     name: `params.${param.name}`,
   });
 
-  console.log(fields, 'fields');
-
   const addRow = useCallback(() => {
     append(defaultRowData(param.row));
   }, [append, param.row]);
-
 
   return (
     <div className="flex flex-col text-xs w-full">

--- a/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
@@ -29,7 +29,6 @@ function RepeatableCell({
   const paramCol = column
 
   return <td
-
     scope="row"
     className="border font-medium whitespace-nowrap bg-gray-50 align-top"
   >
@@ -37,14 +36,14 @@ function RepeatableCell({
       form={form}
       param={paramCol}
       {...paramCol}
-      name={`${name}.${rowIndex}.${paramCol.name}`}
+      name={`params.${name}.${rowIndex}.${paramCol.name}`}
       node={node}
     />}
     {paramCol.type === 'PortSelectionParam' && <PortSelectionInput
       form={form}
       param={paramCol}
       {...paramCol}
-      name={`${name}.${rowIndex}.${paramCol.name}`}
+      name={`params.${name}.${rowIndex}.${paramCol.name}`}
       node={node}
     />}
   </td>;

--- a/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
@@ -11,24 +11,22 @@ import { DndProvider, useDrop } from 'react-dnd';
 import { Row } from '@tanstack/react-table';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 
-function RepeatableCol({
+function RepeatableCell({
   column,
   form,
   name,
-  columnIndex,
+  rowIndex,
   node,
-  paramRow
 }: {
-  column: any,
+  column: Param,
   form: UseFormReturn<{[p: string]: any}, any>,
   name: any,
   columnIndex: number,
+  rowIndex: number,
   node: ReactFlowNode,
-  paramRow: Param[],
 }) {
 
-  const paramCol = paramRow[columnIndex];
-  paramCol.value = column[paramCol.name];
+  const paramCol = column
 
   return <td
 
@@ -39,14 +37,14 @@ function RepeatableCol({
       form={form}
       param={paramCol}
       {...paramCol}
-      // name={`${name}.${columnIndex}.${paramCol.name}`}
+      name={`${name}.${rowIndex}.${paramCol.name}`}
       node={node}
     />}
     {paramCol.type === 'PortSelectionParam' && <PortSelectionInput
       form={form}
       param={paramCol}
       {...paramCol}
-      // name={`${name}.${columnIndex}.${paramCol.name}`}
+      name={`${name}.${rowIndex}.${paramCol.name}`}
       node={node}
     />}
   </td>;
@@ -77,9 +75,9 @@ function RepeatableDraggableRow(props: RepeatableInputProps & {
       </button>
     </td>
     {
-      row.map((column: any, columnIndex: number) => (<RepeatableCol key={`${paramRow[columnIndex].name}-${columnIndex}`}
-        column={column} form={form} name={name}
-        columnIndex={columnIndex} node={node} paramRow={paramRow} />))
+      param.row.map((column: Param, columnIndex: number) => (<RepeatableCell key={`${paramRow[columnIndex].name}-${columnIndex}`}
+        column={column} form={form} name={name} rowIndex={rowIndex}
+        columnIndex={columnIndex} node={node} />))
     }
     <td className="border font-medium whitespace-nowrap bg-gray-50 align-top">
       <button
@@ -101,7 +99,7 @@ interface RepeatableInputProps {
 
 }
 
-export function RepeatableInput1({
+export function RepeatableControl({
   form,
   param,
   node,
@@ -113,12 +111,10 @@ export function RepeatableInput1({
     return [param.row]
   }
 
-  const defaultRowData = (row: Param[]): {[p: string]: unknown}[] => {
-    return row.map((column: Param) => {
-      return {
-        [column.name]: column.value
-      }
-    });
+  const defaultRowData = (row: Param[]): unknown => {
+    return Object.fromEntries( row.map((column: Param) => {
+      return [column.name, column.value]
+    }));
   }
 
   const getDefaultData = () => {
@@ -203,9 +199,9 @@ export const RepeatableInput = (props: RepeatableInputProps) => {
     <DndProvider backend={HTML5Backend}>
       <Controller
         render={({ field, fieldState, formState}) =>
-          (<RepeatableInput1 field={field} {...props} />)}
+          (<RepeatableControl field={field} {...props} />)}
         name={'params'}
-        control={props.form.control} // todo: 这里随便写的
+        control={props.form.control}
       />
     </DndProvider>
   )

--- a/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
@@ -1,6 +1,6 @@
 import { Param, RepeatableParam } from '@data-story/core';
 import React, { useState } from 'react';
-import { Controller, UseFormRegister, UseFormReturn } from 'react-hook-form';
+import { Controller, ControllerRenderProps, UseFormRegister, UseFormReturn } from 'react-hook-form';
 import { StringableInput } from './StringableInput';
 import { PortSelectionInput } from '../modals/nodeSettingsModal/tabs/Params/PortSelectionInput';
 import { StringableWithConfig } from '../modals/nodeSettingsModal/tabs/Params';
@@ -16,7 +16,8 @@ function RepeatableDraggableRow(props: RepeatableInputProps & {
   row: any,
   reorderRow: (draggedRowIndex: number, targetRowIndex: number) => void;
 }) {
-  const { form, param, name,  node, row, rowIndex, reorderRow } = props;
+  const { form, param,  node, row, rowIndex, reorderRow } = props;
+  const name = param.name;
   const [, dropRef] = useDrop({
     accept: 'row',
     drop: (draggedRow: Row<unknown>) => reorderRow(draggedRow.index, rowIndex),
@@ -33,28 +34,28 @@ function RepeatableDraggableRow(props: RepeatableInputProps & {
         <DragIcon/>
       </button>
     </td>
-    {/*{*/}
-    {/*  row.map((column: Param, columnIndex: number) => (<td*/}
-    {/*    key={column.name}*/}
-    {/*    scope="row"*/}
-    {/*    className="border font-medium whitespace-nowrap bg-gray-50 align-top"*/}
-    {/*  >*/}
-    {/*    {column.type === 'StringableParam' && <StringableWithConfig*/}
-    {/*      form={form}*/}
-    {/*      param={column}*/}
-    {/*      {...column}*/}
-    {/*      name={`${name}.${columnIndex}.${column.name}`}*/}
-    {/*      node={node}*/}
-    {/*    />}*/}
-    {/*    {column.type === 'PortSelectionParam' && <PortSelectionInput*/}
-    {/*      form={form}*/}
-    {/*      param={column}*/}
-    {/*      {...column}*/}
-    {/*      name={`${name}.${columnIndex}.${column.name}`}*/}
-    {/*      node={node}*/}
-    {/*    />}*/}
-    {/*  </td>))*/}
-    {/*}*/}
+    {
+      row.map((column: Param, columnIndex: number) => (<td
+        key={column.name}
+        scope="row"
+        className="border font-medium whitespace-nowrap bg-gray-50 align-top"
+      >
+        {column.type === 'StringableParam' && <StringableWithConfig
+          form={form}
+          param={column}
+          {...column}
+          name={`${name}.${columnIndex}.${column.name}`}
+          node={node}
+        />}
+        {column.type === 'PortSelectionParam' && <PortSelectionInput
+          form={form}
+          param={column}
+          {...column}
+          name={`${name}.${columnIndex}.${column.name}`}
+          node={node}
+        />}
+      </td>))
+    }
     <td className="border font-medium whitespace-nowrap bg-gray-50 align-top">
       <button
         className="p-2"
@@ -70,24 +71,24 @@ interface RepeatableInputProps {
   form: UseFormReturn<{
     [x: string]: any;
   }, any>;
-  name: string;
   param: RepeatableParam<Param[]>;
   node: ReactFlowNode;
+
 }
 
 export function RepeatableInput1({
-  name,
   form,
   param,
   node,
-}: RepeatableInputProps) {
+  field
+}: RepeatableInputProps & {
+  field:  ControllerRenderProps<any, 'params'>;
+}) {
   const defaultRows = () => {
-    if (param.value.length === 0) return [structuredClone(param.row)]
-
-    return param.value
+    return [param.row]
   }
 
-
+  console.log(field, 'field');
   const [localRows, setLocalRows] = useState<any[]>(defaultRows());
   const reorderRow = (draggedRowIndex: number, targetRowIndex: number) => {
     localRows.splice(
@@ -100,23 +101,15 @@ export function RepeatableInput1({
     // props.filed.onChange(JSON.stringify(localRows));
     console.log('localRows AFTER', localRows);
   };
+  console.log('localRows', localRows);
 
   const addRow = () => {
     console.log('Adding row!')
 
-    console.log(
-      'localRows BEFORE',
-      structuredClone(localRows)
-    )
-
-    console.log(
-      'param.row',
-      structuredClone(param.row)
-    )
 
     setLocalRows([
-      ...JSON.parse(JSON.stringify((localRows))),
-      JSON.parse(JSON.stringify((param.row)))
+      ...(localRows),
+      param.row
     ])
   }
 
@@ -138,7 +131,7 @@ export function RepeatableInput1({
         </thead>
         <tbody>
           {localRows.map((row, i) => {
-            return (<RepeatableDraggableRow reorderRow={reorderRow} row={row} rowIndex={i}  param={param} form={form} node={node} name={name} />
+            return (<RepeatableDraggableRow key={i} reorderRow={reorderRow} row={row} rowIndex={i}  param={param} form={form} node={node} />
             )
           })}
         </tbody>
@@ -154,11 +147,13 @@ export function RepeatableInput1({
 }
 
 export const RepeatableInput = (props: RepeatableInputProps) => {
+  console.log(props, 'props');
   return (
     <DndProvider backend={HTML5Backend}>
       <Controller
-        render={()=> (<RepeatableInput1 {...props} />)}
-        name={'RepeatableInput'}
+        render={({ field, fieldState, formState}) =>
+          (<RepeatableInput1 field={field} {...props} />)}
+        name={'params'}
         control={props.form.control} // todo: 这里随便写的
       />
     </DndProvider>

--- a/packages/ui/src/components/DataStory/Form/StringableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/StringableInput.tsx
@@ -55,12 +55,12 @@ export function StringableInput({
         ? <textarea
           className="text-xs p-2 w-full bg-gray-50"
           rows={rows}
-          {...form.register(`params.${name}`)}
+          {...form.register(`${name}`)}
           onSelect={handleCursorChange}
         />
         : <input
           className="text-xs p-2 w-full bg-gray-50"
-          {...form.register(`params.${name}`)}
+          {...form.register(`${name}`)}
         />
       }
     </div>

--- a/packages/ui/src/components/DataStory/Workbench.tsx
+++ b/packages/ui/src/components/DataStory/Workbench.tsx
@@ -18,7 +18,6 @@ import { useHotkeys } from './useHotkeys';
 import DataStoryPeekNodeComponent from '../Node/DataStoryPeekNodeComponent';
 import { WorkbenchProps } from './types';
 import DataStoryOutputNodeComponent from '../Node/DataStoryOutputNodeComponent';
-import { useWhyDidYouUpdate } from 'ahooks';
 
 const nodeTypes = {
   dataStoryNodeComponent: DataStoryNodeComponent,
@@ -55,7 +54,6 @@ export const Workbench = ({
   const [showRunModal, setShowRunModal] = useState(false);
   const [showAddNodeModal, setShowAddNodeModal] = useState(false);
 
-  useWhyDidYouUpdate('Workbench', { connect, nodes, edges, onNodesChange, onEdgesChange, onInit, openNodeModalId, setOpenNodeModalId, traverseNodes});
   useHotkeys({
     nodes,
     openNodeModalId,

--- a/packages/ui/src/components/DataStory/Workbench.tsx
+++ b/packages/ui/src/components/DataStory/Workbench.tsx
@@ -1,11 +1,10 @@
 import { DataStoryControls } from './dataStoryControls';
-import { useEffect, useId, useState } from 'react';
+import { useId, useState } from 'react';
 import ReactFlow, {
   Background,
   BackgroundVariant,
   ReactFlowInstance,
   ReactFlowProvider,
-  useUpdateNodeInternals
 } from 'reactflow';
 import DataStoryNodeComponent from '../Node/DataStoryNodeComponent';
 import { RunModal } from './modals/runModal';
@@ -15,13 +14,11 @@ import { shallow } from 'zustand/shallow';
 import { NodeSettingsModal } from './modals/nodeSettingsModal/nodeSettingsModal';
 import DataStoryCommentNodeComponent from '../Node/DataStoryCommentNodeComponent';
 import DataStoryInputNodeComponent from '../Node/DataStoryInputNodeComponent';
-import { ServerConfig } from './clients/ServerConfig';
-import { Diagram } from '@data-story/core';
 import { useHotkeys } from './useHotkeys';
 import DataStoryPeekNodeComponent from '../Node/DataStoryPeekNodeComponent';
 import { WorkbenchProps } from './types';
-import { ReactFlowNode } from '../Node/ReactFlowNode';
 import DataStoryOutputNodeComponent from '../Node/DataStoryOutputNodeComponent';
+import { useWhyDidYouUpdate } from 'ahooks';
 
 const nodeTypes = {
   dataStoryNodeComponent: DataStoryNodeComponent,
@@ -58,6 +55,7 @@ export const Workbench = ({
   const [showRunModal, setShowRunModal] = useState(false);
   const [showAddNodeModal, setShowAddNodeModal] = useState(false);
 
+  useWhyDidYouUpdate('Workbench', { connect, nodes, edges, onNodesChange, onEdgesChange, onInit, openNodeModalId, setOpenNodeModalId, traverseNodes});
   useHotkeys({
     nodes,
     openNodeModalId,
@@ -108,23 +106,13 @@ export const Workbench = ({
           />
           <Background color='#E7E7E7' variant={BackgroundVariant.Lines} />
         </ReactFlow>
-        <UpdateNodeInternals nodes={nodes} />
+        <NodeSettingsModal showModal={Boolean(openNodeModalId)} />
       </ReactFlowProvider>
 
       {/* Modals */}
       <RunModal showModal={showRunModal} setShowModal={setShowRunModal}/>
       <AddNodeModal showModal={showAddNodeModal} setShowModal={setShowAddNodeModal}/>
-      <NodeSettingsModal showModal={Boolean(openNodeModalId)} />
     </>
   );
 };
 
-export const UpdateNodeInternals = ({ nodes }: {
-  nodes: ReactFlowNode[];
-}) => {
-  const updateNodeInternals = useUpdateNodeInternals();
-  useEffect(() => {
-    updateNodeInternals(nodes.map((node) => node.id));
-  }, [nodes, updateNodeInternals])
-  return null
-}

--- a/packages/ui/src/components/DataStory/icons/closeIcon.tsx
+++ b/packages/ui/src/components/DataStory/icons/closeIcon.tsx
@@ -4,7 +4,7 @@ export function CloseIcon() {
   return (
     <>
       {/* Close Icon */}
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-6 h-6 text-gray-700">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-3 h-3 text-gray-500">
         <path strokeLinecap="round" strokeLinejoin="round" d="M6 6l12 12M18 6l-12 12" />
       </svg>
     </>

--- a/packages/ui/src/components/DataStory/icons/dragIcon.tsx
+++ b/packages/ui/src/components/DataStory/icons/dragIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export function DragIcon() {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-6 h-6 text-gray-700">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-4 h-4 text-gray-500">
       <path strokeLinecap="round" strokeLinejoin="round" d="M8 9h8m-8 6h8" />
     </svg>
   );

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/nodeSettingsModal.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/nodeSettingsModal.tsx
@@ -68,7 +68,7 @@ export const NodeSettingsModalContent = () => {
             // Param fields
             for (const [key, value] of Object.entries(submitted.params)) {
               const param = newData.params.find((p) => p.name === key)!;
-              param.value = value;
+              param?.value && (param.value = value);
             }
 
             n.data = newData;

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/nodeSettingsModal.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/nodeSettingsModal.tsx
@@ -6,6 +6,7 @@ import { ReactFlowNode } from '../../../Node/ReactFlowNode';
 import { useEscapeKey } from '../../hooks/useEscapeKey';
 import { useState } from 'react';
 import { Param, ParamValue, pascalToSentenceCase } from '@data-story/core';
+import { useUpdateNodeInternals } from 'reactflow';
 
 type TabKey = 'Params' | 'InputSchemas' | 'OutputSchemas' | 'Code' | 'Docs';
 
@@ -30,6 +31,7 @@ export const NodeSettingsModalContent = () => {
   });
 
   const { nodes, openNodeModalId, setOpenNodeModalId, setNodes } = useStore(selector, shallow);
+  const updateNodeInternals = useUpdateNodeInternals();
 
   const node = nodes.find((node: ReactFlowNode) => node.id === openNodeModalId)!
 
@@ -72,6 +74,7 @@ export const NodeSettingsModalContent = () => {
             n.data = newData;
           }
 
+          updateNodeInternals(n.id);
           return n;
         })
       );

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/Params.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/Params.tsx
@@ -25,7 +25,7 @@ export function Params({
           {param.type === 'StringableParam' && <StringableWithConfig
             param={param}
             form={form}
-            name={param.name}
+            name={`params.${param.name}`}
             node={node}
           />}
 
@@ -37,11 +37,9 @@ export function Params({
           />}
 
           {param.type === 'SelectParam' && <SelectInput
-            // param={param}
-            name={param.name}
+            name={`params.${param.name}`}
             form={form}
             param={param}
-            // node={node}
           />}
         </div>)
       })}

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/PortSelectionInput.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/PortSelectionInput.tsx
@@ -27,14 +27,16 @@ export function PortSelectionInput({
   return (<div className="group flex flex-col bg-gray-50">
     <div className="flex justify-between">
       <select
-        key={'ports'}
+        key={'port'}
         className="bg-gray-50 px-2 py-1"
         {...form.register(name!)}
       >
-        {parsedOutputs.map(output => (<option
-          key={output.name}
-          value={output.name}
-        >{output.name}</option>))}
+        {parsedOutputs.map(output => (
+          <option
+            key={output.name}
+            value={output.name}
+          >{output.name}</option>
+        ))}
       </select>
     </div>
   </div>)

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/PortSelectionInput.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/PortSelectionInput.tsx
@@ -16,34 +16,13 @@ export function PortSelectionInput({
   name?: string,
   node: ReactFlowNode,
 }) {
-  const [ addPortOpen, setAddPortOpen ] = useState(false)
-  const [ newPortName, setNewPortName ] = useState('')
-  const [ newPortSchema, setNewPortSchema ] = useState('{}')
+
   const outputsDraft = useWatch({
     control: form.control,
     name: 'outputs',
     exact: true,
   });
   const parsedOutputs = useMemo(() => JSON.parse(outputsDraft), [outputsDraft]);
-
-  const onAddPort = () => {
-    const newPort = {
-      name: newPortName,
-      id: `${node.id}.${newPortName}`,
-      schema: JSON.parse(newPortSchema)
-    }
-
-    const alreadyExists = node.data.outputs.find((port) => port.name === newPortName)
-
-    if(!alreadyExists) node.data.outputs.unshift(newPort)
-
-    setAddPortOpen(false)
-
-    form.setValue(name!, newPortName)
-    form.setValue('outputs', JSON.stringify(node.data.outputs, null, 2))
-  }
-
-  const allowCreate = (param as PortSelectionParam).allowCreate
 
   return (<div className="group flex flex-col bg-gray-50">
     <div className="flex justify-between">
@@ -57,28 +36,6 @@ export function PortSelectionInput({
           value={output.name}
         >{output.name}</option>))}
       </select>
-      {allowCreate && <button
-        onClick={() => setAddPortOpen(!addPortOpen)}
-        key={'add-port'}
-        className="bg-gray-50 px-2 py-1"
-      >+ Add port</button>}
     </div>
-    {addPortOpen && <div className="flex p-2 space-y-2 flex-col">
-      <input
-        className="bg-gray-50 px-2 py-1 border border-gray-300"
-        placeholder='new port name...'
-        onChange={(e) => setNewPortName(e.target.value)}
-      />
-      <textarea
-        className="bg-gray-50 px-2 py-1 border border-gray-300"
-        placeholder='new port schema...'
-        defaultValue={newPortSchema}
-        onChange={(e) => setNewPortSchema(e.target.value)}
-      />
-      <button
-        className="bg-gray-50 px-2 py-1 border border-gray-300"
-        onClick={onAddPort}
-      >Save</button>
-    </div>}
   </div>)
 }

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/RepeatableWithConfig.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/RepeatableWithConfig.tsx
@@ -34,7 +34,6 @@ export function RepeatableWithConfig({
     <RepeatableInput
       form={form}
       param={param as any}
-      {...param}
       node={node}
     />
   </div>)

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/outputSchemas/dataStoryOutputTable.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/outputSchemas/dataStoryOutputTable.tsx
@@ -14,7 +14,7 @@ function PortEditCell({ initialValue, onBlur }: {initialValue: unknown, onBlur: 
   return (
     <input
       type="text"
-      className="text-sm rounded-lg focus:outline-none focus:ring focus:ring-blue-500 block p-1 bg-gray-100 width-90"
+      className="text-xs p-2 w-full bg-gray-50"
       value={value as string}
       onChange={(e) => {
         setValue(e.target.value)
@@ -39,7 +39,7 @@ const PortEditObjectCell = ({ initialValue, onBlur }: {initialValue: unknown, on
 
   return (
     <textarea
-      className="text-sm rounded-lg focus:outline-none focus:ring focus:ring-blue-500 block p-1 bg-gray-100 width-90"
+      className="text-xs p-2 w-full bg-gray-50 h-16"
       rows={1}
       placeholder="Type here..."
       value={ value as string}
@@ -100,21 +100,28 @@ const DraggableRow: FC<{
       <tr
         ref={previewRef} //previewRef could go here
         style={{ opacity: isDragging ? 0.5 : 1 }}
-        className="bg-white p-4"
+        className="bg-white border-b dark:border-gray-700"
       >
-        <td ref={dropRef} onClick={handleExpandCollapse}>
+        <td
+          ref={dropRef}
+          onClick={handleExpandCollapse}
+          className="border font-medium whitespace-nowrap bg-gray-50 align-top"
+        >
           <button className='px-2' ref={dragRef}>
             <DragIcon />
           </button>
         </td>
         {row.getVisibleCells().map((cell) => (
-          <td key={cell.id} >
+          <td
+            key={cell.id}
+            className="border font-medium whitespace-nowrap bg-gray-50 align-top"
+          >
             {
               flexRender(cell.column.columnDef.cell, cell.getContext())
             }
           </td>
         ))}
-        <td>
+        <td className="border font-medium whitespace-nowrap bg-gray-50 align-top">
           <button onClick={handleDeleteRow} >
             <CloseIcon />
           </button>
@@ -204,14 +211,14 @@ export function OutputTable(props: {
   }, [data, props.filed, props.node.id]);
 
   return (
-    <div className="p-2">
+    <div className="flex flex-col text-xs w-full">
       <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
-        <thead className="text-gray-700 uppercase dark:text-gray-400 p-6 w-full">
+        <thead className="text-xs uppercase bg-gray-50 text-gray-400">
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id}>
-              <th/>
+              <th className='px-6 py-3 border'/>
               {headerGroup.headers.map((header) => (
-                <th key={header.id} colSpan={header.colSpan} className='text-left p-2'>
+                <th key={header.id} colSpan={header.colSpan} className='px-6 py-3 border'>
                   {header.isPlaceholder
                     ? null
                     : flexRender(
@@ -220,6 +227,7 @@ export function OutputTable(props: {
                     )}
                 </th>
               ))}
+              <th className='px-6 py-3 border'/>
             </tr>
           ))}
         </thead>
@@ -234,9 +242,15 @@ export function OutputTable(props: {
           ))}
         </tbody>
       </table>
-      <button onClick={handleAddRow} id="addRowBtn" className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-2 rounded mt-2">
+      <div className="flex bg-gray-50 w-full">
+        <button
+          onClick={handleAddRow}
+          id="addRowBtn"
+          className="border w-full p-2 text-xs uppercase border-rounded text-gray-400"
+        >
         Add Row
-      </button>
+        </button>
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/outputSchemas/dataStoryOutputTable.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/outputSchemas/dataStoryOutputTable.tsx
@@ -107,7 +107,7 @@ const DraggableRow: FC<{
           onClick={handleExpandCollapse}
           className="border font-medium whitespace-nowrap bg-gray-50 align-top"
         >
-          <button className='px-2' ref={dragRef}>
+          <button className="p-2" ref={dragRef}>
             <DragIcon />
           </button>
         </td>
@@ -122,7 +122,7 @@ const DraggableRow: FC<{
           </td>
         ))}
         <td className="border font-medium whitespace-nowrap bg-gray-50 align-top">
-          <button onClick={handleDeleteRow} >
+          <button className="p-2" onClick={handleDeleteRow} >
             <CloseIcon />
           </button>
         </td>
@@ -131,7 +131,7 @@ const DraggableRow: FC<{
         <tr>
           {/*// @ts-ignore*/}
           <td colSpan="4">
-            <pre className="bg-gray-100 text-gray-800 text-sm font-mono p-4 border border-gray-300 rounded-md overflow-auto">
+            <pre className="bg-gray-50 text-gray-500 text-sm font-mono p-4 border-rounded border rounded-md overflow-auto">
               {JSON.stringify(row.original, null, 2)}
             </pre>
           </td>

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/outputSchemas/dataStoryOutputTable.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/outputSchemas/dataStoryOutputTable.tsx
@@ -143,12 +143,12 @@ const DraggableRow: FC<{
 };
 
 export function OutputTable(props: {
-  filed:  ControllerRenderProps<any, 'outputs'>;
+  field:  ControllerRenderProps<any, 'outputs'>;
   node: ReactFlowNode;
   outputs?: Port[];
 }) {
   const [columns] = React.useState(() => [...defaultColumns]);
-  const [data, setData] = React.useState(formatOutputs(props.filed.value));
+  const [data, setData] = React.useState(formatOutputs(props.field.value));
 
   const reorderRow = (draggedRowIndex: number, targetRowIndex: number) => {
     data.splice(
@@ -157,8 +157,9 @@ export function OutputTable(props: {
       data.splice(draggedRowIndex, 1)[0] as Port
     );
     setData([...data]);
+    console.log('output data', data);
 
-    props.filed.onChange(JSON.stringify(data));
+    props.field.onChange(JSON.stringify(data));
   };
 
   const table = useReactTable({
@@ -182,7 +183,7 @@ export function OutputTable(props: {
         });
 
         setData(updatedData);
-        props.filed.onChange(JSON.stringify(updatedData));
+        props.field.onChange(JSON.stringify(updatedData));
       },
     },
     debugTable: true,
@@ -193,8 +194,8 @@ export function OutputTable(props: {
   const deleteRow = useCallback((id: string) => {
     const updatedData = data.filter((row) => row.id !== id);
     setData([...updatedData]);
-    props.filed.onChange(JSON.stringify(updatedData));
-  }, [data, props.filed]);
+    props.field.onChange(JSON.stringify(updatedData));
+  }, [data, props.field]);
 
   const handleAddRow = useCallback( () => {
     const id = props.node.id;
@@ -207,8 +208,8 @@ export function OutputTable(props: {
 
     const updatedData = [...data, newRow];
     setData(updatedData);
-    props.filed.onChange(JSON.stringify(updatedData));
-  }, [data, props.filed, props.node.id]);
+    props.field.onChange(JSON.stringify(updatedData));
+  }, [data, props.field, props.node.id]);
 
   return (
     <div className="flex flex-col text-xs w-full">
@@ -263,7 +264,7 @@ export const DataStoryOutputTable = (props: OutputSchemaProps) => {
         control={props.form.control}
         name="outputs"
         render={({ field }) => (
-          <OutputTable filed={field} node={props.node} />
+          <OutputTable field={field} node={props.node} />
         )}
       />
 

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/outputSchemas/dataStoryOutputTable.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/outputSchemas/dataStoryOutputTable.tsx
@@ -171,7 +171,6 @@ export function OutputTable(props: {
     // Provide our updateData function to our table meta
     meta: {
       updateData: (rowIndex, columnId, value) => {
-        console.log(rowIndex, columnId, value, 'rowIndex, columnId, value');
         const updatedData = data.map((row, index) => {
           if (index === rowIndex) {
             return {

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/outputSchemas/dataStoryOutputTable.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/outputSchemas/dataStoryOutputTable.tsx
@@ -131,7 +131,7 @@ const DraggableRow: FC<{
         <tr>
           {/*// @ts-ignore*/}
           <td colSpan="4">
-            <pre className="bg-gray-50 text-gray-500 text-sm font-mono p-4 border-rounded border rounded-md overflow-auto">
+            <pre className="bg-gray-50 text-gray-500 text-sm p-4 border overflow-auto">
               {JSON.stringify(row.original, null, 2)}
             </pre>
           </td>

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/outputSchemas/outputSchemas.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/outputSchemas/outputSchemas.tsx
@@ -9,7 +9,7 @@ export function OutputSchemas({
   form,
 }: OutputSchemaProps) {
 
-  return <div className="max-h-128 overflow-y-scroll relative pb-6 pt-4 px-6 flex-auto space-y-1 text-sm font-mono text-gray-800">
+  return <div className="max-h-128 overflow-y-scroll relative pb-6 pt-4 px-6 flex-auto space-y-1 text-sm text-gray-800">
     <div
       className="flex flex-col"
     >

--- a/packages/ui/src/components/Node/DataStoryInputNodeComponent.tsx
+++ b/packages/ui/src/components/Node/DataStoryInputNodeComponent.tsx
@@ -16,7 +16,7 @@ const DataStoryInputNodeComponent = ({ id, data, selected }: { id: string; data:
   // if(data.outputs.length !== 1) console.log('Warning: DataStoryInputNodeComponent has more than one output')
 
   // const outputPort = data.outputs[0]
-  const portName = data.params[0].value as string
+  const portName = (data?.params?.[0]?.value ?? '') as string
 
   return (
     <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -291,6 +291,7 @@ __metadata:
     "@types/react": "npm:*"
     "@types/react-dom": "npm:*"
     "@types/ws": "npm:^8.5.4"
+    ahooks: "npm:^3.7.10"
     autoprefixer: "npm:^10.4.13"
     axios: "npm:^1.3.4"
     clsx: "npm:^2.0.0"
@@ -3837,6 +3838,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ahooks@npm:^3.7.10":
+  version: 3.7.10
+  resolution: "ahooks@npm:3.7.10"
+  dependencies:
+    "@babel/runtime": "npm:^7.21.0"
+    dayjs: "npm:^1.9.1"
+    intersection-observer: "npm:^0.12.0"
+    js-cookie: "npm:^2.x.x"
+    lodash: "npm:^4.17.21"
+    resize-observer-polyfill: "npm:^1.5.1"
+    screenfull: "npm:^5.0.0"
+    tslib: "npm:^2.4.1"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 10/b64345423b739eeaddf6fafc6652e3c356151a3fca9160987d8ef8bc7985246b5c54821e57eebd6e7fb8b20940a50c3ae92a06cfc39f863e170945b235cf68e7
+  languageName: node
+  linkType: hard
+
 "ajv-formats@npm:^2.1.1":
   version: 2.1.1
   resolution: "ajv-formats@npm:2.1.1"
@@ -6138,7 +6157,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dayjs@npm:^1.10.4, dayjs@npm:^1.11.7":
+"dayjs@npm:^1.10.4, dayjs@npm:^1.11.7, dayjs@npm:^1.9.1":
   version: 1.11.10
   resolution: "dayjs@npm:1.11.10"
   checksum: 10/27e8f5bc01c0a76f36c656e62ab7f08c2e7b040b09e613cd4844abf03fb258e0350f0a83b02c887b84d771c1f11e092deda0beef8c6df2a1afbc3f6c1fade279
@@ -9578,7 +9597,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"intersection-observer@npm:^0.12.2":
+"intersection-observer@npm:^0.12.0, intersection-observer@npm:^0.12.2":
   version: 0.12.2
   resolution: "intersection-observer@npm:0.12.2"
   checksum: 10/cb1a6369bd1636b3f227d7cb7fec22f5a35b9d8ba9e26303b405d50c54c3ef02c5a547107b1d951e7eb421e192a564222faf4660a21fad69c34dcb9f926c159c
@@ -10277,6 +10296,13 @@ __metadata:
     "@sideway/formula": "npm:^3.0.1"
     "@sideway/pinpoint": "npm:^2.0.0"
   checksum: 10/6c48ed73e091d6328d9062aa9647b83e971004f2ab7a58a0e8bdee68cd4295e4141981a79461f85bd70333a77d6865fc2420bf9b392e2287384008f4f781ea71
+  languageName: node
+  linkType: hard
+
+"js-cookie@npm:^2.x.x":
+  version: 2.2.1
+  resolution: "js-cookie@npm:2.2.1"
+  checksum: 10/4387f5f5691cb96ca9ff8852c589d3012b53f484fda68630a39e20cabc6c5b740f09225e23233ba56cd9de6ebe300a23d20b2c7315f10c309ad5a89fd8c4990b
   languageName: node
   linkType: hard
 
@@ -14576,6 +14602,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resize-observer-polyfill@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "resize-observer-polyfill@npm:1.5.1"
+  checksum: 10/e10ee50cd6cf558001de5c6fb03fee15debd011c2f694564b71f81742eef03fb30d6c2596d1d5bf946d9991cb692fcef529b7bd2e4057041377ecc9636c753ce
+  languageName: node
+  linkType: hard
+
 "resolve-alpn@npm:^1.0.0, resolve-alpn@npm:^1.2.0":
   version: 1.2.1
   resolution: "resolve-alpn@npm:1.2.1"
@@ -14949,6 +14982,13 @@ __metadata:
     ajv-formats: "npm:^2.1.1"
     ajv-keywords: "npm:^5.1.0"
   checksum: 10/808784735eeb153ab7f3f787f840aa3bc63f423d2a5a7e96c9e70a0e53d0bc62d7b37ea396fc598ce19196e4fb86a72f897154b7c6ce2358bbc426166f205e14
+  languageName: node
+  linkType: hard
+
+"screenfull@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "screenfull@npm:5.2.0"
+  checksum: 10/b8b4b8010f48889341ad1981ca9e6e02db1f10dec686244d95bd2bfde47451059f5ba4c744449913b10f021f14f79d374987a873b6086eb488295962ba50381e
   languageName: node
   linkType: hard
 
@@ -16424,7 +16464,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0":
+"tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.4.1":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 10/bd26c22d36736513980091a1e356378e8b662ded04204453d353a7f34a4c21ed0afc59b5f90719d4ba756e581a162ecbf93118dc9c6be5acf70aa309188166ca


### PR DESCRIPTION
### RepeatableInput Component

Here is the change relationship diagram of the `repeatableInput` component : https://app.diagrams.net/#Hstone-lyl%2Fassets%2Fmaster%2Foutput-list.drawio#%7B%22pageId%22%3A%227duryvOtYs7e6wOFj5al%22%7D

- [x] Adjust the style to match the output tab style

| Before | After |
| ------ | ----- |
| ❌      | ✅    |
|![image](https://github.com/ajthinking/data-story/assets/20497176/635b190a-b213-43b4-bfd8-7acbc5f6a66c)|![image](https://github.com/ajthinking/data-story/assets/20497176/a3c5e0be-7e34-4f71-bbe9-189625319a36)|


- [X] Add features: delete row, drag row.

https://github.com/ajthinking/data-story/assets/20497176/0dfef25b-f6f4-4677-8b95-8377b789b0b4

- [ ] Make the RepeatableInput testable and add the corresponding tests

### PortSelection

- [X] remove "add port"
- [X] Fix the bug: the port selection value in RepeatableInput becomes disordered after saving.

https://github.com/ajthinking/data-story/assets/20497176/af7e7bba-efd8-4e5d-b218-024501a0d0cd

- [ ] Make the PortSelection testable and add the corresponding tests

### bug

- [X] fix: resolved the issue of the page continuously reloading

reproduce: Open the playground and add some nodes. After a while, the page will become increasingly slower, regardless of the operation you perform.

Before:

https://github.com/ajthinking/data-story/assets/20497176/d92de896-a75f-4bb3-835f-71de49d85ece

After:

https://github.com/ajthinking/data-story/assets/20497176/10fe32e3-9832-4f19-a858-7b5f46fbf444

- [X] fix: Cannot read properties of undefined (reading 'value') at DataStoryInputNodeComponent

| Before | After |
| ------ | ----- |
| ❌      | ✅    |
|![image](https://github.com/ajthinking/data-story/assets/20497176/dabd1422-a1d2-441c-b7e2-530ac7a9b47a)|![image](https://github.com/ajthinking/data-story/assets/20497176/f1462221-7afb-467c-a314-4d868052a8a2)|


