### PR TITLE
Make param evaluations testable 

### DIFF
--- a/packages/core/src/computers/Create.test.ts
+++ b/packages/core/src/computers/Create.test.ts
@@ -1,7 +1,12 @@
+import { hjsonEvaluation } from '../Param/evaluations/hjsonEvaluation';
+import { jsEvaluation } from '../Param/evaluations/jsEvaluation';
+import { jsExpressionEvaluation } from '../Param/evaluations/jsExpressionEvaluation'
 import { when } from '../support/computerTester/ComputerTester';
+import { multiline } from '../utils/multiline';
 import { Create } from './Create';
+import Hjson from '@data-story/hjson';
 
-it('outputs array json as array', async () => {
+it('reads json by default', async () => {
   await when(Create)
     .hasParams({ data: JSON.stringify([{a: 1}]) })
     .doRun()
@@ -9,10 +14,76 @@ it('outputs array json as array', async () => {
     .ok()
 })
 
-it('wraps non array outputs', async () => {
+it('wraps non array inputs', async () => {
   await when(Create)
-    .hasParams({ data: JSON.stringify('awakening') })
+    .hasParams({ data: JSON.stringify({a: 1}) })
     .doRun()
-    .expectOutput(['awakening'])
+    .expectOutput([{a: 1}])
+    .ok()
+})
+
+it('can parse hjson', async () => {
+  await when(Create)
+    .hasParam({
+      name: 'data',
+      value: '{ cool: "yes" }',
+      evaluations: [
+        { ...hjsonEvaluation, selected: true }
+      ]
+    })
+    .doRun()
+    .expectOutput([{ cool: 'yes' }])
+    .ok()
+})
+
+it('can parse js function', async () => {
+  await when(Create)
+    .hasParam({
+      name: 'data',
+      value: '() => ({ sum: 1 + 1 })',
+      evaluations: [
+        { ...jsEvaluation, selected: true }
+      ]
+    })
+    .doRun()
+    .expectOutput([{ sum: 2 }])
+    .ok()
+})
+
+it('can parse js expression', async () => {
+  await when(Create)
+    .hasParam({
+      name: 'data',
+      value: multiline`
+      ({
+        interesting: 'yes'
+      })`,
+      evaluations: [
+        { ...jsExpressionEvaluation, selected: true }
+      ]
+    })
+    .doRun()
+    .expectOutput([{ interesting: 'yes' }])
+    .ok()
+})
+
+it('cannot directly parse js objects starting with bracket', async () => {
+  await when(Create)
+    .hasParam({
+      name: 'data',
+      value: multiline`
+      // JS eval thinks this is a block followed by a labeled statment
+      // Probably not what you would expect but that is how eval works
+      {
+        label: 'statement'
+      }`,
+      evaluations: [
+        { ...jsExpressionEvaluation, selected: true }
+      ]
+    })
+    .doRun()
+    // TODO this should throw an error.
+    // We only allow object items.
+    .expectOutput([ 'statement' ])
     .ok()
 })


### PR DESCRIPTION
The ComputerTester now supports two ways of adding configured params:

1. Many values at the same time:
```ts
  await when(SomeNode)
    .hasParams({ count: 1337, delay: 10 })
```
2. Partially or fully configured param, one at a time:
```ts
  await when(SomeNode)
    .hasParam({
      name: 'count',
      value: '1000 + 337',
      evaluations: [
        { ...jsExpressionEvaluation, selected: true }
      ]
    })
```

These methods can be combined as needed.