### PR TITLE
Refactor connect

### DIFF
--- a/packages/core/src/Diagram.test.ts
+++ b/packages/core/src/Diagram.test.ts
@@ -147,3 +147,42 @@ describe('unfold', () => {
     `);
   })
 })
+
+describe('connect', () => {
+  it('adds a link', () => {
+    const diagram = new Diagram()
+
+    const link: Link = {
+      id: 'fake-link-id',
+      sourcePortId: 'fake-port-id-1',
+      targetPortId: 'fake-port-id-2',
+    }
+
+    expect(diagram.links).toEqual([])
+    diagram.connect(link)
+    expect(diagram.links).toEqual([link])
+  })
+
+  it('calls provided onConnect handlers', () => {
+    const callback1 = vi.fn()
+    const callback2 = vi.fn()
+
+    const diagram = new Diagram({
+      onConnect: [
+        callback1,
+        callback2,
+      ]
+    })
+
+    const link: Link = {
+      id: 'fake-link-id',
+      sourcePortId: 'fake-port-id-1',
+      targetPortId: 'fake-port-id-2',
+    }
+
+    diagram.connect(link)
+
+    expect(callback1).toHaveBeenCalledWith(link, diagram)
+    expect(callback2).toHaveBeenCalledWith(link, diagram)
+  })
+})

--- a/packages/core/src/Diagram.ts
+++ b/packages/core/src/Diagram.ts
@@ -1,6 +1,9 @@
 import { PortId } from './types/PortId'
 import { Link } from './types/Link'
 import { Node } from './types/Node'
+import { syncPortSchemas } from './syncPortSchemas'
+
+export type OnConnectCallbacks = (link: Link, diagram: Diagram) => void
 
 export class Diagram {
   nodes: Node[]
@@ -11,15 +14,20 @@ export class Diagram {
     y: 0,
     zoom: 1
   }
+  onConnect: OnConnectCallbacks[]
 
   constructor(options?: {
     nodes?: Node[],
     links?: Link[],
-    localNodeDefinitions?: Record<string, Diagram>
+    localNodeDefinitions?: Record<string, Diagram>,
+    onConnect?: OnConnectCallbacks[],
   }) {
     this.nodes = options?.nodes || []
     this.links = options?.links || []
     this.localNodeDefinitions = options?.localNodeDefinitions || {}
+    this.onConnect = options?.onConnect || [
+      syncPortSchemas,
+    ]
   }
 
   linksAtInputPortId(id: PortId | undefined): Link[] {
@@ -154,5 +162,15 @@ export class Diagram {
     }
 
     return this;
+  }
+
+  connect(link: Link) {
+    this.links.push(link)
+
+    for(const callback of this.onConnect) {
+      callback(link, this)
+    }
+
+    return this
   }
 }

--- a/packages/core/src/syncPortSchemas.test.ts
+++ b/packages/core/src/syncPortSchemas.test.ts
@@ -1,0 +1,52 @@
+import { Diagram } from './Diagram'
+import { syncPortSchemas } from './syncPortSchemas'
+import { Node } from './types/Node'
+
+it('forwards schema to linked ports', () => {
+  const outputPort = {
+    id: 'node1.output',
+    name: 'output',
+    schema: {
+      someProperty: 'someValue'
+    }
+  }
+
+  const node1: Node = {
+    id: 'node1',
+    type: 'MyNode',
+    inputs: [],
+    outputs: [outputPort],
+    params: []
+  }
+
+  const inputPort = {
+    id: 'node2.input',
+    name: 'input',
+    schema: {}
+  }
+
+  const node2: Node = {
+    id: 'node2',
+    type: 'MyNode',
+    inputs: [inputPort],
+    outputs: [],
+    params: []
+  }
+
+  const link = {
+    id: 'link1',
+    sourcePortId: 'node1.output',
+    targetPortId: 'node2.input'
+  }
+
+  const diagram = new Diagram({
+    nodes: [node1, node2],
+    links: [link]
+  })
+
+  syncPortSchemas(link, diagram)
+
+  expect(inputPort.schema).toMatchObject({
+    someProperty: 'someValue'
+  })
+})

--- a/packages/core/src/syncPortSchemas.ts
+++ b/packages/core/src/syncPortSchemas.ts
@@ -1,0 +1,20 @@
+import { Diagram } from './Diagram';
+import { Link } from './types/Link';
+
+export const syncPortSchemas = (link: Link, diagram: Diagram) => {
+  const sourceNode = diagram.nodeWithOutputPortId(link.sourcePortId)
+  const sourcePort = sourceNode?.outputs.find(output => output.id === link.sourcePortId)
+  if(!sourcePort) return
+
+  const links = diagram.linksAtOutputPortId(link.sourcePortId)
+
+  links.forEach(link => {
+    const targetNode = diagram.nodeWithInputPortId(link.targetPortId)
+    const incomingSchema = sourcePort.schema
+
+    const inputPort = targetNode?.inputs.find(input => input.id === link.targetPortId)
+    if(!inputPort) return
+
+    inputPort.schema = incomingSchema ?? {}
+  })
+}

--- a/packages/ui/src/components/DataStory/modals/addNodeModal.tsx
+++ b/packages/ui/src/components/DataStory/modals/addNodeModal.tsx
@@ -6,7 +6,6 @@ import { StoreSchema, useStore } from '../store/store';
 import clsx from 'clsx';
 
 export interface AddNodeModalContentProps {
-
   setShowModal: (show: boolean) => void
 }
 


### PR DESCRIPTION
This PR changes the store connect implementation to always go via `Diagram.connect`.

### Background
Sometimes we create diagrams in the UI. Sometimes we create diagrams by deserializing saved diagrams. Sometimes we create diagrams with core builders. To ensure all these use cases have the same behavior and produce predictable side effects, changes must always be done via `Diagram` class.

### Considerations
Currently, the Diagram will have default onConnect callbacks: `[ syncPortSchemas ]`.
While the callbacks are configurable via Diagram constructor options, they will not persist on save/load because store is currently unaware of these callbacks, will loose them and then always use the defaults.