### PR TITLE
Add no-items feature in Await

### DIFF
--- a/packages/core/src/computers/Await.test.ts
+++ b/packages/core/src/computers/Await.test.ts
@@ -1,0 +1,18 @@
+import { when } from '../support/computerTester/ComputerTester';
+import { Await } from './Await';
+
+it('outputs an item through no_items when no input', async () => {
+  await when(Await)
+    .hasParams({ number_of_items: 1 })
+    .getsInputs({
+      input: []
+    })
+    .doRun()
+    .expectOutputs({
+      output: [],
+      no_items: [
+        { message: 'No items available to await node.'}
+      ]
+    })
+    .ok()
+})

--- a/packages/core/src/computers/Await.ts
+++ b/packages/core/src/computers/Await.ts
@@ -4,7 +4,7 @@ import { numberCast } from '../Param/casts/numberCast';
 export const Await: ComputerConfig = {
   name: 'Await',
   inputs: ['input'],
-  outputs: ['output'],
+  outputs: ['output', 'no_items'],
   params: [
     {
       name: 'number_of_items',
@@ -33,13 +33,20 @@ export const Await: ComputerConfig = {
   },
 
   async *run({ input, output, params }) {
+    let hasPulledAny = false
+
     while(true) {
       const incoming = input.pull()
 
       const pulledCount = incoming.length
+      if(pulledCount > 0) hasPulledAny = true
       const chunkSize = params.number_of_items as number
 
       output.push(incoming)
+
+      if(pulledCount === 0) output.pushTo('no_items', [{
+        message: 'No items available to await node.'
+      }])
 
       if(pulledCount < chunkSize) break;
 


### PR DESCRIPTION
Add a `no_items` port on `Await`. Enables the user to check for no data in a branch, and then react accordingly using a "trigger item".

<img width="961" alt="image" src="https://github.com/ajthinking/data-story/assets/3457668/8b66b145-0b43-4193-b1b8-1215992c396f">
