### PR TITLE
Fix broken casts. Rename MapTable

### DIFF
--- a/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
+++ b/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
@@ -104,11 +104,11 @@ export const prepareStringable = (itemValue: ItemValue, param: Param) => {
   const casts = param.casts || [];
   const selectedCast = casts.find(c => c.selected);
 
-  if (selectedCast?.type === 'String') {
+  if (selectedCast?.type === 'stringCast') {
     transformedValue = String(transformedValue);
   }
 
-  if (selectedCast?.type === 'Number') {
+  if (selectedCast?.type === 'numberCast') {
     transformedValue = Number(transformedValue);
   }
 

--- a/packages/core/src/computers/CreateProperties.test.ts
+++ b/packages/core/src/computers/CreateProperties.test.ts
@@ -1,5 +1,5 @@
 import { when } from '../support/computerTester/ComputerTester';
-import { MapTable } from './MapTable';
+import { CreateProperties } from './CreateProperties';
 
 // TODO
 

--- a/packages/core/src/computers/CreateProperties.ts
+++ b/packages/core/src/computers/CreateProperties.ts
@@ -4,9 +4,9 @@ import { jsEvaluation } from '../Param/evaluations/jsEvaluation';
 import { jsonEvaluation } from '../Param/evaluations/jsonEvaluation';
 import { ComputerConfig } from '../types/ComputerConfig';
 
-export const MapTable: ComputerConfig = {
-  name: 'MapTable',
-  label: 'MapTable',
+export const CreateProperties: ComputerConfig = {
+  name: 'CreateProperties',
+  label: 'CreateProperties',
   inputs: ['input'],
   outputs: ['output'],
   params: [

--- a/packages/core/src/computers/index.ts
+++ b/packages/core/src/computers/index.ts
@@ -14,7 +14,7 @@ export { InstantThrow } from './InstantThrow';
 export { Input } from './Input';
 export { Map } from './Map'
 export { Log } from './Log';
-export { MapTable } from './MapTable'
+export { CreateProperties } from './CreateProperties'
 // export { Merge } from './Merge';
 export { Pass } from './Pass';
 export { Request } from './Request'

--- a/packages/core/src/support/benchmark.ts
+++ b/packages/core/src/support/benchmark.ts
@@ -2,7 +2,7 @@ import { Application } from '../Application';
 import { DiagramBuilder } from '../DiagramBuilder';
 import { Executor } from '../Executor';
 import { InMemoryStorage } from '../InMemoryStorage';
-import { Create, Ignore, MapTable } from '../computers';
+import { Create, Ignore, CreateProperties } from '../computers';
 import { coreNodeProvider } from '../coreNodeProvider';
 
 (async () => {
@@ -24,7 +24,7 @@ import { coreNodeProvider } from '../coreNodeProvider';
 
   const diagram = new DiagramBuilder()
     .add(Create, {json: JSON.stringify(data)})
-    .add(MapTable)
+    .add(CreateProperties)
     .add(Ignore)
     .get()
 


### PR DESCRIPTION
* This setting will now take effect:

<img width="809" alt="image" src="https://github.com/ajthinking/data-story/assets/3457668/943a9f1f-a38d-40e2-8f02-50acd23784ec">

* Renames `MapTable` to `CreateProperties`, to not confuse it with `Map`
