### PR TITLE
feat: implement functionality to retain diagrams in the current workspace after refreshing the desktop page

### DIFF
--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -46,12 +46,21 @@ class DataStoryWindow {
     this.workspace.initSettingsAndEnv(this.getMainWindowActions());
   }
 
-  public initWorkspace(): void {
-    const mainWindowActions = this.getMainWindowActions()
+  public reloadWindow(): void {
+    console.log('Reloading window', this.workspace);
+    if(this.workspace instanceof DefaultWorkspace) {
+      console.log('entering initWorkspace')
+      // this.initWorkspace();
+    } else {
+      console.log('entering switchWorkspace')
+      this.workspace.openDiagram(this.getMainWindowActions(), this.workspace.filePath);
+    }
+  }
 
+  public initWorkspace(): void {
     // Assuming DefaultWorkspace is a defined class
     this.workspace = new DefaultWorkspace();
-    this.workspace.initSettingsAndEnv(mainWindowActions);
+    this.workspace.initSettingsAndEnv(this.getMainWindowActions());
   }
 
   private createWindow(): void {
@@ -97,7 +106,7 @@ function startDesktopWindow(): void {
     getMainWindowActions: dataStoryWindow.getMainWindowActions.bind(dataStoryWindow),
     getWorkspace: dataStoryWindow.getWorkspace.bind(dataStoryWindow),
     switchWorkspace: dataStoryWindow.switchWorkspace.bind(dataStoryWindow),
-    initWorkspace: dataStoryWindow.initWorkspace.bind(dataStoryWindow),
+    initWorkspace: dataStoryWindow.reloadWindow.bind(dataStoryWindow),
   });
 }
 

--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -46,15 +46,12 @@ class DataStoryWindow {
     this.workspace.initSettingsAndEnv(this.getMainWindowActions());
   }
 
-  public reloadWindow(): void {
-    console.log('Reloading window', this.workspace);
+  public async refreshWindow ()  {
     if(this.workspace instanceof DefaultWorkspace) {
-      console.log('entering initWorkspace')
-      // this.initWorkspace();
-    } else {
-      console.log('entering switchWorkspace')
-      this.workspace.openDiagram(this.getMainWindowActions(), this.workspace.filePath);
+      return JSON.stringify('');
     }
+
+    return await this.workspace.openDiagram(this.getMainWindowActions(), this.workspace.filePath);
   }
 
   public initWorkspace(): void {
@@ -106,7 +103,7 @@ function startDesktopWindow(): void {
     getMainWindowActions: dataStoryWindow.getMainWindowActions.bind(dataStoryWindow),
     getWorkspace: dataStoryWindow.getWorkspace.bind(dataStoryWindow),
     switchWorkspace: dataStoryWindow.switchWorkspace.bind(dataStoryWindow),
-    initWorkspace: dataStoryWindow.reloadWindow.bind(dataStoryWindow),
+    refreshWindow: dataStoryWindow.refreshWindow.bind(dataStoryWindow),
   });
 }
 

--- a/packages/desktop/src/main/ipcHandle.ts
+++ b/packages/desktop/src/main/ipcHandle.ts
@@ -30,6 +30,7 @@ export const registerIpcHandlers = (options: IpcHandlerOptions) => {
         await getCurrentWorkspace().saveDiagram(jsonData, mainWindowActions, file.filePath);
         result.data = jsonData;
         result.isSuccess = true;
+        switchWorkspace(file.filePath);
       }
       return result;
     } catch(err) {

--- a/packages/desktop/src/main/ipcHandle.ts
+++ b/packages/desktop/src/main/ipcHandle.ts
@@ -7,7 +7,7 @@ import { dialog, ipcMain } from 'electron';
 import { Workspace } from './workspace';
 
 export const registerIpcHandlers = (options: IpcHandlerOptions) => {
-  const { getMainWindowActions, getWorkspace, switchWorkspace, initWorkspace } = options;
+  const { getMainWindowActions, getWorkspace, switchWorkspace, refreshWindow } = options;
   const mainWindowActions = getMainWindowActions();
   const getCurrentWorkspace = (): Workspace => getWorkspace();
 
@@ -68,8 +68,10 @@ export const registerIpcHandlers = (options: IpcHandlerOptions) => {
     }
   };
 
-  const refreshDesktop = (): void => {
-    initWorkspace();
+  const refreshDesktop = async (): Promise<OpenedDiagramResult>  => {
+    const data = await refreshWindow();
+
+    return { data, isSuccess: true };
   }
 
   ipcMain.handle('saveDiagram', async(event, jsonData: string): Promise<OpenedDiagramResult> => {

--- a/packages/desktop/src/types.d.ts
+++ b/packages/desktop/src/types.d.ts
@@ -22,5 +22,5 @@ export interface IpcHandlerOptions {
   getMainWindowActions: () =>  MainWindowActions;
   getWorkspace: () => Workspace;
   switchWorkspace: (filePath?: string) => void;
-  initWorkspace: () => void;
+  refreshWindow: () => Promise<string>;
 }


### PR DESCRIPTION
![image](https://github.com/ajthinking/data-story/assets/20497176/36e075c1-1d86-40fe-b0d3-cb0316431128)

If a user adds some nodes to create a new diagram in the `desktop data-story`, saves it to an a.json file, and then refreshes the page, it should show the diagram from the local `a.json` file.

https://github.com/ajthinking/data-story/assets/20497176/8af9e485-f187-40f4-a047-a097eb6230aa

When a user opens `desktop data-story` and an a.json file, and then refreshes the page, regardless of whether the loaded diagram was modified, the page should only display the content from the local `a.json` file.

https://github.com/ajthinking/data-story/assets/20497176/97861662-756c-4e09-b341-56a553a3b2d2

