### PR TITLE
Simplify Application

### DIFF
--- a/packages/core/src/Application.test.ts
+++ b/packages/core/src/Application.test.ts
@@ -69,18 +69,6 @@ describe('boot', () => {
   })
 })
 
-describe('addComputers', () => {
-  it('adds computers to the application', () => {
-    const app = new Application()
-
-    const computers = new Map<string, Computer>()
-
-    app.addComputers(computers)
-
-    expect(app.computers).toStrictEqual(computers)
-  })
-})
-
 describe('addComputerConfigs', () => {
   it('adds computers to the application via a config object', () => {
     const app = new Application()
@@ -91,7 +79,7 @@ describe('addComputerConfigs', () => {
 
     app.addComputerConfigs([config])
 
-    expect(app.computers.get('Signal')).toMatchObject(
+    expect(app.computers.Signal).toMatchObject(
       new ComputerFactory().get(config)
     )
   })
@@ -117,15 +105,7 @@ describe('descriptions', () => {
   it('returns descriptions of all computers', () => {
     const app = new Application()
 
-    const computer1 = new ComputerFactory().get(
-      Signal
-    )
-
-    app.addComputers(
-      new Map([
-        [computer1.name, computer1],
-      ])
-    )
+    app.addComputerConfigs([ Signal ])
 
     expect(app.descriptions()).toMatchObject([
       { name: 'Signal' }

--- a/packages/core/src/Application.test.ts
+++ b/packages/core/src/Application.test.ts
@@ -1,6 +1,8 @@
 import { Application } from './Application'
 import { ComputerFactory } from './ComputerFactory'
 import { Signal } from './computers'
+import { Computer } from './types/Computer'
+import { ComputerConfig } from './types/ComputerConfig'
 import { ServiceProvider } from './types/ServiceProvider'
 
 describe('register', () => {
@@ -71,11 +73,27 @@ describe('addComputers', () => {
   it('adds computers to the application', () => {
     const app = new Application()
 
-    const computers = new Map<string, any>()
+    const computers = new Map<string, Computer>()
 
     app.addComputers(computers)
 
     expect(app.computers).toStrictEqual(computers)
+  })
+})
+
+describe('addComputerConfigs', () => {
+  it('adds computers to the application via a config object', () => {
+    const app = new Application()
+    const config: ComputerConfig = {
+      name: 'Signal',
+      run: async function*() {}
+    }
+
+    app.addComputerConfigs([config])
+
+    expect(app.computers.get('Signal')).toMatchObject(
+      new ComputerFactory().get(config)
+    )
   })
 })
 

--- a/packages/core/src/Application.ts
+++ b/packages/core/src/Application.ts
@@ -6,7 +6,7 @@ import { ServiceProvider } from './types/ServiceProvider';
 
 export class Application {
   providers: ServiceProvider[] = [];
-  computers = new Map<string, Computer>();
+  computers: Record<string, Computer> = {};
   hooks = new Map<string, Function>();
 
   register(provider: ServiceProvider | ServiceProvider[]) {
@@ -27,16 +27,10 @@ export class Application {
   }
 
   addComputerConfigs(computerConfigs: ComputerConfig[]) {
-    const newComputers = new Map(computerConfigs.map(config => {
+    for (const config of computerConfigs) {
       const computer = new ComputerFactory().get(config);
-      return [computer.name, computer];
-    }));
-
-    this.computers = new Map([...this.computers, ...newComputers]);
-  }
-
-  addComputers(computers: Map<string, Computer>) {
-    this.computers = new Map([...this.computers, ...computers]);
+      this.computers[computer.name] = computer;
+    }
   }
 
   addHooks(hooks: Record<string, Function>) {
@@ -46,7 +40,7 @@ export class Application {
   }
 
   descriptions() {
-    return Array.from(this.computers.values()).map(computer => {
+    return Object.values(this.computers).map(computer => {
       return NodeDescriptionFactory.fromComputer(computer);
     });
   }

--- a/packages/core/src/Application.ts
+++ b/packages/core/src/Application.ts
@@ -26,17 +26,17 @@ export class Application {
     return this;
   }
 
-  addComputers(computers: Map<string, Computer> | ComputerConfig[]) {
-    if(computers instanceof Map) {
-      this.computers = new Map([...this.computers, ...computers]);
-    } else {
-      const newComputers = new Map(computers.map(config => {
-        const computer = new ComputerFactory().get(config);
-        return [computer.name, computer];
-      }));
+  addComputerConfigs(computerConfigs: ComputerConfig[]) {
+    const newComputers = new Map(computerConfigs.map(config => {
+      const computer = new ComputerFactory().get(config);
+      return [computer.name, computer];
+    }));
 
-      this.computers = new Map([...this.computers, ...newComputers]);
-    }
+    this.computers = new Map([...this.computers, ...newComputers]);
+  }
+
+  addComputers(computers: Map<string, Computer>) {
+    this.computers = new Map([...this.computers, ...computers]);
   }
 
   addHooks(hooks: Record<string, Function>) {

--- a/packages/core/src/ExecutionMemoryFactory.test.ts
+++ b/packages/core/src/ExecutionMemoryFactory.test.ts
@@ -1,3 +1,4 @@
+import { ComputerFactory } from './ComputerFactory';
 import { DiagramBuilder } from './DiagramBuilder'
 import { ExecutionMemoryFactory } from './ExecutionMemoryFactory';
 import { InMemoryStorage } from './InMemoryStorage';
@@ -10,9 +11,10 @@ describe('create', () => {
       .add(ConsoleLog)
       .get();
 
-    const computers = new Map()
-      .set('Create', Create)
-      .set('ConsoleLog', ConsoleLog);
+    const computers = {
+      Create: new ComputerFactory().get(Create),
+      ConsoleLog: new ComputerFactory().get(ConsoleLog),
+    }
 
     const storage = new InMemoryStorage();
 
@@ -34,9 +36,10 @@ describe('create', () => {
       .add(ConsoleLog)
       .get();
 
-    const computers = new Map()
-      .set('Create', Create)
-      .set('ConsoleLog', ConsoleLog);
+    const computers = {
+      Create: new ComputerFactory().get(Create),
+      ConsoleLog: new ComputerFactory().get(ConsoleLog),
+    }
 
     const storage = new InMemoryStorage();
 
@@ -57,9 +60,10 @@ describe('create', () => {
       .add(ConsoleLog)
       .get();
 
-    const computers = new Map()
-      .set('Create', Create)
-      .set('ConsoleLog', ConsoleLog);
+    const computers = {
+      Create: new ComputerFactory().get(Create),
+      ConsoleLog: new ComputerFactory().get(ConsoleLog),
+    }
 
     const storage = new InMemoryStorage();
 
@@ -84,9 +88,10 @@ describe('create', () => {
       .add(ConsoleLog)
       .get();
 
-    const computers = new Map()
-      .set('Create', Create)
-      .set('ConsoleLog', ConsoleLog);
+    const computers = {
+      Create: new ComputerFactory().get(Create),
+      ConsoleLog: new ComputerFactory().get(ConsoleLog),
+    }
 
     const storage = new InMemoryStorage();
 

--- a/packages/core/src/ExecutionMemoryFactory.ts
+++ b/packages/core/src/ExecutionMemoryFactory.ts
@@ -15,11 +15,11 @@ import { toLookup } from './utils/toLookup'
 export class ExecutionMemoryFactory {
   constructor(
     public diagram: Diagram,
-    public computers: Map<string, Computer>,
+    public computers: Record<string, Computer>,
     public storage: Storage
   ) {}
 
-  static create(diagram: Diagram, computers: Map<string, Computer>, storage: Storage) {
+  static create(diagram: Diagram, computers: Record<string, Computer>, storage: Storage) {
     const instance = new this(diagram, computers, storage)
 
     // Create a new memory
@@ -59,7 +59,7 @@ export class ExecutionMemoryFactory {
       memory.outputDevices.set(node.id, outputDevice)
 
       // Initialize runner generators
-      const computer = instance.computers.get(node.type)
+      const computer = instance.computers[node.type]
       if(!computer) throw new Error(`Computer "${node.type}" not found`)
 
       memory.setNodeRunner(

--- a/packages/core/src/Executor.test.ts
+++ b/packages/core/src/Executor.test.ts
@@ -14,7 +14,7 @@ import { coreNodeProvider } from './coreNodeProvider';
 describe('execute', () => {
   it('can execute an empty diagram and return an execution update', async () => {
     const diagram = new Diagram()
-    const computers = new Map<string, Computer>()
+    const computers: Record<string, Computer> = {}
 
     const storage = new InMemoryStorage()
 
@@ -47,11 +47,13 @@ describe('execute', () => {
 
     let proof = 'dummy-should-change-this'
 
-    const computers = new Map<string, Computer>().set('Dummy', {
-      async *run({}) {
-        proof = 'dummy-rocks'
-      },
-    } as Computer)
+    const computers: Record<string, Computer> = {
+      Dummy: {
+        async *run({}) {
+          proof = 'dummy-rocks'
+        },
+      } as Computer
+    }
 
     const storage = new InMemoryStorage()
 
@@ -87,11 +89,13 @@ describe('execute', () => {
       nodes: [node]
     })
 
-    const computers = new Map<string, Computer>().set('Accepter', {
-      async *run({ output }) {
-        // do nothing
-      },
-    } as Computer)
+    const computers: Record<string, Computer> = {
+      Accepter: {
+        async *run({}) {
+          // Do nothing
+        },
+      } as Computer
+    }
 
     const storage = new InMemoryStorage()
 
@@ -124,11 +128,13 @@ describe('execute', () => {
       nodes: [node]
     })
 
-    const computers = new Map<string, Computer>().set('Spawner', {
-      async *run({ output }) {
-        output.push([{ type: 'Zergling' }])
-      },
-    } as Computer)
+    const computers: Record<string, Computer> = {
+      Spawner: {
+        async *run({ output }) {
+          output.push([{ type: 'Zergling' }])
+        },
+      } as Computer
+    }
 
     const storage = new InMemoryStorage()
 
@@ -203,9 +209,10 @@ describe('execute', () => {
       },
     } as Computer
 
-    const computers = new Map<string, Computer>()
-      .set(createComputer.name, createComputer)
-      .set(logComputer.name, logComputer)
+    const computers: Record<string, Computer> = {
+      Create: createComputer,
+      Log: logComputer,
+    }
 
     const storage = new InMemoryStorage()
 

--- a/packages/core/src/Executor.ts
+++ b/packages/core/src/Executor.ts
@@ -17,7 +17,7 @@ export class Executor {
 
   constructor(
     diagram: Diagram,
-    public readonly computers: Map<string, Computer>,
+    public readonly computers: Record<string, Computer>,
     public readonly storage: Storage
   ) {
     this.diagram = diagram.unfold()
@@ -127,7 +127,7 @@ export class Executor {
   protected getRunnableNodes(): Node[] {
     return this.diagram.nodes.filter(node => {
       // If the computer implements a custom hook
-      const computer = this.computers.get(node.type)!
+      const computer = this.computers[node.type]
       const hook = computer.canRun
       if(hook) return hook({
         isAvailable: () => this.memory.getNodeStatus(node.id) === 'AVAILABLE',

--- a/packages/core/src/coreNodeProvider.ts
+++ b/packages/core/src/coreNodeProvider.ts
@@ -5,13 +5,8 @@ import { ComputerFactory } from './ComputerFactory';
 
 export const coreNodeProvider: ServiceProvider = {
   register: (app: Application) => {
-    // Make all computers and put in a Map
-    const computers = new Map(Object.values(computerConfigs).map(config => {
-      const computer = new ComputerFactory().get(config);
-      return [computer.name, computer];
-    }));
-
-    app.addComputers(computers);
+    const configs = Object.values(computerConfigs)
+    app.addComputerConfigs(configs);
   },
 
   boot: (app: Application) => {}

--- a/packages/core/src/support/diagramExecutionTester/DiagramExecutionTester.ts
+++ b/packages/core/src/support/diagramExecutionTester/DiagramExecutionTester.ts
@@ -6,6 +6,7 @@ import { Executor } from '../../Executor';
 import { InMemoryStorage } from '../../InMemoryStorage';
 import * as computerConfigs from '../../computers'
 import { ComputerFactory } from '../../ComputerFactory';
+import { Computer } from '../../types/Computer';
 
 export const whenRunning = (diagram: Diagram) => {
   return new DiagramExecutionTester(diagram)
@@ -18,13 +19,17 @@ export class DiagramExecutionTester {
   constructor(public diagram: Diagram) {}
 
   async ok() {
+    let computers: Record<string, Computer> = {}
+
+    for(const config of Object.values(computerConfigs)) {
+      const computer = new ComputerFactory().get(config)
+      computers[computer.name] = computer
+    }
+
     const executor = new Executor(
       this.diagram,
       // TODO: this should be injectable, not hardcoded take all
-      new Map(Object.values(computerConfigs).map(config => {
-        const computer = new ComputerFactory().get(config);
-        return [computer.name, computer];
-      })),
+      computers,
       await this.makeStorage()
     )
 

--- a/packages/hubspot/src/hubspotProvider.ts
+++ b/packages/hubspot/src/hubspotProvider.ts
@@ -4,7 +4,7 @@ import * as computerConfigs from './computers'
 export const hubspotProvider: ServiceProvider = {
   register: (app: Application) => {
     const configs = Object.values(computerConfigs as {[key: string]: ComputerConfig})
-    app.addComputers(configs);
+    app.addComputerConfigs(configs);
   },
 
   boot: (app: Application) => {}

--- a/packages/nodejs/src/nodeJsProvider.ts
+++ b/packages/nodejs/src/nodeJsProvider.ts
@@ -3,13 +3,8 @@ import * as computerConfigs from './computers'
 
 export const nodeJsProvider: ServiceProvider = {
   register: (app: Application) => {
-    // Make all computers and put in a Map
-    const computers = new Map(Object.values(computerConfigs as {[key: string]: ComputerConfig}).map(config => {
-      const computer = new ComputerFactory().get(config);
-      return [computer.name, computer];
-    }));
-
-    app.addComputers(computers);
+    const configs = Object.values(computerConfigs)
+    app.addComputerConfigs(configs);
   },
 
   boot: (app: Application) => {}

--- a/packages/openai/src/openAiProvider.ts
+++ b/packages/openai/src/openAiProvider.ts
@@ -3,13 +3,8 @@ import * as computerConfigs from './computers'
 
 export const openAiProvider: ServiceProvider = {
   register: (app: Application) => {
-    // Make all computers and put in a Map
-    const computers = new Map(Object.values(computerConfigs as {[key: string]: ComputerConfig}).map(config => {
-      const computer = new ComputerFactory().get(config);
-      return [computer.name, computer];
-    }));
-
-    app.addComputers(computers);
+    const configs = Object.values(computerConfigs)
+    app.addComputerConfigs(configs);
   },
 
   boot: (app: Application) => {}


### PR DESCRIPTION
* Changes Application computer record to a simpler type: `Record<string, Computer>`
* Drops Application `addComputers`, instead use `addComputerConfigs`.