### PR TITLE
Evaluation bug fixes

### DIFF
--- a/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
+++ b/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
@@ -102,7 +102,9 @@ export const prepareStringable = (itemValue: ItemValue, param: Param, globalPara
 
   if (selectedEvaluation?.type === 'JS_EXPRESSION') {
     try {
-      transformedValue = eval(transformedValue);
+      // Wrap with parentheses to ensure brackets are not interpreted as a block
+      const nonBlockExpression = `(${transformedValue})`;
+      transformedValue = eval(nonBlockExpression);
     } catch(error) {
       console.log(`Failed to evaluate JS expression: ${transformedValue}`)
       throw error

--- a/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
+++ b/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
@@ -9,9 +9,9 @@ export class StringableParamEvaluator implements ParamsValueEvaluator<Stringable
   type = 'StringableParam' as const;
 
   evaluate(itemValue: ItemValue, param: StringableParam, globalParams: Param[]) {
-  // **********************************************************************
-  // VALIDATE
-  // **********************************************************************
+    // **********************************************************************
+    // VALIDATE
+    // **********************************************************************
 
     // Ensure param is StringableParam
     if (param.type !== 'StringableParam') throw new Error(`Param "${param.name}" must be StringableParam`);
@@ -87,7 +87,7 @@ export class StringableParamEvaluator implements ParamsValueEvaluator<Stringable
       transformedValue = Hjson.parse(transformedValue);
     }
 
-    if (selectedEvaluation?.type === 'JS') {
+    if (selectedEvaluation?.type === 'JS_FUNCTION') {
       const fn = eval(transformedValue);
       transformedValue = fn(itemValue);
     }

--- a/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
+++ b/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
@@ -9,121 +9,118 @@ export class StringableParamEvaluator implements ParamsValueEvaluator<Stringable
   type = 'StringableParam' as const;
 
   evaluate(itemValue: ItemValue, param: StringableParam, globalParams: Param[]) {
-    return prepareStringable(itemValue, param, globalParams);
-  }
-
-  canEvaluate(param: Param): param is StringableParam {
-    return param.type === this.type;
-  }
-}
-export const prepareStringable = (itemValue: ItemValue, param: Param, globalParams: Param[]) => {
   // **********************************************************************
   // VALIDATE
   // **********************************************************************
 
-  // Ensure param is StringableParam
-  if (param.type !== 'StringableParam') throw new Error(`Param "${param.name}" must be StringableParam`);
+    // Ensure param is StringableParam
+    if (param.type !== 'StringableParam') throw new Error(`Param "${param.name}" must be StringableParam`);
 
-  let transformedValue: string | any = String(param.value);
+    let transformedValue: string | any = String(param.value);
 
-  // **********************************************************************
-  // INTERPOLATE GLOBAL PARAMS
-  // **********************************************************************
-  if (param.interpolate) {
+    // **********************************************************************
+    // INTERPOLATE GLOBAL PARAMS
+    // **********************************************************************
+    if (param.interpolate) {
     // Find any @{PARAM_NAME} and replace with the value of the global param
-    const GLOBAL_PARAM_PATTERN = /@\{(\w+)\}/g;
-    transformedValue = transformedValue.replace(GLOBAL_PARAM_PATTERN, (_: string, name: string) => {
-      return globalParams.find(p => p.name === name)?.value;
-    });
-  }
+      const GLOBAL_PARAM_PATTERN = /@\{(\w+)\}/g;
+      transformedValue = transformedValue.replace(GLOBAL_PARAM_PATTERN, (_: string, name: string) => {
+        return globalParams.find(p => p.name === name)?.value;
+      });
+    }
 
-  // **********************************************************************
-  // INTERPOLATE ITEM PROPERTIES
-  // **********************************************************************
-  if (param.interpolate) {
+    // **********************************************************************
+    // INTERPOLATE ITEM PROPERTIES
+    // **********************************************************************
+    if (param.interpolate) {
     /** Replace template strings with item properties
      * Example: { greeting: "Hi ${name}!"}
      * Becomes: { greeting: "Hi Bob!"}
      * When the item value is { name: "Bob" }
      */
-    transformedValue = transformedValue.replace(
-      /\${([\w\.]+)}/g,
-      (_: string, name: string) => get(itemValue, name)
-    );
-  }
-
-  // **********************************************************************
-  // FUNCTIONS
-  // **********************************************************************
-  // TODO option for this
-  if (true) {
-    /** Replaces function calls */
-    transformedValue = transformedValue.replace(/@(\w+)\((.*)\)/g, (_: string, fn: string, expression: string) => {
-      const args = expression.split(',').map(arg => arg.trim());
-
-      const functions: Record<string, Function> = {
-        evalMath: (expression: string) => evalMath(expression),
-        env: (expression: string) => {
-          if (typeof process === 'undefined') throw new Error('env() is not available in the browser');
-
-          return process.env[args[0]];
-        },
-        number: (expression: string) => Number(expression),
-        string: (expression: string) => String(expression),
-      }
-
-      const match = functions[fn];
-
-      // If we don't know the function, just return the expression
-      if (!match) return expression;
-
-      return match(...args);
-    });
-  }
-
-  // **********************************************************************
-  // EVALUATE
-  // **********************************************************************
-  const evaluations = param.evaluations || [];
-  const selectedEvaluation = evaluations.find(e => e.selected);
-
-  if (selectedEvaluation?.type === 'JSON') {
-    transformedValue = JSON.parse(transformedValue);
-  }
-
-  if (selectedEvaluation?.type === 'HJSON') {
-    transformedValue = Hjson.parse(transformedValue);
-  }
-
-  if (selectedEvaluation?.type === 'JS') {
-    const fn = eval(transformedValue);
-    transformedValue = fn(itemValue);
-  }
-
-  if (selectedEvaluation?.type === 'JS_EXPRESSION') {
-    try {
-      // Wrap with parentheses to ensure brackets are not interpreted as a block
-      const nonBlockExpression = `(${transformedValue})`;
-      transformedValue = eval(nonBlockExpression);
-    } catch(error) {
-      console.log(`Failed to evaluate JS expression: ${transformedValue}`)
-      throw error
+      transformedValue = transformedValue.replace(
+        /\${([\w\.]+)}/g,
+        (_: string, name: string) => get(itemValue, name)
+      );
     }
+
+    // **********************************************************************
+    // FUNCTIONS
+    // **********************************************************************
+    // TODO option for this
+    if (true) {
+    /** Replaces function calls */
+      transformedValue = transformedValue.replace(/@(\w+)\((.*)\)/g, (_: string, fn: string, expression: string) => {
+        const args = expression.split(',').map(arg => arg.trim());
+
+        const functions: Record<string, Function> = {
+          evalMath: (expression: string) => evalMath(expression),
+          env: (expression: string) => {
+            if (typeof process === 'undefined') throw new Error('env() is not available in the browser');
+
+            return process.env[args[0]];
+          },
+          number: (expression: string) => Number(expression),
+          string: (expression: string) => String(expression),
+        }
+
+        const match = functions[fn];
+
+        // If we don't know the function, just return the expression
+        if (!match) return expression;
+
+        return match(...args);
+      });
+    }
+
+    // **********************************************************************
+    // EVALUATE
+    // **********************************************************************
+    const evaluations = param.evaluations || [];
+    const selectedEvaluation = evaluations.find(e => e.selected);
+
+    if (selectedEvaluation?.type === 'JSON') {
+      transformedValue = JSON.parse(transformedValue);
+    }
+
+    if (selectedEvaluation?.type === 'HJSON') {
+      transformedValue = Hjson.parse(transformedValue);
+    }
+
+    if (selectedEvaluation?.type === 'JS') {
+      const fn = eval(transformedValue);
+      transformedValue = fn(itemValue);
+    }
+
+    if (selectedEvaluation?.type === 'JS_EXPRESSION') {
+      try {
+      // Wrap with parentheses to ensure brackets are not interpreted as a block
+        const nonBlockExpression = `(${transformedValue})`;
+        transformedValue = eval(nonBlockExpression);
+      } catch(error) {
+        console.log(`Failed to evaluate JS expression: ${transformedValue}`)
+        throw error
+      }
+    }
+
+    // **********************************************************************
+    // CAST
+    // **********************************************************************
+    const casts = param.casts || [];
+    const selectedCast = casts.find(c => c.selected);
+
+    if (selectedCast?.type === 'stringCast') {
+      transformedValue = String(transformedValue);
+    }
+
+    if (selectedCast?.type === 'numberCast') {
+      transformedValue = Number(transformedValue);
+    }
+
+    return transformedValue;
   }
 
-  // **********************************************************************
-  // CAST
-  // **********************************************************************
-  const casts = param.casts || [];
-  const selectedCast = casts.find(c => c.selected);
-
-  if (selectedCast?.type === 'stringCast') {
-    transformedValue = String(transformedValue);
+  canEvaluate(param: Param): param is StringableParam {
+    return param.type === this.type;
   }
-
-  if (selectedCast?.type === 'numberCast') {
-    transformedValue = Number(transformedValue);
-  }
-
-  return transformedValue;
 }

--- a/packages/core/src/Param/Param.ts
+++ b/packages/core/src/Param/Param.ts
@@ -5,7 +5,7 @@ import { Evaluation } from './Evaluation'
 import { numberCast } from './casts/numberCast'
 import { stringCast } from './casts/stringCast'
 import { hjsonEvaluation } from './evaluations/hjsonEvaluation'
-import { jsEvaluation } from './evaluations/jsEvaluation'
+import { jsFunctionEvaluation } from './evaluations/jsFunctionEvaluation'
 import { jsonEvaluation } from './evaluations/jsonEvaluation'
 
 export type StringableParam = {

--- a/packages/core/src/Param/evaluations/jsEvaluation.ts
+++ b/packages/core/src/Param/evaluations/jsEvaluation.ts
@@ -1,6 +1,0 @@
-import { Evaluation } from '../Evaluation';
-
-export const jsEvaluation: Evaluation = {
-  type: 'JS',
-  label: 'JS',
-}

--- a/packages/core/src/Param/evaluations/jsFunctionEvaluation.ts
+++ b/packages/core/src/Param/evaluations/jsFunctionEvaluation.ts
@@ -1,0 +1,6 @@
+import { Evaluation } from '../Evaluation';
+
+export const jsFunctionEvaluation: Evaluation = {
+  type: 'JS_FUNCTION',
+  label: 'JS Function',
+}

--- a/packages/core/src/computers/ConsoleLog.ts
+++ b/packages/core/src/computers/ConsoleLog.ts
@@ -2,7 +2,7 @@ import { ItemWithParams } from '../ItemWithParams/ItemWithParams';
 import { numberCast } from '../Param/casts/numberCast';
 import { stringCast } from '../Param/casts/stringCast';
 import { hjsonEvaluation } from '../Param/evaluations/hjsonEvaluation';
-import { jsEvaluation } from '../Param/evaluations/jsEvaluation';
+import { jsFunctionEvaluation } from '../Param/evaluations/jsFunctionEvaluation';
 import { jsonEvaluation } from '../Param/evaluations/jsonEvaluation';
 import { ComputerConfig } from '../types/ComputerConfig';
 
@@ -21,7 +21,7 @@ export const ConsoleLog: ComputerConfig = {
       canInterpolate: true,
       interpolate: true,
       evaluations: [
-        jsEvaluation,
+        jsFunctionEvaluation,
         jsonEvaluation,
         hjsonEvaluation,
       ],

--- a/packages/core/src/computers/Create.test.ts
+++ b/packages/core/src/computers/Create.test.ts
@@ -67,13 +67,11 @@ it('can parse js expression', async () => {
     .ok()
 })
 
-it('cannot directly parse js objects starting with bracket', async () => {
+it('can directly parse js objects starting with bracket', async () => {
   await when(Create)
     .hasParam({
       name: 'data',
       value: multiline`
-      // JS eval thinks this is a block followed by a labeled statment
-      // Probably not what you would expect but that is how eval works
       {
         label: 'statement'
       }`,
@@ -82,8 +80,8 @@ it('cannot directly parse js objects starting with bracket', async () => {
       ]
     })
     .doRun()
-    // TODO this should throw an error.
-    // We only allow object items.
-    .expectOutput([ 'statement' ])
+    .expectOutput([ {
+      label: 'statement'
+    }])
     .ok()
 })

--- a/packages/core/src/computers/Create.test.ts
+++ b/packages/core/src/computers/Create.test.ts
@@ -1,5 +1,5 @@
 import { hjsonEvaluation } from '../Param/evaluations/hjsonEvaluation';
-import { jsEvaluation } from '../Param/evaluations/jsEvaluation';
+import { jsFunctionEvaluation } from '../Param/evaluations/jsFunctionEvaluation';
 import { jsExpressionEvaluation } from '../Param/evaluations/jsExpressionEvaluation'
 import { when } from '../support/computerTester/ComputerTester';
 import { multiline } from '../utils/multiline';
@@ -42,7 +42,7 @@ it('can parse js function', async () => {
       name: 'data',
       value: '() => ({ sum: 1 + 1 })',
       evaluations: [
-        { ...jsEvaluation, selected: true }
+        { ...jsFunctionEvaluation, selected: true }
       ]
     })
     .doRun()

--- a/packages/core/src/computers/Create.ts
+++ b/packages/core/src/computers/Create.ts
@@ -2,7 +2,7 @@ import { ComputerConfig } from '../types/ComputerConfig';
 import { json_ } from '../Param';
 import { jsonEvaluation } from '../Param/evaluations/jsonEvaluation';
 import { hjsonEvaluation } from '../Param/evaluations/hjsonEvaluation';
-import { jsEvaluation } from '../Param/evaluations/jsEvaluation';
+import { jsFunctionEvaluation } from '../Param/evaluations/jsFunctionEvaluation';
 import { jsExpressionEvaluation } from '../Param/evaluations/jsExpressionEvaluation';
 
 export const Create: ComputerConfig = {
@@ -14,9 +14,9 @@ export const Create: ComputerConfig = {
       help: 'You may use json, hson js function or expression',
       value: JSON.stringify({ foo: 'bar' }, null, 2),
       evaluations: [
-        { ...jsonEvaluation, selected: true },
-        hjsonEvaluation,
-        jsEvaluation,
+        { ...hjsonEvaluation, selected: true },
+        jsonEvaluation,
+        jsFunctionEvaluation,
         jsExpressionEvaluation,
       ]
     })

--- a/packages/core/src/computers/CreateProperties.ts
+++ b/packages/core/src/computers/CreateProperties.ts
@@ -1,6 +1,8 @@
 import { numberCast } from '../Param/casts/numberCast';
 import { stringCast } from '../Param/casts/stringCast';
+import { hjsonEvaluation } from '../Param/evaluations/hjsonEvaluation';
 import { jsEvaluation } from '../Param/evaluations/jsEvaluation';
+import { jsExpressionEvaluation } from '../Param/evaluations/jsExpressionEvaluation';
 import { jsonEvaluation } from '../Param/evaluations/jsonEvaluation';
 import { ComputerConfig } from '../types/ComputerConfig';
 
@@ -37,7 +39,9 @@ export const CreateProperties: ComputerConfig = {
           interpolate: true,
           evaluations: [
             jsonEvaluation,
+            hjsonEvaluation,
             jsEvaluation,
+            jsExpressionEvaluation,
           ],
           casts: [
             numberCast,

--- a/packages/core/src/computers/CreateProperties.ts
+++ b/packages/core/src/computers/CreateProperties.ts
@@ -1,7 +1,7 @@
 import { numberCast } from '../Param/casts/numberCast';
 import { stringCast } from '../Param/casts/stringCast';
 import { hjsonEvaluation } from '../Param/evaluations/hjsonEvaluation';
-import { jsEvaluation } from '../Param/evaluations/jsEvaluation';
+import { jsFunctionEvaluation } from '../Param/evaluations/jsFunctionEvaluation';
 import { jsExpressionEvaluation } from '../Param/evaluations/jsExpressionEvaluation';
 import { jsonEvaluation } from '../Param/evaluations/jsonEvaluation';
 import { ComputerConfig } from '../types/ComputerConfig';
@@ -40,7 +40,7 @@ export const CreateProperties: ComputerConfig = {
           evaluations: [
             jsonEvaluation,
             hjsonEvaluation,
-            jsEvaluation,
+            jsFunctionEvaluation,
             jsExpressionEvaluation,
           ],
           casts: [

--- a/packages/core/src/computers/Map.ts
+++ b/packages/core/src/computers/Map.ts
@@ -1,5 +1,5 @@
 import { json_ } from '../Param';
-import { jsEvaluation } from '../Param/evaluations/jsEvaluation';
+import { jsFunctionEvaluation } from '../Param/evaluations/jsFunctionEvaluation';
 import { jsonEvaluation } from '../Param/evaluations/jsonEvaluation';
 import { hjsonEvaluation } from '../Param/evaluations/hjsonEvaluation';
 import { ComputerConfig } from '../types/ComputerConfig';
@@ -34,7 +34,7 @@ export const Map: ComputerConfig = {
       evaluations: [
         { ...hjsonEvaluation, selected: true },
         jsonEvaluation,
-        jsEvaluation,
+        jsFunctionEvaluation,
       ]
     })
   ],

--- a/packages/core/src/computers/Signal.ts
+++ b/packages/core/src/computers/Signal.ts
@@ -4,6 +4,10 @@ import { numberCast } from '../Param/casts/numberCast';
 import { multiline } from '../utils/multiline';
 import { hjson, json_, num } from '../Param';
 import Hjson from '@data-story/hjson';
+import { jsEvaluation } from '../Param/evaluations/jsEvaluation';
+import { jsExpressionEvaluation } from '../Param/evaluations/jsExpressionEvaluation';
+import { jsonEvaluation } from '../Param/evaluations/jsonEvaluation';
+import { hjsonEvaluation } from '../Param/evaluations/hjsonEvaluation';
 
 export const Signal: ComputerConfig = {
   name: 'Signal',
@@ -36,6 +40,12 @@ export const Signal: ComputerConfig = {
       label: 'Template expression',
       help: 'Use this field to customize the signal. ${i} is available as a variable.',
       value: Hjson.stringify({id: '${i}'}),
+      evaluations: [
+        { ...hjsonEvaluation, selected: true },
+        jsonEvaluation,
+        jsEvaluation,
+        jsExpressionEvaluation,
+      ]
     })
   ],
 

--- a/packages/core/src/computers/Signal.ts
+++ b/packages/core/src/computers/Signal.ts
@@ -4,7 +4,7 @@ import { numberCast } from '../Param/casts/numberCast';
 import { multiline } from '../utils/multiline';
 import { hjson, json_, num } from '../Param';
 import Hjson from '@data-story/hjson';
-import { jsEvaluation } from '../Param/evaluations/jsEvaluation';
+import { jsFunctionEvaluation } from '../Param/evaluations/jsFunctionEvaluation';
 import { jsExpressionEvaluation } from '../Param/evaluations/jsExpressionEvaluation';
 import { jsonEvaluation } from '../Param/evaluations/jsonEvaluation';
 import { hjsonEvaluation } from '../Param/evaluations/hjsonEvaluation';
@@ -43,7 +43,7 @@ export const Signal: ComputerConfig = {
       evaluations: [
         { ...hjsonEvaluation, selected: true },
         jsonEvaluation,
-        jsEvaluation,
+        jsFunctionEvaluation,
         jsExpressionEvaluation,
       ]
     })

--- a/packages/core/src/computers/Throw.ts
+++ b/packages/core/src/computers/Throw.ts
@@ -2,7 +2,7 @@ import { NodeRunError } from '../NodeRunError';
 import { numberCast } from '../Param/casts/numberCast';
 import { stringCast } from '../Param/casts/stringCast';
 import { hjsonEvaluation } from '../Param/evaluations/hjsonEvaluation';
-import { jsEvaluation } from '../Param/evaluations/jsEvaluation';
+import { jsFunctionEvaluation } from '../Param/evaluations/jsFunctionEvaluation';
 import { jsonEvaluation } from '../Param/evaluations/jsonEvaluation';
 import { ComputerConfig } from '../types/ComputerConfig';
 
@@ -19,7 +19,7 @@ export const Throw: ComputerConfig = {
       canInterpolate: true,
       interpolate: true,
       evaluations: [
-        jsEvaluation,
+        jsFunctionEvaluation,
         jsonEvaluation,
         hjsonEvaluation,
       ],


### PR DESCRIPTION
* Wraps any JS_EXPRESSION with () to not confuse objects with code blocks.
* Rename ambigious "JS" evaluation to "JS_FUNCTION"
* Adds missing evaluations to Create, Signal and CreateProperties
* Simplifies `StringableParamEvaluator.evaluate`


