### PR TITLE
/docs dev: Start a NodeJS server automatically

### DIFF
--- a/packages/docs/.gitignore
+++ b/packages/docs/.gitignore
@@ -1,3 +1,4 @@
+dist
 .next
 node_modules
 .yarn

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -3,10 +3,9 @@
   "version": "0.0.1",
   "description": "DataStory documentation",
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "watch:server": "nodemon -x 'node --experimental-default-type=module ./servers/full.js'"
+    "dev": "node ./dist/servers/nextServer.js",
+    "build": "next build && tsc -p tsconfig.server.json",
+    "start": "next start"
   },
   "repository": {
     "type": "git",

--- a/packages/docs/servers/dataStoryApp.ts
+++ b/packages/docs/servers/dataStoryApp.ts
@@ -1,0 +1,9 @@
+import { Application, coreNodeProvider } from '@data-story/core';
+import { nodeJsProvider } from '@data-story/nodejs';
+
+export const dataStoryApp = new Application()
+  .register([
+    coreNodeProvider,
+    nodeJsProvider,
+  ])
+  .boot();

--- a/packages/docs/servers/nextServer.ts
+++ b/packages/docs/servers/nextServer.ts
@@ -1,0 +1,48 @@
+import next from 'next';
+import { createServer } from 'http';
+import { parse } from 'url';
+import { SocketServer } from '@data-story/nodejs';
+import { dataStoryApp } from './dataStoryApp';
+
+const NEXT_PORT = process.env.PORT || 3000;
+const DATASTORY_PORT = Number(process.env.DATASTORY_PORT) || 3300;
+
+const dev = process.env.NODE_ENV !== 'production';
+
+/**
+ * Custom NextJS server
+ * Purpose is to have the DataStory NodeJS server
+ * running alongside the NextJS server
+ * so everything can be started with a single command
+ * Note, this server is only used in development
+ */
+const app = next({ dev });
+const handle = app.getRequestHandler();
+
+app.prepare().then(() => {
+  const httpServer = createServer((req, res) => {
+    if (!req.url) {
+      console.error('Request URL is undefined');
+      res.statusCode = 400;
+      res.end('Bad Request: URL is undefined');
+      return;
+    }
+
+    const parsedUrl = parse(req.url, true);
+    handle(req, res, parsedUrl);
+  });
+
+  // Initialize DataStory SocketServer
+  const dataStoryServer = new SocketServer({
+    app: dataStoryApp,
+    port: DATASTORY_PORT
+  });
+
+  dataStoryServer.start();
+
+  // Start the HTTP server
+  httpServer.listen(NEXT_PORT, () => {
+    console.log(`> Ready on http://localhost:${NEXT_PORT}`);
+    console.log(`> Started DataStory NodeJS server on ${DATASTORY_PORT}`);
+  });
+});

--- a/packages/docs/tsconfig.server.json
+++ b/packages/docs/tsconfig.server.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "dist",
+    "target": "ES2019",
+    "lib": ["ES2019", "DOM"],
+    "isolatedModules": false,
+    "noEmit": false
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -23,10 +23,6 @@
       "cache": false,
       "persistent": true
     },
-    "watch:server": {
-      "cache": false,
-      "persistent": true
-    },
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist"],


### PR DESCRIPTION
Attempt to have a watchable DataStory NodeJS running automatically on `yarn dev`.
This would be nice when going to `/playground-node`, that it is already up and watching.
Currently we have to run: `yarn dev` in one tab, `yarn watch:server` in *another* tab.