### PR TITLE
fix: resolve build order issue when executing `yarn dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "packages/private/*"
   ],
   "scripts": {
-    "dev": "echo _____RUNNING_ROOT_DEV_____ && yarn kill && turbo dev --parallel",
+    "dev": "echo _____RUNNING_ROOT_DEV_____ && yarn kill && yarn build && turbo dev --parallel",
     "kill": "kill-port 3000 3300",
     "build": "turbo build",
     "docs:add-nodes": "npx ts-node ./scripts/addNodesToDocs.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -5,8 +5,7 @@
       "dependsOn": [
         "watch:webpack",
         "watch:tsc",
-        "watch:css",
-        "build"
+        "watch:css"
       ],
       "cache": false,
       "persistent": true


### PR DESCRIPTION
When initiating `yarn dev`, `data-story` should first execute `yarn build`, followed by concurrently running `watch:webpack, watch:tsc, and watch:css` tasks.

if the `watch:tsc` task in `packages/openai` depends on `"@data-story/core"` but the `core`'s `build` hasn't finished yet, it results in an error.
