### PR TITLE
Allow nullable object fields in Table

### DIFF
--- a/packages/ui/src/components/Node/ItemCollection.test.ts
+++ b/packages/ui/src/components/Node/ItemCollection.test.ts
@@ -91,4 +91,27 @@ describe('toTable', () => {
     expect(headers).toEqual([]);
     expect(rows).toEqual([]);
   });
+
+  it('should handle nullable objects filled and not filled', () => {
+    const mockData = [
+      {
+        'name': {
+          'first': 'John',
+          'last': 'Doe'
+        },
+        'age': 21,
+      },
+      {
+        'name': null,
+        'age': 22,
+      },
+    ];
+
+    const { headers, rows } = new ItemCollection(mockData).toTable();
+    expect(headers).toEqual(['name.first', 'name.last', 'age', 'name']);
+    expect(rows).toEqual([
+      ['John', 'Doe', '21', undefined],
+      [undefined, undefined, '22', 'null'],
+    ]);
+  })
 });

--- a/packages/ui/src/components/Node/ItemCollection.ts
+++ b/packages/ui/src/components/Node/ItemCollection.ts
@@ -1,4 +1,4 @@
-import { ItemValue } from '@data-story/core'
+import { ItemValue, get } from '@data-story/core'
 
 type JSONValue = string | number | boolean | {[key: string]: JSONValue} | JSONValue[];
 
@@ -36,26 +36,22 @@ export class ItemCollection {
     /**
      * @description get value by header's path
      */
-    const getValueByPath = (object: ItemValue, path: string[]): string | undefined => {
-      let current: any = object;
-      for(let i = 0; i < path.length; i++) {
-        if (current[path[i]] === undefined) {
-          return undefined;
-        }
-        current = current[path[i]];
+    const getValueByPath = (object: ItemValue, path: string): string | undefined => {
+      let rawValue: any = get(object, path);
+
+      const currentType = typeof rawValue;
+
+      if (currentType === 'object' && Array.isArray(rawValue)) {
+        return this.serializeArrayContent(rawValue);
       }
 
-      const currentType = typeof current;
-
-      if (currentType === 'object' && Array.isArray(current)) {
-        return this.serializeArrayContent(current);
-      }
-
-      if (currentType === 'object' && current !== null) {
+      if (currentType === 'object' && rawValue !== null) {
         return undefined;
       }
 
-      return typeof current === 'string' ? current : JSON.stringify(current);
+      return typeof rawValue === 'string'
+        ? rawValue
+        : JSON.stringify(rawValue);
     }
 
     /**
@@ -64,7 +60,7 @@ export class ItemCollection {
     this.items.forEach(item => {
       const row: (string | undefined)[] = [];
       headers.forEach(header => {
-        const value = getValueByPath(item, header.split('.'));
+        const value = getValueByPath(item, header);
         row.push(value);
       });
       rows.push(row);


### PR DESCRIPTION
Before: ItemCollection like this caused Table node to crash:
```js
[
  {
    name: ajthinking,
    optional: {
      city: Stockholm
    }
  },
  {
    name: stone,
    optional: null
  }
]
```

After: 
<img width="661" alt="image" src="https://github.com/ajthinking/data-story/assets/3457668/27fb8114-f33d-4ed0-89eb-7cdf8941f373">
