### PR TITLE
feat: add state for dropdown in StringableInput component

### DIFF
--- a/packages/core/src/Executor.ts
+++ b/packages/core/src/Executor.ts
@@ -136,6 +136,7 @@ export class Executor {
       if(hook) return hook({
         isAvailable: () => this.memory.getNodeStatus(node.id) === 'AVAILABLE',
         input: this.memory.getInputDevice(node.id)!,
+        // todo: It seems the params didn't evaluate correctly
         params: arrayToRecord(node.params, 'name')
       })
 

--- a/packages/core/src/InputDevice.test.ts
+++ b/packages/core/src/InputDevice.test.ts
@@ -1,7 +1,7 @@
 import { Diagram } from './Diagram'
 import { ExecutionMemory } from './ExecutionMemory'
 import { InputDevice } from './InputDevice'
-import { Param, StringableParam } from './Param'
+import { createDefaultStringable } from './Param'
 import { UnfoldedDiagramFactory } from './UnfoldedDiagramFactory'
 import { Node } from './types/Node'
 
@@ -222,16 +222,15 @@ describe('params', () => {
       type: 'node-type',
       inputs: [{id: 'target-input-id', name: 'input', schema: {}}],
       outputs: [],
-      params: [{
+      params: [createDefaultStringable({
         name: 'greeting',
         label: 'Greeting',
         help: 'The greeting to use',
-        type: 'StringableParam',
         value: 'Hello ${name}',
         multiline: false,
         canInterpolate: true,
         interpolate: true,
-      }]
+      })]
     }
 
     const links = [

--- a/packages/core/src/ItemWithParams/RepeatableParamEvaluator.test.ts
+++ b/packages/core/src/ItemWithParams/RepeatableParamEvaluator.test.ts
@@ -40,7 +40,7 @@ describe('evaluate', () => {
       []
     );
 
-    expect(result).toEqual(removePropertyData.value);
+    expect(result).toEqual([{ property: 'foo-1' }]);
   });
 
   it('should test RepeatableParam contain the PortSelectionParam type', () => {
@@ -50,7 +50,10 @@ describe('evaluate', () => {
       []
     );
 
-    expect(result).toEqual(mockPortMapData.value);
+    expect(result).toEqual([
+      { value: 22, port: 'unfiltered' },
+      { value: 'id', port: 'outputzdbj' }
+    ]);
   });
 
   it('should test RepeatableParam contain the RepeatableParam type', () => {
@@ -60,7 +63,10 @@ describe('evaluate', () => {
       []
     );
 
-    expect(result).toEqual(mockRepeatableData.value);
+    expect(result).toEqual([
+      { value: 'value-11', remove_properties: [{ property: 'property-11' }] },
+      { value: 'value-22', remove_properties: [{ property: 'property-22' }] }
+    ]);
   });
 
   it('recursive called count', () => {
@@ -95,7 +101,9 @@ describe('evaluate', () => {
           {
             "name": "value",
             "type": "StringableParam",
-            "value": "value-11",
+            "value": {
+              "value": "value-11",
+            },
           },
           [],
         ],
@@ -113,7 +121,9 @@ describe('evaluate', () => {
             "type": "RepeatableParam",
             "value": [
               {
-                "property": "property-11",
+                "property": {
+                  "value": "property-11",
+                },
               },
             ],
           },
@@ -124,7 +134,9 @@ describe('evaluate', () => {
           {
             "name": "property",
             "type": "StringableParam",
-            "value": "property-11",
+            "value": {
+              "value": "property-11",
+            },
           },
           [],
         ],
@@ -133,7 +145,9 @@ describe('evaluate', () => {
           {
             "name": "value",
             "type": "StringableParam",
-            "value": "value-22",
+            "value": {
+              "value": "value-22",
+            },
           },
           [],
         ],
@@ -151,7 +165,9 @@ describe('evaluate', () => {
             "type": "RepeatableParam",
             "value": [
               {
-                "property": "property-22",
+                "property": {
+                  "value": "property-22",
+                },
               },
             ],
           },
@@ -162,7 +178,9 @@ describe('evaluate', () => {
           {
             "name": "property",
             "type": "StringableParam",
-            "value": "property-22",
+            "value": {
+              "value": "property-22",
+            },
           },
           [],
         ],

--- a/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
+++ b/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
@@ -18,7 +18,6 @@ export class StringableParamEvaluator implements ParamsValueEvaluator<Stringable
     // Ensure param is StringableParam
     if (param.type !== 'StringableParam') throw new Error(`Param "${param.name}" must be StringableParam`);
 
-    // maintain compatibility with Stringable. new type: object | old type: string
     let transformedValue: any  = String(param.value?.value);
 
     // **********************************************************************

--- a/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
+++ b/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
@@ -16,7 +16,10 @@ export class StringableParamEvaluator implements ParamsValueEvaluator<Stringable
     // Ensure param is StringableParam
     if (param.type !== 'StringableParam') throw new Error(`Param "${param.name}" must be StringableParam`);
 
-    let transformedValue: string | any = String(param.value);
+    // maintain compatibility with Stringable. new type: object | old type: string
+    let transformedValue: string | any =  typeof param.value === 'object' ?
+      String(param.value?.content ) :
+      String(param.value);
 
     // **********************************************************************
     // INTERPOLATE GLOBAL PARAMS

--- a/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
+++ b/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
@@ -19,7 +19,6 @@ export class StringableParamEvaluator implements ParamsValueEvaluator<Stringable
     if (param.type !== 'StringableParam') throw new Error(`Param "${param.name}" must be StringableParam`);
 
     // maintain compatibility with Stringable. new type: object | old type: string
-    console.log(param.value, 'param.value', param);
     let transformedValue: any  = String(param.value?.value);
 
     // **********************************************************************

--- a/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
+++ b/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
@@ -20,9 +20,7 @@ export class StringableParamEvaluator implements ParamsValueEvaluator<Stringable
 
     // maintain compatibility with Stringable. new type: object | old type: string
     console.log(param.value, 'param.value', param);
-    let transformedValue: string | any = typeof param.value === 'object' ?
-      String(param.value?.value) :
-      String(param.value);
+    let transformedValue: any  = String(param.value?.value);
 
     // **********************************************************************
     // INTERPOLATE GLOBAL PARAMS
@@ -82,20 +80,9 @@ export class StringableParamEvaluator implements ParamsValueEvaluator<Stringable
     // **********************************************************************
     // EVALUATE
     // **********************************************************************
-    // Compatible with the storage method for evaluations.
-    let selectedEvaluation: Evaluation | undefined;
-    if (typeof param.value === 'object') {
-      // new method: evaluation is stored in param.value
-      selectedEvaluation = {
-        type: param.value?.['Evaluation'] as string,
-        label: param.value?.['Evaluation'] as string,
-        selected: true,
-      };
-    } else {
-      // old method: evaluation is stored in param.evaluations
-      const evaluations = param.evaluations || [];
-      selectedEvaluation = evaluations.find(e => e.selected);
-    }
+    const selectedEvaluation = {
+      type: param.value?.['Evaluation'] as string,
+    };
 
     if (selectedEvaluation?.type === 'JSON') {
       transformedValue = JSON.parse(transformedValue);
@@ -124,20 +111,9 @@ export class StringableParamEvaluator implements ParamsValueEvaluator<Stringable
     // **********************************************************************
     // CAST
     // **********************************************************************
-    // Compatible with the storage method for casts.
-    let selectedCast: Cast | undefined;
-    if (typeof param.value === 'object') {
-      // new method: cast is stored in param.value
-      selectedCast = {
-        type: param.value?.['Cast'] as string,
-        label: param.value?.['Cast'] as string,
-        selected: true,
-      };
-    } else {
-      // old method: cast is stored in param.casts
-      const casts = param.casts || [];
-      selectedCast = casts.find(c => c.selected);
-    }
+    let selectedCast = {
+      type: param.value?.['Cast'] as string,
+    };
 
     if (selectedCast?.type === 'stringCast') {
       transformedValue = String(transformedValue);

--- a/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
+++ b/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
@@ -19,8 +19,9 @@ export class StringableParamEvaluator implements ParamsValueEvaluator<Stringable
     if (param.type !== 'StringableParam') throw new Error(`Param "${param.name}" must be StringableParam`);
 
     // maintain compatibility with Stringable. new type: object | old type: string
+    console.log(param.value, 'param.value', param);
     let transformedValue: string | any = typeof param.value === 'object' ?
-      String(param.value?.content) :
+      String(param.value?.value) :
       String(param.value);
 
     // **********************************************************************

--- a/packages/core/src/ItemWithParams/mock.ts
+++ b/packages/core/src/ItemWithParams/mock.ts
@@ -10,7 +10,9 @@ export const removePropertyData = {
   ],
   'value': [
     {
-      'property': 'foo-1'
+      'property': {
+        value: 'foo-1',
+      }
     }
   ]
 };
@@ -29,18 +31,26 @@ export const mockRepeatableData = {
   ],
   value: [
     {
-      value: 'value-11',
+      value: {
+        value: 'value-11'
+      },
       remove_properties: [
         {
-          'property': 'property-11'
+          'property': {
+            value: 'property-11'
+          }
         }
       ]
     },
     {
-      value: 'value-22',
+      value: {
+        value: 'value-22'
+      },
       remove_properties: [
         {
-          'property': 'property-22'
+          'property': {
+            value: 'property-22'
+          }
         }
       ]
     }
@@ -64,11 +74,17 @@ export const mockPortMapData = {
   ],
   'value': [
     {
-      'value': '22',
+      'value': {
+        value: '22',
+        'Cast': 'numberCast'
+      },
       'port': 'unfiltered'
     },
     {
-      'value': 'id',
+      'value': {
+        value: 'id',
+        'Cast': 'stringCast'
+      },
       'port': 'outputzdbj'
     }
   ]

--- a/packages/core/src/Param/Param.ts
+++ b/packages/core/src/Param/Param.ts
@@ -20,7 +20,7 @@ export type StringableParam = {
   interpolationsFromPort?: PortName[],
   casts?: Cast[],
   evaluations?: Evaluation[],
-  value: string | number
+  value: string | number | Record<string, number | string>
 }
 
 export type PropertySelectionParam = {

--- a/packages/core/src/Param/Param.ts
+++ b/packages/core/src/Param/Param.ts
@@ -105,7 +105,7 @@ export const createDefaultStringable = ({
     casts,
     interpolationsFromPort,
     value: {
-      value: value,
+      value: value ?? '',
     },
   }
 }

--- a/packages/core/src/Param/Param.ts
+++ b/packages/core/src/Param/Param.ts
@@ -139,7 +139,7 @@ export const str = ({
     interpolate: interpolate ?? true,
     evaluations: evaluations,
     casts: [
-      { ...stringCast, selected: true },
+      stringCast
     ],
     value: {
       value: value ?? '',
@@ -177,7 +177,7 @@ export const num = ({
     interpolate: interpolate ?? true,
     evaluations: evaluations,
     casts: [
-      { ...numberCast, selected: true },
+      numberCast
     ],
     value: {
       value: value ?? 0,
@@ -214,7 +214,7 @@ export const json_ = ({
     canInterpolate: canInterpolate ?? true,
     interpolate: interpolate ?? true,
     evaluations: evaluations ?? [
-      { ...jsonEvaluation, selected: true },
+      jsonEvaluation,
       hjsonEvaluation,
       jsFunctionEvaluation,
       jsExpressionEvaluation,
@@ -258,7 +258,7 @@ export const hjson = ({
     canInterpolate: canInterpolate ?? true,
     interpolate: interpolate ?? true,
     evaluations: evaluations ?? [
-      { ...hjsonEvaluation, selected: true },
+      hjsonEvaluation ,
       jsonEvaluation,
     ],
     casts: [

--- a/packages/core/src/Param/Param.ts
+++ b/packages/core/src/Param/Param.ts
@@ -77,6 +77,39 @@ export type ParamValue = Param['value']
 
 // // quick param builders
 
+type StringableConfigType = Omit<StringableParam, 'value' | 'type'> & {
+  value: StringableInputValue['value']
+}
+
+export const createDefaultStringable = ({
+  name,
+  label,
+  help,
+  multiline,
+  canInterpolate,
+  interpolate,
+  evaluations,
+  casts,
+  interpolationsFromPort,
+  value,
+}:StringableConfigType): StringableParam => {
+  return {
+    name,
+    type: 'StringableParam',
+    label,
+    help,
+    multiline,
+    canInterpolate,
+    interpolate,
+    evaluations,
+    casts,
+    interpolationsFromPort,
+    value: {
+      value: value,
+    },
+  }
+}
+
 export const str = ({
   name,
   label,

--- a/packages/core/src/Param/Param.ts
+++ b/packages/core/src/Param/Param.ts
@@ -1,5 +1,4 @@
 import { PortName } from '../types/Port'
-import { snakeCaseToTitleCase } from '../utils/snakeCaseToTitleCase'
 import { Cast } from './Cast'
 import { Evaluation } from './Evaluation'
 import { numberCast } from './casts/numberCast'
@@ -8,6 +7,12 @@ import { hjsonEvaluation } from './evaluations/hjsonEvaluation'
 import { jsExpressionEvaluation } from './evaluations/jsExpressionEvaluation'
 import { jsFunctionEvaluation } from './evaluations/jsFunctionEvaluation'
 import { jsonEvaluation } from './evaluations/jsonEvaluation'
+
+export interface StringableInputValue extends Record<string, any> {
+  value: any,
+  Evaluation?: string,
+  Cast?: string,
+}
 
 export type StringableParam = {
   name: string,
@@ -20,7 +25,7 @@ export type StringableParam = {
   interpolationsFromPort?: PortName[],
   casts?: Cast[],
   evaluations?: Evaluation[],
-  value: string | number | Record<string, number | string>
+  value: StringableInputValue,
 }
 
 export type PropertySelectionParam = {
@@ -58,7 +63,7 @@ export type RepeatableParam<RepeatableRow> = {
   help: string,
   type: 'RepeatableParam',
   row: RepeatableRow,
-  value: Param[]
+  value: Record<string, unknown>[]
 }
 
 export type Param =
@@ -103,7 +108,10 @@ export const str = ({
     casts: [
       { ...stringCast, selected: true },
     ],
-    value: value ?? '',
+    value: {
+      value: value ?? '',
+      Cast: stringCast.type,
+    }
   }
 }
 
@@ -138,7 +146,10 @@ export const num = ({
     casts: [
       { ...numberCast, selected: true },
     ],
-    value: value ?? 0,
+    value: {
+      value: value ?? 0,
+      Cast: numberCast.type,
+    },
   }
 }
 
@@ -179,7 +190,10 @@ export const json_ = ({
       numberCast,
       stringCast,
     ],
-    value: value ?? 0,
+    value: {
+      value: value ?? 0,
+      Evaluation: jsonEvaluation.type,
+    },
   }
 }
 
@@ -218,6 +232,9 @@ export const hjson = ({
       numberCast,
       stringCast,
     ],
-    value: value ?? 0,
+    value: {
+      value: value ?? 0,
+      Evaluation: hjsonEvaluation.type
+    },
   }
 }

--- a/packages/core/src/UnfoldedDiagramFactory.test.ts
+++ b/packages/core/src/UnfoldedDiagramFactory.test.ts
@@ -51,7 +51,10 @@ describe('unfold', () => {
       'Input.1': expect.arrayContaining([
         expect.objectContaining({
           name: 'stamp',
-          value: 'foo',
+          value:  {
+            Cast: 'stringCast',
+            value: 'foo',
+          },
         }),
       ]),
     })

--- a/packages/core/src/computers/Await.ts
+++ b/packages/core/src/computers/Await.ts
@@ -1,30 +1,28 @@
 import { ComputerConfig } from '../types/ComputerConfig';
-import { numberCast } from '../Param/casts/numberCast';
+import { num, StringableInputValue } from '../Param';
 
 export const Await: ComputerConfig = {
   name: 'Await',
   inputs: ['input'],
   outputs: ['output', 'no_items'],
   params: [
-    {
-      name: 'number_of_items',
-      label: 'Number of Items',
-      help: 'How many items to await?',
-      type: 'StringableParam',
-      multiline: false,
-      canInterpolate: true,
-      interpolate: true,
-      casts: [
-        {...numberCast, selected: true}
-      ],
-      value: 'Infinity'
-    },
+    num(
+      {
+        name: 'number_of_items',
+        label: 'Number of Items',
+        help: 'How many items to await?',
+        multiline: false,
+        canInterpolate: true,
+        interpolate: true,
+        value: 'Infinity',
+      }
+    )
   ],
 
   canRun({ input, params }) {
     const haveChunk = input.haveItemsAtInput(
       'input',
-      params.number_of_items.value as number
+      (params.number_of_items.value as StringableInputValue).value as number
     )
 
     const haveRemainder = input.haveAllItemsAtInput('input')
@@ -40,7 +38,7 @@ export const Await: ComputerConfig = {
 
       const pulledCount = incoming.length
       if(pulledCount > 0) hasPulledAny = true
-      const chunkSize = params.number_of_items as number
+      const chunkSize = params.number_of_items as unknown as number
 
       output.push(incoming)
 

--- a/packages/core/src/computers/Comment.ts
+++ b/packages/core/src/computers/Comment.ts
@@ -1,16 +1,16 @@
 import { ComputerConfig } from '../types/ComputerConfig';
 import { multiline } from '../utils/multiline';
+import { createDefaultStringable } from '../Param';
 
 export const Comment: ComputerConfig = {
   name: 'Comment',
   inputs: [],
   outputs: [],
   params: [
-    {
+    createDefaultStringable( {
       name: 'content',
       label: 'Content',
       help: 'Markdown content',
-      type: 'StringableParam',
       multiline: true,
       canInterpolate: false,
       interpolate: false,
@@ -19,8 +19,8 @@ export const Comment: ComputerConfig = {
       value: multiline`
         ### Comment
         paragraph
-      `,
-    }
+      `
+    })
   ],
 
   async *run({}) {},

--- a/packages/core/src/computers/ConsoleLog.ts
+++ b/packages/core/src/computers/ConsoleLog.ts
@@ -5,6 +5,7 @@ import { hjsonEvaluation } from '../Param/evaluations/hjsonEvaluation';
 import { jsFunctionEvaluation } from '../Param/evaluations/jsFunctionEvaluation';
 import { jsonEvaluation } from '../Param/evaluations/jsonEvaluation';
 import { ComputerConfig } from '../types/ComputerConfig';
+import { createDefaultStringable } from '../Param';
 
 export const ConsoleLog: ComputerConfig = {
   name: 'ConsoleLog',
@@ -12,11 +13,10 @@ export const ConsoleLog: ComputerConfig = {
   inputs: ['input'],
 
   params: [
-    {
+    createDefaultStringable( {
       name: 'message',
       label: 'message',
       help: 'What to log. Leave blank to log the whole item.',
-      type: 'StringableParam',
       multiline: false,
       canInterpolate: true,
       interpolate: true,
@@ -30,7 +30,7 @@ export const ConsoleLog: ComputerConfig = {
         stringCast,
       ],
       value: '',
-    }
+    })
   ],
 
   async *run({ input, hooks, params: rawParams }) {

--- a/packages/core/src/computers/Create.test.ts
+++ b/packages/core/src/computers/Create.test.ts
@@ -4,7 +4,6 @@ import { jsExpressionEvaluation } from '../Param/evaluations/jsExpressionEvaluat
 import { when } from '../support/computerTester/ComputerTester';
 import { multiline } from '../utils/multiline';
 import { Create } from './Create';
-import Hjson from '@data-story/hjson';
 
 it('reads json by default', async () => {
   await when(Create)
@@ -26,7 +25,10 @@ it('can parse hjson', async () => {
   await when(Create)
     .hasParam({
       name: 'data',
-      value: '{ cool: "yes" }',
+      value: {
+        value: '{ cool: "yes" }',
+        Evaluation: 'HJSON'
+      },
       evaluations: [
         { ...hjsonEvaluation, selected: true }
       ]
@@ -40,7 +42,10 @@ it('can parse js function', async () => {
   await when(Create)
     .hasParam({
       name: 'data',
-      value: '() => ({ sum: 1 + 1 })',
+      value: {
+        value: '() => ({ sum: 1 + 1 })',
+        Evaluation: 'JS_FUNCTION'
+      },
       evaluations: [
         { ...jsFunctionEvaluation, selected: true }
       ]
@@ -54,10 +59,13 @@ it('can parse js expression', async () => {
   await when(Create)
     .hasParam({
       name: 'data',
-      value: multiline`
+      value: {
+        value: multiline`
       ({
         interesting: 'yes'
       })`,
+        Evaluation: 'JS_EXPRESSION'
+      },
       evaluations: [
         { ...jsExpressionEvaluation, selected: true }
       ]
@@ -71,10 +79,13 @@ it('can directly parse js objects starting with bracket', async () => {
   await when(Create)
     .hasParam({
       name: 'data',
-      value: multiline`
+      value: {
+        value: multiline`
       {
         label: 'statement'
       }`,
+        Evaluation: 'JS_EXPRESSION'
+      },
       evaluations: [
         { ...jsExpressionEvaluation, selected: true }
       ]

--- a/packages/core/src/computers/CreateProperties.ts
+++ b/packages/core/src/computers/CreateProperties.ts
@@ -5,6 +5,7 @@ import { jsFunctionEvaluation } from '../Param/evaluations/jsFunctionEvaluation'
 import { jsExpressionEvaluation } from '../Param/evaluations/jsExpressionEvaluation';
 import { jsonEvaluation } from '../Param/evaluations/jsonEvaluation';
 import { ComputerConfig } from '../types/ComputerConfig';
+import { createDefaultStringable } from '../Param';
 
 export const CreateProperties: ComputerConfig = {
   name: 'CreateProperties',
@@ -18,22 +19,20 @@ export const CreateProperties: ComputerConfig = {
       help: 'The properties to create',
       type: 'RepeatableParam',
       row: [
-        {
+        createDefaultStringable({
           name: 'key',
           label: 'Key',
           help: 'The key to create',
-          type: 'StringableParam',
           multiline: false,
           canInterpolate: true,
           interpolate: true,
           interpolationsFromPort: ['input'],
           value: '',
-        },
-        {
+        }),
+        createDefaultStringable({
           name: 'value',
           label: 'Value',
           help: 'The value to create',
-          type: 'StringableParam',
           multiline: true,
           canInterpolate: true,
           interpolate: true,
@@ -48,7 +47,7 @@ export const CreateProperties: ComputerConfig = {
             stringCast,
           ],
           value: '',
-        },
+        })
       ],
       value: [],
     },

--- a/packages/core/src/computers/Describe.ts
+++ b/packages/core/src/computers/Describe.ts
@@ -40,9 +40,7 @@ export const Describe: ComputerConfig = {
 
   async *run({ input, output, params }) {
     const incoming = input.pull()
-      .map(i => {
-        return get(i.value, String(params.path));
-      })
+      .map(i => get(i.value, String(params.path)))
 
     const description = describeCollection(incoming)
     const truncated = truncateDescription(description, Number(params.truncate_limit))

--- a/packages/core/src/computers/Describe.ts
+++ b/packages/core/src/computers/Describe.ts
@@ -3,7 +3,7 @@ import { multiline } from '../utils/multiline';
 import { stringCast } from '../Param/casts/stringCast';
 import { numberCast } from '../Param/casts/numberCast';
 import { get } from '../utils/get';
-import { createDefaultStringable } from '../Param';
+import { num, str } from '../Param';
 
 export const Describe: ComputerConfig = {
   name: 'Describe',
@@ -13,19 +13,16 @@ export const Describe: ComputerConfig = {
   inputs: ['input'],
   outputs: ['truncated', 'full'],
   params: [
-    createDefaultStringable(  {
+    str(  {
       name: 'path',
       label: 'Path',
       help: 'Dot notated path to desired description root. Leave empty to use the root of the collection.',
       multiline: false,
       canInterpolate: true,
       interpolate: true,
-      casts: [
-        {...stringCast, selected: true}
-      ],
       value: ''
     }),
-    createDefaultStringable(
+    num(
       {
         name: 'truncate_limit',
         label: 'Truncate limit',
@@ -33,9 +30,6 @@ export const Describe: ComputerConfig = {
         multiline: false,
         canInterpolate: true,
         interpolate: true,
-        casts: [
-          {...numberCast, selected: true}
-        ],
         value: String(10)
       }),
   ],
@@ -45,9 +39,14 @@ export const Describe: ComputerConfig = {
   },
 
   async *run({ input, output, params }) {
+    console.log(params, 'params111')
     const incoming = input.pull()
-      .map(i => get(i.value, String(params.path)))
+      .map(i => {
+        console.log(i.value, 'i.value', String(params.path), 'String(params.path)');
+        return get(i.value, String(params.path));
+      })
 
+    console.log(incoming, 'incoming');
     const description = describeCollection(incoming)
     const truncated = truncateDescription(description, Number(params.truncate_limit))
 
@@ -74,6 +73,7 @@ export function describeCollection(arr: any[]) {
     });
   };
 
+  console.log(arr, 'arr', result, 'result');
   // Iterate over each object in the array
   arr.forEach(obj => {
     processObject(obj, result);

--- a/packages/core/src/computers/Describe.ts
+++ b/packages/core/src/computers/Describe.ts
@@ -3,6 +3,7 @@ import { multiline } from '../utils/multiline';
 import { stringCast } from '../Param/casts/stringCast';
 import { numberCast } from '../Param/casts/numberCast';
 import { get } from '../utils/get';
+import { createDefaultStringable } from '../Param';
 
 export const Describe: ComputerConfig = {
   name: 'Describe',
@@ -12,11 +13,10 @@ export const Describe: ComputerConfig = {
   inputs: ['input'],
   outputs: ['truncated', 'full'],
   params: [
-    {
+    createDefaultStringable(  {
       name: 'path',
       label: 'Path',
       help: 'Dot notated path to desired description root. Leave empty to use the root of the collection.',
-      type: 'StringableParam',
       multiline: false,
       canInterpolate: true,
       interpolate: true,
@@ -24,20 +24,20 @@ export const Describe: ComputerConfig = {
         {...stringCast, selected: true}
       ],
       value: ''
-    },
-    {
-      name: 'truncate_limit',
-      label: 'Truncate limit',
-      help: 'How many keys to display?',
-      type: 'StringableParam',
-      multiline: false,
-      canInterpolate: true,
-      interpolate: true,
-      casts: [
-        {...numberCast, selected: true}
-      ],
-      value: String(10)
-    },
+    }),
+    createDefaultStringable(
+      {
+        name: 'truncate_limit',
+        label: 'Truncate limit',
+        help: 'How many keys to display?',
+        multiline: false,
+        canInterpolate: true,
+        interpolate: true,
+        casts: [
+          {...numberCast, selected: true}
+        ],
+        value: String(10)
+      }),
   ],
 
   canRun({ input }) {

--- a/packages/core/src/computers/Describe.ts
+++ b/packages/core/src/computers/Describe.ts
@@ -39,14 +39,11 @@ export const Describe: ComputerConfig = {
   },
 
   async *run({ input, output, params }) {
-    console.log(params, 'params111')
     const incoming = input.pull()
       .map(i => {
-        console.log(i.value, 'i.value', String(params.path), 'String(params.path)');
         return get(i.value, String(params.path));
       })
 
-    console.log(incoming, 'incoming');
     const description = describeCollection(incoming)
     const truncated = truncateDescription(description, Number(params.truncate_limit))
 
@@ -73,7 +70,6 @@ export function describeCollection(arr: any[]) {
     });
   };
 
-  console.log(arr, 'arr', result, 'result');
   // Iterate over each object in the array
   arr.forEach(obj => {
     processObject(obj, result);

--- a/packages/core/src/computers/Map.ts
+++ b/packages/core/src/computers/Map.ts
@@ -28,7 +28,7 @@ export const Map: ComputerConfig = {
     },
     json_({
       name: 'json',
-      value: '{\n\tfoo: bar\n}',
+      value: '{\n\t"foo": "bar"\n}',
       help: '',
     })
   ],

--- a/packages/core/src/computers/Sleep.ts
+++ b/packages/core/src/computers/Sleep.ts
@@ -1,17 +1,17 @@
 import { sleep } from '../utils/sleep';
 import { ComputerConfig } from '../types/ComputerConfig';
 import { numberCast } from '../Param/casts/numberCast';
+import { createDefaultStringable } from '../Param';
 
 export const Sleep: ComputerConfig = {
   name: 'Sleep',
   inputs: ['input'],
   outputs: ['output'],
   params: [
-    {
+    createDefaultStringable({
       name: 'duration',
       label: 'Duration',
       help: 'How many ms to sleep?',
-      type: 'StringableParam',
       multiline: false,
       canInterpolate: true,
       interpolate: true,
@@ -19,7 +19,7 @@ export const Sleep: ComputerConfig = {
         {...numberCast, selected: true}
       ],
       value: String(100)
-    },
+    }),
   ],
 
   async *run({ input, output }) {

--- a/packages/core/src/computers/Throw.ts
+++ b/packages/core/src/computers/Throw.ts
@@ -5,16 +5,16 @@ import { hjsonEvaluation } from '../Param/evaluations/hjsonEvaluation';
 import { jsFunctionEvaluation } from '../Param/evaluations/jsFunctionEvaluation';
 import { jsonEvaluation } from '../Param/evaluations/jsonEvaluation';
 import { ComputerConfig } from '../types/ComputerConfig';
+import { createDefaultStringable } from '../Param';
 
 export const Throw: ComputerConfig = {
   name: 'Throw',
   inputs: ['input'],
   params: [
-    {
+    createDefaultStringable({
       name: 'message',
       label: 'message',
       help: 'What to throw',
-      type: 'StringableParam',
       multiline: false,
       canInterpolate: true,
       interpolate: true,
@@ -28,7 +28,7 @@ export const Throw: ComputerConfig = {
         stringCast,
       ],
       value: 'Some error',
-    }
+    })
   ],
 
   async *run({ input, node }) {

--- a/packages/core/src/support/computerTester/ComputerTester.ts
+++ b/packages/core/src/support/computerTester/ComputerTester.ts
@@ -278,9 +278,11 @@ export class ComputerTester {
       const hasExplicitValue = this.explicitParamValues.hasOwnProperty(param.name)
 
       if(hasExplicitValue) {
-        param.value = {
+        param.value = param.type === 'StringableParam' ?  {
+          ...param.value,
           value: this.explicitParamValues[param.name]
-        }
+        } : this.explicitParamValues[param.name];
+
         continue
       }
     }

--- a/packages/core/src/support/computerTester/ComputerTester.ts
+++ b/packages/core/src/support/computerTester/ComputerTester.ts
@@ -278,7 +278,9 @@ export class ComputerTester {
       const hasExplicitValue = this.explicitParamValues.hasOwnProperty(param.name)
 
       if(hasExplicitValue) {
-        param.value = this.explicitParamValues[param.name]
+        param.value = {
+          value: this.explicitParamValues[param.name]
+        }
         continue
       }
     }

--- a/packages/nodejs/src/computers/ListFiles/ListFiles.ts
+++ b/packages/nodejs/src/computers/ListFiles/ListFiles.ts
@@ -1,4 +1,4 @@
-import { ComputerConfig } from '@data-story/core';
+import { ComputerConfig, createDefaultStringable } from '@data-story/core';
 import { promises as fs } from 'fs'
 import * as nodePath from 'path'
 
@@ -14,18 +14,17 @@ export const ListFiles: ComputerConfig = {
     }
   }],
   params: [
-    {
+    createDefaultStringable({
       name: 'path',
       label: 'Path',
       help: 'Dir to list',
-      type: 'StringableParam',
       multiline: true,
       canInterpolate: false,
       interpolate: false,
       evaluations: [],
       casts: [],
       value: '/',
-    }
+    })
   ],
 
   async *run({ input, output }) {

--- a/packages/nodejs/src/computers/ReadFiles/ReadFiles.ts
+++ b/packages/nodejs/src/computers/ReadFiles/ReadFiles.ts
@@ -1,6 +1,6 @@
 import * as glob from 'glob';
 import { promises as fs } from 'fs';
-import { ComputerConfig } from '@data-story/core';
+import { ComputerConfig, createDefaultStringable } from '@data-story/core';
 
 export const ReadFiles: ComputerConfig = {
   name: 'ReadFiles',
@@ -16,23 +16,21 @@ export const ReadFiles: ComputerConfig = {
     }
   }],
   params: [
-    {
+    createDefaultStringable({
       name: 'include',
       label: 'Include',
       help: 'Glob pattern to include',
-      type: 'StringableParam',
       multiline: true,
       canInterpolate: true,
       interpolate: true,
       evaluations: [],
       casts: [],
       value: '${path}/**/*.ts',
-    },
-    {
+    }),
+    createDefaultStringable(    {
       name: 'ignore',
       label: 'Ignore',
       help: 'Glob pattern to ignore',
-      type: 'StringableParam',
       multiline: true,
       canInterpolate: true,
       interpolate: true,
@@ -40,6 +38,7 @@ export const ReadFiles: ComputerConfig = {
       casts: [],
       value: '**/node_modules/**',
     },
+    )
   ],
 
   async *run({ input, output }) {

--- a/packages/nodejs/src/computers/RunCommand/RunCommand.ts
+++ b/packages/nodejs/src/computers/RunCommand/RunCommand.ts
@@ -1,6 +1,6 @@
 import { promisify } from 'util';
 import { exec as execCallback } from 'child_process';
-import { ComputerConfig } from '@data-story/core';
+import { ComputerConfig, createDefaultStringable } from '@data-story/core';
 
 const exec = promisify(execCallback);
 
@@ -25,18 +25,17 @@ export const RunCommand: ComputerConfig = {
   inputs: ['input'],
   outputs: ['output', 'error'],
   params: [
-    {
+    createDefaultStringable({
       name: 'command',
       label: 'Command',
       help: 'Command to run',
-      type: 'StringableParam',
       multiline: true,
       canInterpolate: false,
       interpolate: false,
       evaluations: [],
       casts: [],
       value: 'say "Hello World"',
-    }
+    })
   ],
 
   async *run({ input, output, params }) {

--- a/packages/openai/src/computers/AskChatGpt/AskChatGpt.ts
+++ b/packages/openai/src/computers/AskChatGpt/AskChatGpt.ts
@@ -1,23 +1,23 @@
 import { ComputerConfig } from '@data-story/core';
 import { Configuration, OpenAIApi } from 'openai';
+import { createDefaultStringable } from '@data-story/core';
 
 export const AskChatGpt: ComputerConfig = {
   name: 'AskChatGpt',
   inputs: ['input'],
   outputs: ['completions'],
   params: [
-    {
+    createDefaultStringable({
       name: 'prompt',
       label: 'Prompt',
       help: 'Chat prompt',
-      type: 'StringableParam',
       multiline: true,
       canInterpolate: true,
       interpolate: true,
       evaluations: [],
       casts: [],
       value: 'What is the meaning of life?',
-    },
+    }),
   ],
 
   category: 'API',

--- a/packages/ui/src/components/DataStory/Form/RepeatableInput.cy.tsx
+++ b/packages/ui/src/components/DataStory/Form/RepeatableInput.cy.tsx
@@ -1,21 +1,29 @@
 import { DataStoryProvider } from '../store/store';
 import { ReactFlowProvider } from 'reactflow';
 import { RepeatableInput } from './RepeatableInput';
-import { FormProvider, useForm, useFormContext } from 'react-hook-form';
-import { FormCommonProps, RepeatableInputProps } from '../types';
+import { FormProvider, useForm } from 'react-hook-form';
+import { FormCommonProps } from '../types';
 import { ParamsComponentFactory } from '../modals/nodeSettingsModal/tabs/Params/ParamsComponentFactory';
 import { defaultValues, mockNode, mockParam } from './mocks';
+import { FormFieldWrapper, useFormField } from './UseFormField';
 
 const MockComponent = ({ param, type }: {
   param: FormCommonProps & {param: unknown},
   type: 'StringableParam' | 'PortSelectionParam'
 }) => {
-  const { getValues } = useFormContext();
-  const value = getValues(param.name as string);
-  return {
-    StringableParam: <div data-cy='data-story-stringable-param'>{value}</div>,
-    PortSelectionParam: <div data-cy='data-story-port-selection-param'>{value}</div>
-  }[type];
+  const { getValues } = useFormField();
+  const value = getValues();
+  return (
+    <>
+      {
+        //The StringableParam` is composed of `stringInput` + `dropdown`. only mocked the `stringInput` part, so retrieve `value.value`
+        type === 'StringableParam' && <div data-cy='data-story-stringable-param'>{value.value}</div>
+      }
+      {
+        type === 'PortSelectionParam' && <div data-cy='data-story-port-selection-param'>{value}</div>
+      }
+    </>
+  )
 };
 
 const RepeatableInputWithForm = () => {
@@ -27,13 +35,17 @@ const RepeatableInputWithForm = () => {
   ParamsComponentFactory.defaultInstance.availableComponents = [
     {
       getComponent: (params) => {
-        return <MockComponent param={params} type={'StringableParam'}/>
+        return <FormFieldWrapper fieldName={'value'}>
+          <MockComponent param={params} type={'StringableParam'}/>
+        </FormFieldWrapper>
       },
       getType: () => 'StringableParam'
     },
     {
       getComponent: (params) => {
-        return <MockComponent param={params} type={'PortSelectionParam'} />
+        return <FormFieldWrapper fieldName={'port'}>
+          <MockComponent param={params} type={'PortSelectionParam'} />
+        </FormFieldWrapper>
       },
       getType: () => 'PortSelectionParam'
     }

--- a/packages/ui/src/components/DataStory/Form/RepeatableInput.cy.tsx
+++ b/packages/ui/src/components/DataStory/Form/RepeatableInput.cy.tsx
@@ -1,29 +1,39 @@
 import { DataStoryProvider } from '../store/store';
 import { ReactFlowProvider } from 'reactflow';
 import { RepeatableInput } from './RepeatableInput';
-import { useForm } from 'react-hook-form';
-import { RepeatableInputProps } from '../types';
+import { FormProvider, useForm, useFormContext } from 'react-hook-form';
+import { FormCommonProps, RepeatableInputProps } from '../types';
 import { ParamsComponentFactory } from '../modals/nodeSettingsModal/tabs/Params/ParamsComponentFactory';
 import { defaultValues, mockNode, mockParam } from './mocks';
+
+const MockComponent = ({ param, type }: {
+  param: FormCommonProps & {param: unknown},
+  type: 'StringableParam' | 'PortSelectionParam'
+}) => {
+  const { getValues } = useFormContext();
+  const value = getValues(param.name as string);
+  return {
+    StringableParam: <div data-cy='data-story-stringable-param'>{value}</div>,
+    PortSelectionParam: <div data-cy='data-story-port-selection-param'>{value}</div>
+  }[type];
+};
 
 const RepeatableInputWithForm = () => {
   const mockForm = useForm({
     defaultValues
-  }) as unknown as RepeatableInputProps['form'];
+  });
 
   // change ParamsComponentFactory instance
   ParamsComponentFactory.defaultInstance.availableComponents = [
     {
       getComponent: (params) => {
-        const value = params.form.getValues(params.name as string);
-        return <div data-cy='data-story-stringable-param'> {value} </div>
+        return <MockComponent param={params} type={'StringableParam'}/>
       },
       getType: () => 'StringableParam'
     },
     {
       getComponent: (params) => {
-        const value = params.form.getValues(params.name as string);
-        return <div data-cy='data-story-port-selection-param'>{value}</div>
+        return <MockComponent param={params} type={'PortSelectionParam'} />
       },
       getType: () => 'PortSelectionParam'
     }
@@ -31,7 +41,9 @@ const RepeatableInputWithForm = () => {
 
   return (<DataStoryProvider>
     <ReactFlowProvider>
-      <RepeatableInput form={mockForm} node={mockNode} param={mockParam}/>
+      <FormProvider {...mockForm}>
+        <RepeatableInput node={mockNode} param={mockParam}/>
+      </FormProvider>
     </ReactFlowProvider>
   </DataStoryProvider>)
 }

--- a/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
@@ -8,7 +8,7 @@ import { Row } from '@tanstack/react-table';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { FormComponentProps, RepeatableInputProps } from '../types';
 import { ParamsComponentFactory } from '../modals/nodeSettingsModal/tabs/Params/ParamsComponentFactory';
-import { SubField, SubFieldContext, useFormField } from './UseFormField';
+import { FormFieldWrapper, FormFieldContext, useFormField } from './UseFormField';
 
 function RepeatableCell({
   param: paramColumn,
@@ -18,8 +18,8 @@ function RepeatableCell({
   columnIndex: number,
   rowIndex: number,
 }) {
-  const {fieldName} = useContext(SubFieldContext);
-  return <SubField fieldName={`${rowIndex}`}>
+  const {fieldName} = useContext(FormFieldContext);
+  return <FormFieldWrapper fieldName={`${rowIndex}`}>
     <td
       scope="row"
       className="border font-medium whitespace-nowrap bg-gray-50 align-top"
@@ -33,7 +33,7 @@ function RepeatableCell({
         })
       }
     </td>
-  </SubField>;
+  </FormFieldWrapper>;
 }
 
 function RepeatableDraggableRow(props: RepeatableInputProps & {
@@ -115,7 +115,7 @@ export function RepeatableComponent({
   node,
 }: RepeatableInputProps) {
   const { control } = useFormField();
-  const {fieldName} = useContext(SubFieldContext);
+  const {fieldName} = useContext(FormFieldContext);
   const { fields, append, remove, swap } = useFieldArray({
     control: control,
     name: fieldName,
@@ -171,9 +171,9 @@ export function RepeatableComponent({
 export const RepeatableInput = (props: RepeatableInputProps) => {
   return (
     <DndProvider backend={HTML5Backend}>
-      <SubField fieldName={props.param.name}>
+      <FormFieldWrapper fieldName={props.param.name}>
         <RepeatableComponent {...props} />
-      </SubField>
+      </FormFieldWrapper>
     </DndProvider>
   )
 }

--- a/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
@@ -1,6 +1,6 @@
 import { Param } from '@data-story/core';
 import React, { useCallback } from 'react';
-import { useFieldArray } from 'react-hook-form';
+import { useFieldArray, useFormContext } from 'react-hook-form';
 import { DragIcon } from '../icons/dragIcon';
 import { CloseIcon } from '../icons/closeIcon';
 import { DndProvider, useDrag, useDrop } from 'react-dnd';
@@ -11,7 +11,6 @@ import { ParamsComponentFactory } from '../modals/nodeSettingsModal/tabs/Params/
 
 function RepeatableCell({
   param: paramColumn,
-  form,
   name,
   rowIndex,
   node,
@@ -26,7 +25,6 @@ function RepeatableCell({
     {
       ParamsComponentFactory.defaultInstance.getComponent({
         param: paramColumn,
-        form,
         name: `params.${name}.${rowIndex}.${paramColumn.name}`,
         node,
         type: paramColumn.type,
@@ -41,7 +39,7 @@ function RepeatableDraggableRow(props: RepeatableInputProps & {
   reorderRow: (draggedRowIndex: number, targetRowIndex: number) => void;
   deleteRow: (index: number) => void
 }) {
-  const { form, param, node, row, rowIndex, reorderRow, deleteRow } = props;
+  const { param, node, row, rowIndex, reorderRow, deleteRow } = props;
   const name = param.name;
 
   const [, dropRef] = useDrop({
@@ -81,7 +79,7 @@ function RepeatableDraggableRow(props: RepeatableInputProps & {
       param.row.map((column: Param, columnIndex: number) => (
         <RepeatableCell
           key={`${param.row[columnIndex].name}-${columnIndex}`}
-          param={column} form={form}
+          param={column}
           name={name} rowIndex={rowIndex}
           columnIndex={columnIndex} node={node}
         />
@@ -111,12 +109,12 @@ const defaultRowData = (row: Param[]) => {
 }
 
 export function RepeatableComponent({
-  form,
   param,
   node,
 }: RepeatableInputProps) {
+  const { control } = useFormContext();
   const { fields, append, remove, swap } = useFieldArray({
-    control: form.control,
+    control: control,
     name: `params.${param.name}`,
   });
 
@@ -148,7 +146,7 @@ export function RepeatableComponent({
                 reorderRow={swap}
                 deleteRow={remove}
                 row={row} rowIndex={i}
-                param={param} form={form}
+                param={param}
                 node={node}
               />
             )

--- a/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
@@ -27,7 +27,6 @@ function RepeatableCell({
       {
         ParamsComponentFactory.defaultInstance.getComponent({
           param: paramColumn,
-          name: fieldName,
           node,
           type: paramColumn.type,
         })

--- a/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/RepeatableInput.tsx
@@ -18,7 +18,6 @@ function RepeatableCell({
   columnIndex: number,
   rowIndex: number,
 }) {
-  const {fieldName} = useContext(FormFieldContext);
   return <FormFieldWrapper fieldName={`${rowIndex}`}>
     <td
       scope="row"

--- a/packages/ui/src/components/DataStory/Form/SelectInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/SelectInput.tsx
@@ -1,5 +1,5 @@
 import { SelectParam } from '@data-story/core';
-import { SubField, useFormField } from './UseFormField';
+import { FormFieldWrapper, useFormField } from './UseFormField';
 
 function SelectInputComponent({
   param,
@@ -30,7 +30,7 @@ export function SelectInput({
 }: {
   param: SelectParam
 }) {
-  return (<SubField fieldName={param.name}>
+  return (<FormFieldWrapper fieldName={param.name}>
     <SelectInputComponent param={param} />
-  </SubField>);
+  </FormFieldWrapper>);
 }

--- a/packages/ui/src/components/DataStory/Form/SelectInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/SelectInput.tsx
@@ -1,21 +1,19 @@
 import { SelectParam } from '@data-story/core';
-import { UseFormReturn } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 
 export function SelectInput({
   param,
-  form,
   name,
 }: {
-  form: UseFormReturn<{
-    [x: string]: any;
-  }, any>
   name: string,
   param: SelectParam
 }) {
+  const {register} = useFormContext();
+
   return (
-    <div className="flex w-full text-gray-500 w-full">
+    <div className="flex w-full text-gray-500">
       <select className="bg-gray-50 text-xs px-2 py-2 w-full"
-        {...form.register(name)}
+        {...register(name)}
       >
         {param.options.map((option) => {
           return <option

--- a/packages/ui/src/components/DataStory/Form/SelectInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/SelectInput.tsx
@@ -1,19 +1,17 @@
 import { SelectParam } from '@data-story/core';
-import { useFormContext } from 'react-hook-form';
+import { SubField, useFormField } from './UseFormField';
 
-export function SelectInput({
+function SelectInputComponent({
   param,
-  name,
 }: {
-  name: string,
   param: SelectParam
 }) {
-  const {register} = useFormContext();
+  const {register} = useFormField();
 
   return (
     <div className="flex w-full text-gray-500">
       <select className="bg-gray-50 text-xs px-2 py-2 w-full"
-        {...register(name)}
+        {...register()}
       >
         {param.options.map((option) => {
           return <option
@@ -25,4 +23,14 @@ export function SelectInput({
 
     </div>
   );
+}
+
+export function SelectInput({
+  param,
+}: {
+  param: SelectParam
+}) {
+  return (<SubField fieldName={param.name}>
+    <SelectInputComponent param={param} />
+  </SubField>);
 }

--- a/packages/ui/src/components/DataStory/Form/StringableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/StringableInput.tsx
@@ -21,9 +21,12 @@ export function StringableInput({
   param: StringableParam,
   onCursorPositionChange: (position: number) => void // Add this line
 }) {
+  // todo:1. 测试之前的格式，兼容性问题。 2. textArea 下的表现
+  const stringName = `${name}.content`;
   // State to keep track of the number of rows and cursor position
-  const [rows, setRows] = useState(calculateRows(String(form.getValues(name))));
+  const [rows, setRows] = useState(calculateRows(String(form.getValues(stringName))));
 
+  console.log(rows, 'rows in StringableInput form.getValues(name)')
   const handleCursorChange = (event: any) => {
     // Get the current cursor position
     const cursorPosition = event.target.selectionStart;
@@ -36,9 +39,9 @@ export function StringableInput({
   // Effect to listen for form changes - primarily for external updates
   useEffect(() => {
     const subscription = form.watch((value, formEvent) => {
-      if (formEvent.name === name && formEvent.type === 'change') {
+      if (formEvent.name === stringName && formEvent.type === 'change') {
         try {
-          const fieldValue = get(value, name)
+          const fieldValue = get(value, stringName)
           const newRows = calculateRows(fieldValue);
           setRows(newRows);
         } catch (e) {
@@ -47,7 +50,7 @@ export function StringableInput({
       }
     });
     return () => subscription.unsubscribe();
-  }, [form, name]);
+  }, [form, stringName]);
 
   return (
     <div className="flex w-full text-gray-500">
@@ -55,12 +58,12 @@ export function StringableInput({
         ? <textarea
           className="text-xs p-2 w-full bg-gray-50 font-mono"
           rows={rows}
-          {...form.register(`${name}`)}
+          {...form.register(`${stringName}`)}
           onSelect={handleCursorChange}
         />
         : <input
           className="text-xs p-2 w-full bg-gray-50 font-mono"
-          {...form.register(`${name}`)}
+          {...form.register(`${stringName}`)}
         />
       }
     </div>

--- a/packages/ui/src/components/DataStory/Form/StringableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/StringableInput.tsx
@@ -1,6 +1,6 @@
 import { StringableParam, get } from '@data-story/core';
 import { useEffect, useMemo, useState } from 'react';
-import { UseFormReturn } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 
 // Function to calculate the number of rows based on content
 const calculateRows = (content: string) => {
@@ -10,25 +10,22 @@ const calculateRows = (content: string) => {
 
 export function StringableInput({
   name,
-  form,
   param,
   onCursorPositionChange,
 }: {
-  form: UseFormReturn<{
-    [x: string]: any;
-  }, any>
   name: string,
   param: StringableParam,
   onCursorPositionChange: (position: number) => void // Add this line
 }) {
-  const stringName = useMemo(() => `${name}.content`, [name]);
+  const stringName = useMemo(() => `${name}.value`, [name]);
+  const { getValues, setValue, watch, register } = useFormContext()
 
   // change Stringable format from string to object to maintain compatibility
   const latestValue = useMemo(() => {
-    const latestValue = form.getValues(stringName) ?? form.getValues(name);
-    form.setValue(stringName, latestValue);
+    const latestValue = getValues(stringName) ?? getValues(name);
+    setValue(stringName, latestValue);
     return latestValue;
-  }, [form, name, stringName]);
+  }, [getValues, name, setValue, stringName]);
 
   // State to keep track of the number of rows and cursor position
   const [rows, setRows] = useState(calculateRows(String(latestValue)));
@@ -44,7 +41,7 @@ export function StringableInput({
 
   // Effect to listen for form changes - primarily for external updates
   useEffect(() => {
-    const subscription = form.watch((value, formEvent) => {
+    const subscription = watch((value, formEvent) => {
       if (formEvent.name === stringName && formEvent.type === 'change') {
         try {
           const fieldValue = get(value, stringName)
@@ -56,7 +53,7 @@ export function StringableInput({
       }
     });
     return () => subscription.unsubscribe();
-  }, [form, stringName]);
+  }, [stringName, watch]);
 
   return (
     <div className="flex w-full text-gray-500">
@@ -64,12 +61,12 @@ export function StringableInput({
         ? <textarea
           className="text-xs p-2 w-full bg-gray-50 font-mono"
           rows={rows}
-          {...form.register(`${stringName}`)}
+          {...register(`${stringName}`)}
           onSelect={handleCursorChange}
         />
         : <input
           className="text-xs p-2 w-full bg-gray-50 font-mono"
-          {...form.register(`${stringName}`)}
+          {...register(`${stringName}`)}
         />
       }
     </div>

--- a/packages/ui/src/components/DataStory/Form/StringableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/StringableInput.tsx
@@ -1,6 +1,6 @@
 import { StringableParam, get } from '@data-story/core';
 import { useContext, useEffect, useState } from 'react';
-import { SubField, SubFieldContext, useFormField } from './UseFormField';
+import { FormFieldWrapper, FormFieldContext, useFormField } from './UseFormField';
 
 // Function to calculate the number of rows based on content
 const calculateRows = (content: string) => {
@@ -17,7 +17,7 @@ export function StringableInputComponent({
   param,
   onCursorPositionChange,
 }: StringableInput) {
-  const {fieldName} = useContext(SubFieldContext);
+  const {fieldName} = useContext(FormFieldContext);
 
   const { getValues,  watch, register } = useFormField()
 
@@ -68,7 +68,7 @@ export function StringableInputComponent({
 }
 
 export function StringableInput(params: StringableInput) {
-  return <SubField fieldName={'value'}>
+  return <FormFieldWrapper fieldName={'value'}>
     <StringableInputComponent {...params} />
-  </SubField>
+  </FormFieldWrapper>
 }

--- a/packages/ui/src/components/DataStory/Form/StringableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/StringableInput.tsx
@@ -1,5 +1,5 @@
 import { StringableParam, get } from '@data-story/core';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 
 // Function to calculate the number of rows based on content
@@ -21,8 +21,15 @@ export function StringableInput({
   param: StringableParam,
   onCursorPositionChange: (position: number) => void // Add this line
 }) {
-  // todo:1. 测试之前的格式，兼容性问题。 2. textArea 下的表现
-  const stringName = `${name}.content`;
+  const stringName = useMemo(() => `${name}.content`, [name]);
+
+  // change Stringable format from string to object to maintain compatibility
+  useEffect(() => {
+    const beforeValue = form.getValues(name);
+    if (beforeValue && !form.getValues(stringName)) {
+      form.setValue(stringName, beforeValue);
+    }
+  }, [form, name, stringName]);
   // State to keep track of the number of rows and cursor position
   const [rows, setRows] = useState(calculateRows(String(form.getValues(stringName))));
 

--- a/packages/ui/src/components/DataStory/Form/StringableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/StringableInput.tsx
@@ -17,7 +17,7 @@ export function StringableInput({
   param: StringableParam,
   onCursorPositionChange: (position: number) => void // Add this line
 }) {
-  const stringName = useMemo(() => `${name}.value`, [name]);
+  const stringName = useMemo(() => `${name}.content`, [name]);
   const { getValues, setValue, watch, register } = useFormContext()
 
   // change Stringable format from string to object to maintain compatibility

--- a/packages/ui/src/components/DataStory/Form/StringableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/StringableInput.tsx
@@ -17,7 +17,7 @@ export function StringableInput({
   param: StringableParam,
   onCursorPositionChange: (position: number) => void // Add this line
 }) {
-  const stringName = useMemo(() => `${name}.content`, [name]);
+  const stringName = useMemo(() => `${name}.value`, [name]);
   const { getValues, setValue, watch, register } = useFormContext()
 
   // change Stringable format from string to object to maintain compatibility

--- a/packages/ui/src/components/DataStory/Form/StringableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/StringableInput.tsx
@@ -24,16 +24,15 @@ export function StringableInput({
   const stringName = useMemo(() => `${name}.content`, [name]);
 
   // change Stringable format from string to object to maintain compatibility
-  useEffect(() => {
-    const beforeValue = form.getValues(name);
-    if (beforeValue && !form.getValues(stringName)) {
-      form.setValue(stringName, beforeValue);
-    }
+  const latestValue = useMemo(() => {
+    const latestValue = form.getValues(stringName) ?? form.getValues(name);
+    form.setValue(stringName, latestValue);
+    return latestValue;
   }, [form, name, stringName]);
-  // State to keep track of the number of rows and cursor position
-  const [rows, setRows] = useState(calculateRows(String(form.getValues(stringName))));
 
-  console.log(rows, 'rows in StringableInput form.getValues(name)')
+  // State to keep track of the number of rows and cursor position
+  const [rows, setRows] = useState(calculateRows(String(latestValue)));
+
   const handleCursorChange = (event: any) => {
     // Get the current cursor position
     const cursorPosition = event.target.selectionStart;

--- a/packages/ui/src/components/DataStory/Form/StringableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/StringableInput.tsx
@@ -18,7 +18,7 @@ export function StringableInput({
   onCursorPositionChange: (position: number) => void // Add this line
 }) {
   const stringName = useMemo(() => `${name}.value`, [name]);
-  const { getValues, setValue, watch, register } = useFormContext()
+  const { getValues,  watch, register } = useFormContext()
 
   // State to keep track of the number of rows and cursor position
   const [rows, setRows] = useState(calculateRows(String(getValues(stringName))));

--- a/packages/ui/src/components/DataStory/Form/StringableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/StringableInput.tsx
@@ -20,15 +20,8 @@ export function StringableInput({
   const stringName = useMemo(() => `${name}.value`, [name]);
   const { getValues, setValue, watch, register } = useFormContext()
 
-  // change Stringable format from string to object to maintain compatibility
-  const latestValue = useMemo(() => {
-    const latestValue = getValues(stringName) ?? getValues(name);
-    setValue(stringName, latestValue);
-    return latestValue;
-  }, [getValues, name, setValue, stringName]);
-
   // State to keep track of the number of rows and cursor position
-  const [rows, setRows] = useState(calculateRows(String(latestValue)));
+  const [rows, setRows] = useState(calculateRows(String(getValues(stringName))));
 
   const handleCursorChange = (event: any) => {
     // Get the current cursor position

--- a/packages/ui/src/components/DataStory/Form/UseFormField.tsx
+++ b/packages/ui/src/components/DataStory/Form/UseFormField.tsx
@@ -1,11 +1,17 @@
-import { useFormContext, UseFormReturn } from 'react-hook-form';
+import {
+  FieldValues,
+  useFormContext,
+  UseFormReturn,
+} from 'react-hook-form';
 import { createContext, ReactNode, useContext } from 'react';
+import { UseFormRegisterReturn } from 'react-hook-form/dist/types/form';
 
-const SubFieldContext = createContext<{fieldName: string}>({fieldName:''});
+export const SubFieldContext = createContext<{fieldName: string}>({fieldName:''});
 
 export const SubField = ({fieldName, children}: {fieldName: string, children: ReactNode}) => {
   const {fieldName: parentFieldName} = useContext(SubFieldContext);
   const value = parentFieldName ? `${parentFieldName}.${fieldName}` : fieldName;
+  // console.log(`SubField: ${value}`)
   return (
     <SubFieldContext.Provider value={{fieldName: value}}>
       {children}
@@ -13,12 +19,24 @@ export const SubField = ({fieldName, children}: {fieldName: string, children: Re
   )
 }
 
-const useFormField = () => {
+type UseFormFieldReturn<TFieldValues extends FieldValues = FieldValues, TContext = any> = Pick<
+UseFormReturn<TFieldValues, TContext>,
+'watch' | 'control'
+> & {
+  register: () => UseFormRegisterReturn;
+  setValue: (value: any) => void;
+  getValues: () => any;
+};
+
+export const useFormField = (): UseFormFieldReturn => {
   const {fieldName} = useContext(SubFieldContext);
+  // console.log(fieldName, 'fieldName')
   const form = useFormContext();
   return {
     setValue: (value: any) => form.setValue(fieldName, value),
-    value: () => form.getValues(fieldName),
-    register: () => form.register(fieldName)
+    getValues: () => form.getValues(fieldName),
+    register: () => form.register(fieldName as any),
+    watch: form.watch,
+    control: form.control,
   }
 }

--- a/packages/ui/src/components/DataStory/Form/UseFormField.tsx
+++ b/packages/ui/src/components/DataStory/Form/UseFormField.tsx
@@ -1,0 +1,24 @@
+import { useFormContext, UseFormReturn } from 'react-hook-form';
+import { createContext, ReactNode, useContext } from 'react';
+
+const SubFieldContext = createContext<{fieldName: string}>({fieldName:''});
+
+export const SubField = ({fieldName, children}: {fieldName: string, children: ReactNode}) => {
+  const {fieldName: parentFieldName} = useContext(SubFieldContext);
+  const value = parentFieldName ? `${parentFieldName}.${fieldName}` : fieldName;
+  return (
+    <SubFieldContext.Provider value={{fieldName: value}}>
+      {children}
+    </SubFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const {fieldName} = useContext(SubFieldContext);
+  const form = useFormContext();
+  return {
+    setValue: (value: any) => form.setValue(fieldName, value),
+    value: () => form.getValues(fieldName),
+    register: () => form.register(fieldName)
+  }
+}

--- a/packages/ui/src/components/DataStory/Form/UseFormField.tsx
+++ b/packages/ui/src/components/DataStory/Form/UseFormField.tsx
@@ -6,20 +6,19 @@ import {
 import { createContext, ReactNode, useContext } from 'react';
 import { UseFormRegisterReturn } from 'react-hook-form/dist/types/form';
 
-export const SubFieldContext = createContext<{fieldName: string}>({fieldName:''});
+export const FormFieldContext = createContext<{fieldName: string}>({fieldName:''});
 
-export const SubField = ({fieldName, children}: {fieldName: string, children: ReactNode}) => {
-  const {fieldName: parentFieldName} = useContext(SubFieldContext);
+export const FormFieldWrapper = ({fieldName, children}: {fieldName: string, children: ReactNode}) => {
+  const {fieldName: parentFieldName} = useContext(FormFieldContext);
   const value = parentFieldName ? `${parentFieldName}.${fieldName}` : fieldName;
-  // console.log(`SubField: ${value}`)
   return (
-    <SubFieldContext.Provider value={{fieldName: value}}>
+    <FormFieldContext.Provider value={{fieldName: value}}>
       {children}
-    </SubFieldContext.Provider>
+    </FormFieldContext.Provider>
   )
 }
 
-type UseFormFieldReturn<TFieldValues extends FieldValues = FieldValues, TContext = any> = Pick<
+export type UseFormFieldReturn<TFieldValues extends FieldValues = FieldValues, TContext = any> = Pick<
 UseFormReturn<TFieldValues, TContext>,
 'watch' | 'control'
 > & {
@@ -29,8 +28,7 @@ UseFormReturn<TFieldValues, TContext>,
 };
 
 export const useFormField = (): UseFormFieldReturn => {
-  const {fieldName} = useContext(SubFieldContext);
-  // console.log(fieldName, 'fieldName')
+  const {fieldName} = useContext(FormFieldContext);
   const form = useFormContext();
   return {
     setValue: (value: any) => form.setValue(fieldName, value),

--- a/packages/ui/src/components/DataStory/Form/mocks.ts
+++ b/packages/ui/src/components/DataStory/Form/mocks.ts
@@ -10,14 +10,9 @@ const mockRepeatableRow = [
     'multiline': false,
     'canInterpolate': true,
     'interpolate': true,
-    'casts': [
-      {
-        'type': 'stringCast',
-        'label': 'String',
-        'selected': true
-      }
-    ],
-    'value': 'id'
+    'value': {
+      value: 'id'
+    }
   },
   {
     'name': 'port',
@@ -31,12 +26,16 @@ const mockRepeatableRow = [
 const mockRepeatableValue = [
   {
     'id': 'wrihes',
-    'value': 'id444',
+    'value': {
+      value: 'id444'
+    },
     'port': 'unfiltered'
   },
   {
     'id': '3f4tzr',
-    'value': 'id333',
+    'value': {
+      value: 'id333'
+    },
     'port': 'output4ex3'
   },
 ];
@@ -69,16 +68,12 @@ export const mockNode = {
             'selected': true
           }
         ],
-        'value': 'id'
+        'value': {
+          value: 'id',
+          Cast: 'stringCast'
+        }
       },
-      {
-        'name': 'port_map',
-        'label': 'Port Map',
-        'help': 'Where to map items',
-        'type': 'RepeatableParam',
-        'row': mockRepeatableRow,
-        'value': mockRepeatableValue
-      }
+      mockParam
     ],
     'computer': 'Filter',
     'label': 'Filter',
@@ -105,9 +100,5 @@ export const mockNode = {
   'type': 'nodeComponent',
 } as unknown as ReactFlowNode;
 export const defaultValues = {
-  label: 'Filter',
-  params: {
-    'property': 'id',
-    'port_map': mockRepeatableValue
-  }
+  'port_map': mockRepeatableValue
 }

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/nodeSettingsModal.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/nodeSettingsModal.tsx
@@ -1,7 +1,7 @@
 import { Params, InputSchemas, OutputSchemas, Code, Docs } from './tabs';
 import { shallow } from 'zustand/shallow';
 import { StoreSchema, useStore } from '../../store/store';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { ReactFlowNode } from '../../../Node/ReactFlowNode';
 import { useEscapeKey } from '../../hooks/useEscapeKey';
 import { useState } from 'react';
@@ -85,50 +85,52 @@ export const NodeSettingsModalContent = () => {
   return <>
     <div className="flex justify-center overflow-x-hidden fixed inset-0 z-50 outline-none focus:outline-none">
       <div className="relative w-full max-w-4xl my-8 mx-auto px-8">
-        <div className="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-white outline-none focus:outline-none">
-          {/* ***** HEADER ***** */}
-          <div className="flex items-start justify-between px-8 py-2 border-solid border-slate-200 rounded-t">
-            <input
-              {...form.register('label')}
-              className="pr-4 mt-4 bg-white flex flex-col align-center justify-center text-lg text-gray-400 font-bold tracking widest"
-            />
-            <div className="flex">
-              {form.getValues('label') !== node.data.computer && <div className="flex flex-col pr-4 my-2 mt-3 italic flex flex-col align-center justify-center text-sm text-gray-400 font-base tracking widest">
+        <FormProvider {...form}>
+          <div className="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-white outline-none focus:outline-none">
+            {/* ***** HEADER ***** */}
+            <div className="flex items-start justify-between px-8 py-2 border-solid border-slate-200 rounded-t">
+              <input
+                {...form.register('label')}
+                className="pr-4 mt-4 bg-white flex flex-col align-center justify-center text-lg text-gray-400 font-bold tracking widest"
+              />
+              <div className="flex">
+                {form.getValues('label') !== node.data.computer && <div className="flex flex-col pr-4 my-2 mt-3 italic flex flex-col align-center justify-center text-sm text-gray-400 font-base tracking widest">
                 renamed from {node.data.computer}
-              </div>}
-              <div className="cursor-pointer p-1 ml-auto text-black float-right text-3xl leading-none font-semibold outline-none focus:outline-none" onClick={close}>
-                <span className="text-gray-500 h-6 w-6 text-2xl block outline-none focus:outline-none">
+                </div>}
+                <div className="cursor-pointer p-1 ml-auto text-black float-right text-3xl leading-none font-semibold outline-none focus:outline-none" onClick={close}>
+                  <span className="text-gray-500 h-6 w-6 text-2xl block outline-none focus:outline-none">
                 ×
-                </span>
+                  </span>
+                </div>
               </div>
             </div>
-          </div>
-          {/* ***** TABS ***** */}
-          <div className="mx-8 flex space-x-8 text-xxs uppercase text-gray-400">
-            {Object.keys(TAB_COMPONENTS).map((key) => (
-              <div
-                key={key}
-                onClick={() => setTab(key as TabKey)}
-                className={`pb-2 hover:text-gray-500 cursor-pointer ${tab === key && 'border-b-2 border-blue-400'}`}
-              >
-                {pascalToSentenceCase(key)}
-              </div>
-            ))}
-          </div>
+            {/* ***** TABS ***** */}
+            <div className="mx-8 flex space-x-8 text-xxs uppercase text-gray-400">
+              {Object.keys(TAB_COMPONENTS).map((key) => (
+                <div
+                  key={key}
+                  onClick={() => setTab(key as TabKey)}
+                  className={`pb-2 hover:text-gray-500 cursor-pointer ${tab === key && 'border-b-2 border-blue-400'}`}
+                >
+                  {pascalToSentenceCase(key)}
+                </div>
+              ))}
+            </div>
 
-          {/* ***** CONTENT ***** */}
-          <TabComponent node={node} register={form.register} form={form}/>
+            {/* ***** CONTENT ***** */}
+            <TabComponent node={node} register={form.register} form={form}/>
 
-          {/* ***** FOOTER ***** */}
-          <div className="my-2 flex items-center justify-end p-6 border-t border-solid border-slate-200 rounded-b">
-            <button className="text-gray-500 focus:text-gray-800 background-transparent font-bold uppercase px-6 py-2 text-xs outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="button" onClick={close}>
+            {/* ***** FOOTER ***** */}
+            <div className="my-2 flex items-center justify-end p-6 border-t border-solid border-slate-200 rounded-b">
+              <button className="text-gray-500 focus:text-gray-800 background-transparent font-bold uppercase px-6 py-2 text-xs outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="button" onClick={close}>
               Close
-            </button>
-            {<button className="bg-blue-500 focus:bg-blue-700 text-white active:bg-blue-600 font-bold uppercase text-xs px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="button" onClick={saveAndClose}>
+              </button>
+              {<button className="bg-blue-500 focus:bg-blue-700 text-white active:bg-blue-600 font-bold uppercase text-xs px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1 ease-linear transition-all duration-150" type="button" onClick={saveAndClose}>
               Save
-            </button>}
+              </button>}
+            </div>
           </div>
-        </div>
+        </FormProvider>
       </div>
     </div>
     <div className="opacity-25 fixed inset-0 z-40 bg-black" />

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/Params.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/Params.tsx
@@ -4,7 +4,7 @@ import { RepeatableWithConfig } from './RepeatableWithConfig';
 import { SelectInput } from '../../../../Form/SelectInput';
 import { FormFieldWrapper } from '../../../../Form/UseFormField';
 
-export function ParamsTab({
+export function ParamsComponent({
   node,
 }: {
   node: ReactFlowNode,
@@ -42,6 +42,6 @@ export function Params ({
   node,
 }) {
   return (<FormFieldWrapper fieldName={'params'}>
-    <ParamsTab node={node}/>
+    <ParamsComponent node={node}/>
   </FormFieldWrapper>);
 }

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/Params.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/Params.tsx
@@ -1,5 +1,4 @@
 import { ReactFlowNode } from '../../../../../Node/ReactFlowNode';
-import { UseFormReturn } from 'react-hook-form';
 import { StringableWithConfig } from './StringableWithConfig';
 import { RepeatableWithConfig } from './RepeatableWithConfig';
 import { SelectInput } from '../../../../Form/SelectInput';

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/Params.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/Params.tsx
@@ -2,8 +2,9 @@ import { ReactFlowNode } from '../../../../../Node/ReactFlowNode';
 import { StringableWithConfig } from './StringableWithConfig';
 import { RepeatableWithConfig } from './RepeatableWithConfig';
 import { SelectInput } from '../../../../Form/SelectInput';
+import { SubField } from '../../../../Form/UseFormField';
 
-export function Params({
+export function ParamsTab({
   node,
 }: {
   node: ReactFlowNode,
@@ -37,4 +38,12 @@ export function Params({
     </div>
     {node.data.params.length === 0 && <div className="text-xs text-gray-400">No parameters</div>}
   </div>;
+}
+
+export function Params ({
+  node,
+}) {
+  return (<SubField fieldName={'params'}>
+    <ParamsTab node={node}/>
+  </SubField>);
 }

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/Params.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/Params.tsx
@@ -19,7 +19,6 @@ export function ParamsTab({
           {/* Horizontal layout */}
           {param.type === 'StringableParam' && <StringableWithConfig
             param={param}
-            name={`params.${param.name}`}
             node={node}
           />}
 
@@ -30,7 +29,6 @@ export function ParamsTab({
           />}
 
           {param.type === 'SelectParam' && <SelectInput
-            name={`params.${param.name}`}
             param={param}
           />}
         </div>)

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/Params.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/Params.tsx
@@ -2,7 +2,7 @@ import { ReactFlowNode } from '../../../../../Node/ReactFlowNode';
 import { StringableWithConfig } from './StringableWithConfig';
 import { RepeatableWithConfig } from './RepeatableWithConfig';
 import { SelectInput } from '../../../../Form/SelectInput';
-import { SubField } from '../../../../Form/UseFormField';
+import { FormFieldWrapper } from '../../../../Form/UseFormField';
 
 export function ParamsTab({
   node,
@@ -41,7 +41,7 @@ export function ParamsTab({
 export function Params ({
   node,
 }) {
-  return (<SubField fieldName={'params'}>
+  return (<FormFieldWrapper fieldName={'params'}>
     <ParamsTab node={node}/>
-  </SubField>);
+  </FormFieldWrapper>);
 }

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/Params.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/Params.tsx
@@ -6,13 +6,8 @@ import { SelectInput } from '../../../../Form/SelectInput';
 
 export function Params({
   node,
-  form
 }: {
   node: ReactFlowNode,
-  form: UseFormReturn<{
-    [x: string]: any;
-  }, any>
-
 }) {
   return <div className="max-h-128 overflow-y-scroll relative pb-6 pt-4 px-6 flex-auto space-y-1">
     <div className='max-w-4xl w-full space-y-2 p-4'>
@@ -24,7 +19,6 @@ export function Params({
           {/* Horizontal layout */}
           {param.type === 'StringableParam' && <StringableWithConfig
             param={param}
-            form={form}
             name={`params.${param.name}`}
             node={node}
           />}
@@ -32,13 +26,11 @@ export function Params({
           {/* Vertical layout */}
           {param.type === 'RepeatableParam' && <RepeatableWithConfig
             param={param}
-            form={form}
             node={node}
           />}
 
           {param.type === 'SelectParam' && <SelectInput
             name={`params.${param.name}`}
-            form={form}
             param={param}
           />}
         </div>)

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/PortSelectionInput.cy.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/PortSelectionInput.cy.tsx
@@ -5,7 +5,7 @@ import { FormComponentProps } from '../../../../types';
 const TestedPortSelectionInput = (props: {onForm: (f: FormComponentProps['form']) => any}) => {
   const form = useForm({
     defaultValues: {
-      PortSelected: '',
+      port: '',
       outputs: JSON.stringify([
         { name: 'output1', id: '1' },
         { name: 'output2', id: '2' },
@@ -18,7 +18,6 @@ const TestedPortSelectionInput = (props: {onForm: (f: FormComponentProps['form']
     <FormProvider {...form}>
       <PortSelectionInput
         param={{} as unknown as FormComponentProps['param']}
-        name="PortSelected"
         node={{} as unknown as FormComponentProps['node']}
       />
     </FormProvider>
@@ -48,9 +47,10 @@ describe('PortSelectionInput', () => {
   it('selects the correct option', () => {
     cy.get('select').select('output2');
     cy.get('select').should('have.value', 'output2');
-    cy.dataCy('data-story-port-selection-input').then(() => {
+    cy.dataCy('data-story-port-selection-input').then((el) => {
+      expect(el).contain('output2');
       // @ts-ignore
-      const PortSelectedVal = formRef.val!.getValues('PortSelected');
+      const PortSelectedVal = formRef.val!.getValues('port');
       expect(PortSelectedVal).to.equal('output2');
     })
   });
@@ -73,9 +73,10 @@ describe('PortSelectionInput', () => {
   });
 
   it('PortSelected value is not in options', () => {
-    cy.dataCy('data-story-port-selection-input').then(() => {
+    cy.dataCy('data-story-port-selection-input').then((el) => {
+      expect(el).contain('');
       // @ts-ignore
-      const PortSelectedVal = formRef.val!.getValues('PortSelected');
+      const PortSelectedVal = formRef.val!.getValues('port');
       expect(PortSelectedVal).to.equal('');
     });
     cy.get('select').should('have.value', null);

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/PortSelectionInput.cy.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/PortSelectionInput.cy.tsx
@@ -1,5 +1,5 @@
 import { PortSelectionInput } from './PortSelectionInput';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { FormComponentProps } from '../../../../types';
 
 const TestedPortSelectionInput = (props: {onForm: (f: FormComponentProps['form']) => any}) => {
@@ -11,18 +11,17 @@ const TestedPortSelectionInput = (props: {onForm: (f: FormComponentProps['form']
         { name: 'output2', id: '2' },
       ]),
     },
-  }) as unknown as FormComponentProps['form'];
-  props.onForm(form);
+  });
+  props.onForm(form as unknown as FormComponentProps['form']);
 
   return (
-    <>
+    <FormProvider {...form}>
       <PortSelectionInput
         param={{} as unknown as FormComponentProps['param']}
-        form={form}
         name="PortSelected"
         node={{} as unknown as FormComponentProps['node']}
       />
-    </>
+    </FormProvider>
   );
 }
 

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/PortSelectionInput.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/PortSelectionInput.tsx
@@ -2,7 +2,7 @@ import { Param } from '@data-story/core'
 import { useWatch } from 'react-hook-form';
 import { useMemo } from 'react';
 import { FormComponent, FormComponentProps } from '../../../../types';
-import { SubField, useFormField } from '../../../../Form/UseFormField';
+import { FormFieldWrapper, useFormField } from '../../../../Form/UseFormField';
 
 export function PortSelectionInputComponent({
   param,
@@ -38,9 +38,9 @@ export function PortSelectionInputComponent({
 }
 
 export function PortSelectionInput(params: FormComponentProps & {param: Param}) {
-  return (<SubField fieldName={'port'}>
+  return (<FormFieldWrapper fieldName={'port'}>
     <PortSelectionInputComponent {...params} />
-  </SubField>);
+  </FormFieldWrapper>);
 }
 
 export class PortSelectionComponent implements FormComponent<Param> {

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/PortSelectionInput.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/PortSelectionInput.tsx
@@ -1,14 +1,14 @@
 import { Param } from '@data-story/core'
-import { useFormContext, useWatch } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
 import { useMemo } from 'react';
 import { FormComponent, FormComponentProps } from '../../../../types';
+import { SubField, useFormField } from '../../../../Form/UseFormField';
 
-export function PortSelectionInput({
+export function PortSelectionInputComponent({
   param,
-  name,
   node,
 }: FormComponentProps) {
-  const { register,  control } = useFormContext()
+  const {register, control} = useFormField();
   const outputsDraft = useWatch({
     control: control,
     name: 'outputs',
@@ -24,7 +24,7 @@ export function PortSelectionInput({
       <select
         key={'port'}
         className="bg-gray-50 px-2 py-1"
-        {...register(name!)}
+        {...register()}
       >
         {parsedOutputs.map(output => (
           <option
@@ -35,6 +35,12 @@ export function PortSelectionInput({
       </select>
     </div>
   </div>)
+}
+
+export function PortSelectionInput(params: FormComponentProps & {param: Param}) {
+  return (<SubField fieldName={'port'}>
+    <PortSelectionInputComponent {...params} />
+  </SubField>);
 }
 
 export class PortSelectionComponent implements FormComponent<Param> {

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/PortSelectionInput.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/PortSelectionInput.tsx
@@ -1,16 +1,16 @@
 import { Param } from '@data-story/core'
-import { useWatch } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { useMemo } from 'react';
 import { FormComponent, FormComponentProps } from '../../../../types';
 
 export function PortSelectionInput({
   param,
-  form,
   name,
   node,
 }: FormComponentProps) {
+  const { register,  control } = useFormContext()
   const outputsDraft = useWatch({
-    control: form.control,
+    control: control,
     name: 'outputs',
     exact: true,
   });
@@ -24,7 +24,7 @@ export function PortSelectionInput({
       <select
         key={'port'}
         className="bg-gray-50 px-2 py-1"
-        {...form.register(name!)}
+        {...register(name!)}
       >
         {parsedOutputs.map(output => (
           <option

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/RepeatableWithConfig.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/RepeatableWithConfig.tsx
@@ -1,19 +1,13 @@
 import { Param } from '@data-story/core'
-import { StringableInput } from '../../../../Form/StringableInput'
-import { UseFormReturn } from 'react-hook-form';
 import { DropDown } from '../../../../../DropDown';
 import { RepeatableInput } from '../../../../Form/RepeatableInput';
 import { ReactFlowNode } from '../../../../../Node/ReactFlowNode';
 
 export function RepeatableWithConfig({
   param,
-  form,
   node,
 }: {
   param: Param,
-  form: UseFormReturn<{
-    [x: string]: any;
-  }, any>,
   node: ReactFlowNode,
 }) {
   return (<div className="flex flex-col">
@@ -32,7 +26,6 @@ export function RepeatableWithConfig({
       ]} />
     </div>
     <RepeatableInput
-      form={form}
       param={param as any}
       node={node}
     />

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/StringableWithConfig.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/StringableWithConfig.tsx
@@ -1,21 +1,18 @@
 import { Param, StringableParam } from '@data-story/core'
 import { StringableInput } from '../../../../Form/StringableInput'
-import { useFormContext, UseFormReturn } from 'react-hook-form';
 import { DropDown, OptionGroup } from '../../../../../DropDown';
 import { ReactFlowNode } from '../../../../../Node/ReactFlowNode';
 import { useState } from 'react';
 import { FormComponent, FormComponentProps } from '../../../../types';
-import { SubField, useFormField, UseFormFieldReturn } from '../../../../Form/UseFormField';
+import { SubField, useFormField, UseFormFieldReturn  } from '../../../../Form/UseFormField';
 
 type StringableWithConfigProps = {
   param: StringableParam
-  name?: string,
   node: ReactFlowNode,
 };
 
 function StringableWithConfigComponent({
   param,
-  name,
   node,
 }: StringableWithConfigProps) {
   const [cursorPosition, setCursorPosition] = useState(0);
@@ -23,9 +20,7 @@ function StringableWithConfigComponent({
   const handleCursorPositionChange = (newPosition: number) => {
     setCursorPosition(newPosition);
   };
-  const form = useFormContext();
 
-  console.log(form.getValues(`params.${param.name}`), 222)
   const filedForm = useFormField();
 
   return (<div className="group flex bg-gray-50">
@@ -49,6 +44,16 @@ export function StringableWithConfig(params: StringableWithConfigProps) {
   </SubField>)
 }
 
+export class StringableComponent implements FormComponent<Param> {
+  getComponent(params: FormComponentProps & {param: Param}) {
+    return (<StringableWithConfig {...params} param={params.param as StringableParam}/>);
+  };
+
+  getType() {
+    return 'StringableParam';
+  }
+}
+
 const paramOptions = (
   param: StringableParam,
   node: ReactFlowNode,
@@ -57,7 +62,6 @@ const paramOptions = (
 ): OptionGroup | undefined => {
   const portNames = param.interpolationsFromPort
     ?? node.data.inputs.map(port => port.name)
-  const currentValue = form.getValues();
   const [portName] = portNames
 
   const port = node.data.inputs.find((port) => port.name === portName)
@@ -140,15 +144,5 @@ export const castOptions = (
         })
       }
     })),
-  }
-}
-
-export class StringableComponent implements FormComponent<Param> {
-  getComponent(params: FormComponentProps & {param: Param}) {
-    return (<StringableWithConfig {...params} param={params.param as StringableParam}/>);
-  };
-
-  getType() {
-    return 'StringableParam';
   }
 }

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/StringableWithConfig.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/StringableWithConfig.tsx
@@ -1,21 +1,17 @@
 import { Param, StringableParam } from '@data-story/core'
 import { StringableInput } from '../../../../Form/StringableInput'
-import { UseFormReturn } from 'react-hook-form';
-import { DropDown, Option, OptionGroup } from '../../../../../DropDown';
+import { useFormContext, UseFormReturn } from 'react-hook-form';
+import { DropDown, OptionGroup } from '../../../../../DropDown';
 import { ReactFlowNode } from '../../../../../Node/ReactFlowNode';
 import { useState } from 'react';
 import { FormComponent, FormComponentProps } from '../../../../types';
 
 export function StringableWithConfig({
   param,
-  form,
   name,
   node,
 }: {
   param: StringableParam
-  form: UseFormReturn<{
-    [x: string]: any;
-  }, any>,
   name?: string,
   node: ReactFlowNode,
 }) {
@@ -24,10 +20,10 @@ export function StringableWithConfig({
   const handleCursorPositionChange = (newPosition: number) => {
     setCursorPosition(newPosition);
   };
+  const form = useFormContext();
 
   return (<div className="group flex bg-gray-50">
     <StringableInput
-      form={form}
       {...param}
       param={param as StringableParam}
       name={name ?? param.name}
@@ -35,7 +31,6 @@ export function StringableWithConfig({
     />
     <DropDown
       name={name ?? param.name}
-      form={form}
       optionGroups={[
         paramOptions(param, node, form, cursorPosition),
         evaluationOptions(param),

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/StringableWithConfig.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/StringableWithConfig.tsx
@@ -4,7 +4,7 @@ import { DropDown, OptionGroup } from '../../../../../DropDown';
 import { ReactFlowNode } from '../../../../../Node/ReactFlowNode';
 import { useState } from 'react';
 import { FormComponent, FormComponentProps } from '../../../../types';
-import { SubField, useFormField, UseFormFieldReturn  } from '../../../../Form/UseFormField';
+import { FormFieldWrapper, useFormField, UseFormFieldReturn  } from '../../../../Form/UseFormField';
 
 type StringableWithConfigProps = {
   param: StringableParam
@@ -39,9 +39,9 @@ function StringableWithConfigComponent({
 }
 
 export function StringableWithConfig(params: StringableWithConfigProps) {
-  return (<SubField fieldName={params.param.name}>
+  return (<FormFieldWrapper fieldName={params.param.name}>
     <StringableWithConfigComponent {...params} />
-  </SubField>)
+  </FormFieldWrapper>)
 }
 
 export class StringableComponent implements FormComponent<Param> {

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/StringableWithConfig.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/StringableWithConfig.tsx
@@ -33,11 +33,14 @@ export function StringableWithConfig({
       name={name ?? param.name}
       onCursorPositionChange={handleCursorPositionChange}
     />
-    <DropDown optionGroups={[
-      paramOptions(param, node, form, cursorPosition),
-      evaluationOptions(param),
-      castOptions(param),
-    ].filter(Boolean) as OptionGroup[]} />
+    <DropDown
+      name={name ?? param.name}
+      form={form}
+      optionGroups={[
+        paramOptions(param, node, form, cursorPosition),
+        evaluationOptions(param),
+        castOptions(param),
+      ].filter(Boolean) as OptionGroup[]} />
   </div>)
 }
 

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/outputSchemas/dataStoryOutputTable.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/outputSchemas/dataStoryOutputTable.tsx
@@ -157,7 +157,6 @@ export function OutputTable(props: {
       data.splice(draggedRowIndex, 1)[0] as Port
     );
     setData([...data]);
-    console.log('output data', data);
 
     props.field.onChange(JSON.stringify(data));
   };

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/outputSchemas/dataStoryOutputTable.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/outputSchemas/dataStoryOutputTable.tsx
@@ -3,7 +3,7 @@ import { ColumnDef, flexRender, getCoreRowModel, Row, useReactTable } from '@tan
 import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { Port } from '@data-story/core';
-import { Controller, ControllerRenderProps } from 'react-hook-form';
+import { Controller, ControllerRenderProps, useFormContext } from 'react-hook-form';
 import { defaultColumns, formatOutputs, OutputSchemaProps } from './common';
 import { ReactFlowNode } from '../../../../../Node/ReactFlowNode';
 import { CloseIcon } from '../../../../icons/closeIcon';
@@ -256,10 +256,11 @@ export function OutputTable(props: {
 }
 
 export const DataStoryOutputTable = (props: OutputSchemaProps) => {
+  const { control} = useFormContext()
   return (
     <DndProvider backend={HTML5Backend}>
       <Controller
-        control={props.form.control}
+        control={control}
         name="outputs"
         render={({ field }) => (
           <OutputTable field={field} node={props.node} />

--- a/packages/ui/src/components/DataStory/modals/runModal/DefineMode.tsx
+++ b/packages/ui/src/components/DataStory/modals/runModal/DefineMode.tsx
@@ -1,5 +1,6 @@
 import { StoreSchema, useStore } from '../../store/store';
 import { shallow } from 'zustand/shallow';
+import { createDefaultStringable } from '@data-story/core';
 
 const DefineMode = ({ params, setDefineMode }) => {
   const selector = (state: StoreSchema) => ({
@@ -11,9 +12,8 @@ const DefineMode = ({ params, setDefineMode }) => {
 
   const { setParams } = useStore(selector, shallow);
 
-  const sampleParam = {
+  const sampleParam = createDefaultStringable({
     name: 'sampleParam',
-    type: 'StringableParam',
     label: 'sampleParam',
     help: '',
     multiline: false,
@@ -22,7 +22,7 @@ const DefineMode = ({ params, setDefineMode }) => {
     evaluations: [],
     casts: [],
     value: 'default value',
-  }
+  })
 
   const content = params.length > 0 ? params : [sampleParam];
 

--- a/packages/ui/src/components/DataStory/modals/runModal/FillMode.tsx
+++ b/packages/ui/src/components/DataStory/modals/runModal/FillMode.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { Params } from '../nodeSettingsModal/tabs';
 import { ReactFlowNode } from '../../../Node/ReactFlowNode';
 import { Param, Port } from '@data-story/core';
@@ -38,23 +38,25 @@ const FillMode = ({ params, setParams, handleRun }) => {
   };
 
   return (
-    <div>
-      <Params form={form} node={{ ...nullNode }} />
-      <div className="flex w-full justify-center items-center space-x-2">
-        <button
-          data-cy="run-modal-button"
-          className={clsx(
-            'flex w-full items-center justify-center space-y-4 mt-4 px-16 py-2',
-            'bg-blue-500 hover:bg-blue-600',
-            'font-mono font-bold text-xs text-gray-50 uppercase',
-            'rounded'
-          )}
-          onClick={form.handleSubmit(onSubmit)}
-        >
+    <FormProvider {...form}>
+      <div>
+        <Params node={{ ...nullNode }} />
+        <div className="flex w-full justify-center items-center space-x-2">
+          <button
+            data-cy="run-modal-button"
+            className={clsx(
+              'flex w-full items-center justify-center space-y-4 mt-4 px-16 py-2',
+              'bg-blue-500 hover:bg-blue-600',
+              'font-mono font-bold text-xs text-gray-50 uppercase',
+              'rounded'
+            )}
+            onClick={form.handleSubmit(onSubmit)}
+          >
           Run
-        </button>
+          </button>
+        </div>
       </div>
-    </div>
+    </FormProvider>
   );
 };
 

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -66,7 +66,7 @@ export type StoreInitOptions = {
 export type StoreInitServer = (serverConfig: ServerConfig, observers?: ServerClientObservationConfig)  => void;
 
 export type FormCommonProps = {
-  form: UseFormReturn<{
+  form?: UseFormReturn<{
     [x: string]: any;
   }, any>;
   node: ReactFlowNode;

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -66,6 +66,9 @@ export type StoreInitOptions = {
 export type StoreInitServer = (serverConfig: ServerConfig, observers?: ServerClientObservationConfig)  => void;
 
 export type FormCommonProps = {
+  /**
+   * @deprecated Use `useFormContext` instead
+   */
   form?: UseFormReturn<{
     [x: string]: any;
   }, any>;

--- a/packages/ui/src/components/DropDown/index.tsx
+++ b/packages/ui/src/components/DropDown/index.tsx
@@ -12,7 +12,7 @@ import {
   useInteractions,
   useRole
 } from '@floating-ui/react';
-import { SubField, useFormField } from '../DataStory/Form/UseFormField';
+import { FormFieldWrapper, useFormField } from '../DataStory/Form/UseFormField';
 
 export type Option = {
   label: string
@@ -77,9 +77,9 @@ const DropdownLiComponent = ({
 }
 
 const DropdownLi = (params: DropdownLiProps) => {
-  return (<SubField fieldName={params.optionGroup.label ?? ''}>
+  return (<FormFieldWrapper fieldName={params.optionGroup.label ?? ''}>
     <DropdownLiComponent {...params} />
-  </SubField>)
+  </FormFieldWrapper>)
 }
 
 export const DropDown = ({

--- a/packages/ui/src/components/DropDown/index.tsx
+++ b/packages/ui/src/components/DropDown/index.tsx
@@ -12,7 +12,7 @@ import {
   useInteractions,
   useRole
 } from '@floating-ui/react';
-import { UseFormReturn } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 
 export type Option = {
   label: string
@@ -36,16 +36,14 @@ export type OptionGroup = {
 
 export const DropDown = ({
   optionGroups,
-  form,
   name
 }: {
   optionGroups: OptionGroup[],
   name?: string,
-  form?: UseFormReturn<{
-    [x: string]: any;
-  }, any>
 }) => {
   const [isOpen, setIsOpen] = useState(false);
+
+  const { getValues, setValue, register } = useFormContext()
 
   // Based on the provided optionGroups, form, and name, create unique options for the current dropdown
   const dropDownOptions = useMemo(() =>
@@ -53,16 +51,16 @@ export const DropDown = ({
       return {
         ...optionGroup,
         options: optionGroup.options.map((option) => {
-          if (option.selected) form?.setValue(`${name}.${optionGroup.label}`, option.label);
+          if (option.selected) setValue(`${name}.${optionGroup.label}`, option.label);
 
-          const defaultSelected = form?.getValues(`${name}.${optionGroup.label}`) === option.label || option.selected;
+          const defaultSelected = getValues(`${name}.${optionGroup.label}`) === option.label || option.selected;
           return {
             ...option,
             selected: defaultSelected
           }
         })
       }
-    }), [form, name, optionGroups]);
+    }), [getValues, name, optionGroups, setValue]);
 
   const closeDropdown = useCallback(() => {
     setIsOpen(false);
@@ -125,7 +123,7 @@ export const DropDown = ({
                       return (
                         <li key={option.label} className="cursor-pointer">
                           <div
-                            {...form?.register(optionName)}
+                            {...register(optionName)}
                             className="flex justify-between px-2 py-1 text-xs text-gray-700 hover:bg-gray-100"
                             onClick={(event) => {
                               if (optionGroup.selectable) {
@@ -135,7 +133,7 @@ export const DropDown = ({
                                 })
 
                                 const value = option.selected ? option.label : '';
-                                form?.setValue(optionName, value);
+                                setValue(optionName, value);
                               }
 
                               option.callback({

--- a/packages/ui/src/components/DropDown/index.tsx
+++ b/packages/ui/src/components/DropDown/index.tsx
@@ -34,6 +34,44 @@ export type OptionGroup = {
   selectable?: boolean
 }
 
+function DropdownLi({
+  option,
+  optionName,
+  optionGroup,
+  closeDropdown,
+}:{ option: Option,  optionName: string, optionGroup: OptionGroup, closeDropdown: () => void}) {
+  const { setValue, register } = useFormContext()
+
+  return (
+    <li key={option.label} className="cursor-pointer">
+      <div
+        {...register(optionName)}
+        className="flex justify-between px-2 py-1 text-xs text-gray-700 hover:bg-gray-100"
+        onClick={(event) => {
+          if (optionGroup.selectable) {
+            option.selected = !option.selected;
+            optionGroup.options.forEach((innerOption) => {
+              if (innerOption.label !== option.label) innerOption.selected = false
+            })
+
+            const value = option.selected ? option.label : '';
+            setValue(optionName, value);
+          }
+
+          option.callback({
+            close: closeDropdown,
+            selectedIndex: optionGroup.options.findIndex((option) => option.selected),
+          })
+        }
+        }
+      >
+        {option.label}
+        {option.selected && (<div className="">✓</div>)}
+      </div>
+    </li>
+  );
+}
+
 export const DropDown = ({
   optionGroups,
   name
@@ -43,7 +81,7 @@ export const DropDown = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const { getValues, setValue, register } = useFormContext()
+  const { getValues, setValue } = useFormContext()
 
   // Based on the provided optionGroups, form, and name, create unique options for the current dropdown
   const dropDownOptions = useMemo(() =>
@@ -124,34 +162,7 @@ export const DropDown = ({
                   <ul role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
                     {optionGroup.options.map((option) => {
                       const optionName = `${name}.${optionGroup.label}`;
-                      return (
-                        <li key={option.label} className="cursor-pointer">
-                          <div
-                            {...register(optionName)}
-                            className="flex justify-between px-2 py-1 text-xs text-gray-700 hover:bg-gray-100"
-                            onClick={(event) => {
-                              if (optionGroup.selectable) {
-                                option.selected = !option.selected;
-                                optionGroup.options.forEach((innerOption) => {
-                                  if (innerOption.label !== option.label) innerOption.selected = false
-                                })
-
-                                const value = option.selected ? option.label : '';
-                                setValue(optionName, value);
-                              }
-
-                              option.callback({
-                                close: closeDropdown,
-                                selectedIndex: optionGroup.options.findIndex((option) => option.selected),
-                              })
-                            }
-                            }
-                          >
-                            {option.label}
-                            {option.selected && (<div className="">✓</div>)}
-                          </div>
-                        </li>
-                      )
+                      return (<DropdownLi option={option} optionName={optionName} optionGroup={optionGroup} closeDropdown={closeDropdown} />)
                     })}
                   </ul>
                   {optionGroup.options.length === 0 &&

--- a/packages/ui/src/components/DropDown/index.tsx
+++ b/packages/ui/src/components/DropDown/index.tsx
@@ -12,7 +12,7 @@ import {
   useInteractions,
   useRole
 } from '@floating-ui/react';
-import { useFormContext } from 'react-hook-form';
+import { SubField, useFormField } from '../DataStory/Form/UseFormField';
 
 export type Option = {
   label: string
@@ -34,18 +34,22 @@ export type OptionGroup = {
   selectable?: boolean
 }
 
-function DropdownLi({
+type DropdownLiProps = {
+  option: Option,
+  optionGroup: OptionGroup,
+  closeDropdown: () => void};
+
+const DropdownLiComponent = ({
   option,
-  optionName,
   optionGroup,
   closeDropdown,
-}:{ option: Option,  optionName: string, optionGroup: OptionGroup, closeDropdown: () => void}) {
-  const { setValue, register } = useFormContext()
+}:DropdownLiProps) => {
+  const { setValue, register } = useFormField()
 
   return (
     <li className="cursor-pointer">
       <div
-        {...register(optionName)}
+        {...register()}
         className="flex justify-between px-2 py-1 text-xs text-gray-700 hover:bg-gray-100"
         onClick={(event) => {
           if (optionGroup.selectable) {
@@ -55,7 +59,7 @@ function DropdownLi({
             })
 
             const value = option.selected ? option.label : '';
-            setValue(optionName, value);
+            setValue(value);
           }
 
           option.callback({
@@ -72,24 +76,28 @@ function DropdownLi({
   );
 }
 
+const DropdownLi = (params: DropdownLiProps) => {
+  return (<SubField fieldName={params.optionGroup.label ?? ''}>
+    <DropdownLiComponent {...params} />
+  </SubField>)
+}
+
 export const DropDown = ({
   optionGroups,
-  name
 }: {
   optionGroups: OptionGroup[],
-  name?: string,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const { getValues, setValue } = useFormContext()
+  const { getValues } = useFormField()
 
-  // Based on the provided optionGroups, form, and name, create unique options for the current dropdown
+  // Based on the provided optionGroups and form, create unique options for the current dropdown
   const dropDownOptions = useMemo(() =>
     optionGroups.map((optionGroup) => {
       return {
         ...optionGroup,
         options: optionGroup.options.map((option) => {
-          const value = getValues(`${name}.${optionGroup.label}`);
+          const value = getValues();
 
           return {
             ...option,
@@ -97,7 +105,7 @@ export const DropDown = ({
           }
         })
       }
-    }), [getValues, name, optionGroups]);
+    }), [getValues, optionGroups]);
 
   const closeDropdown = useCallback(() => {
     setIsOpen(false);
@@ -156,8 +164,7 @@ export const DropDown = ({
                     className="font-bold text-gray-400 flex w-full justify-center text-xs px-2 py-2 border-b uppercase tracking-widest">{optionGroup.label}</div>
                   <ul role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
                     {optionGroup.options.map((option) => {
-                      const optionName = `${name}.${optionGroup.label}`;
-                      return (<DropdownLi key={option.label} option={option} optionName={optionName} optionGroup={optionGroup} closeDropdown={closeDropdown} />)
+                      return (<DropdownLi key={option.label} option={option} optionGroup={optionGroup} closeDropdown={closeDropdown} />)
                     })}
                   </ul>
                   {optionGroup.options.length === 0 &&

--- a/packages/ui/src/components/DropDown/index.tsx
+++ b/packages/ui/src/components/DropDown/index.tsx
@@ -99,11 +99,11 @@ export const DropDown = ({ optionGroups }: {optionGroups: OptionGroup[]}) => {
                             className="flex justify-between px-2 py-1 text-xs text-gray-700 hover:bg-gray-100"
                             onClick={(event) => {
                               if (optionGroup.selectable) {
-                                // todo: tested
-                                option.selected = !option.selected
-                                optionGroup.options.forEach((option) => {
-                                  if (option.label !== option.label) option.selected = false
+                                option.selected = !option.selected;
+                                optionGroup.options.forEach((innerOption) => {
+                                  if (innerOption.label !== option.label) innerOption.selected = false
                                 })
+                                console.log(option, 'option', optionGroup.options, 'options')
                               }
 
                               option.callback({

--- a/packages/ui/src/components/DropDown/index.tsx
+++ b/packages/ui/src/components/DropDown/index.tsx
@@ -51,9 +51,13 @@ export const DropDown = ({
       return {
         ...optionGroup,
         options: optionGroup.options.map((option) => {
-          if (option.selected) setValue(`${name}.${optionGroup.label}`, option.label);
+          const value = getValues(`${name}.${optionGroup.label}`);
+          const defaultSelected = option.selected && !value ? true : value === option.label;
 
-          const defaultSelected = getValues(`${name}.${optionGroup.label}`) === option.label || option.selected;
+          if (defaultSelected && !value) {
+            setValue(`${name}.${optionGroup.label}`, option.label);
+          }
+
           return {
             ...option,
             selected: defaultSelected

--- a/packages/ui/src/components/DropDown/index.tsx
+++ b/packages/ui/src/components/DropDown/index.tsx
@@ -53,7 +53,9 @@ export const DropDown = ({
       return {
         ...optionGroup,
         options: optionGroup.options.map((option) => {
-          const defaultSelected = form?.getValues(`${name}.${optionGroup.label}`) === option.label;
+          if (option.selected) form?.setValue(`${name}.${optionGroup.label}`, option.label);
+
+          const defaultSelected = form?.getValues(`${name}.${optionGroup.label}`) === option.label || option.selected;
           return {
             ...option,
             selected: defaultSelected

--- a/packages/ui/src/components/DropDown/index.tsx
+++ b/packages/ui/src/components/DropDown/index.tsx
@@ -43,7 +43,7 @@ function DropdownLi({
   const { setValue, register } = useFormContext()
 
   return (
-    <li key={option.label} className="cursor-pointer">
+    <li className="cursor-pointer">
       <div
         {...register(optionName)}
         className="flex justify-between px-2 py-1 text-xs text-gray-700 hover:bg-gray-100"
@@ -90,19 +90,14 @@ export const DropDown = ({
         ...optionGroup,
         options: optionGroup.options.map((option) => {
           const value = getValues(`${name}.${optionGroup.label}`);
-          const defaultSelected = option.selected && !value ? true : value === option.label;
-
-          if (defaultSelected && !value) {
-            setValue(`${name}.${optionGroup.label}`, option.label);
-          }
 
           return {
             ...option,
-            selected: defaultSelected
+            selected: value === option.value
           }
         })
       }
-    }), [getValues, name, optionGroups, setValue]);
+    }), [getValues, name, optionGroups]);
 
   const closeDropdown = useCallback(() => {
     setIsOpen(false);
@@ -162,7 +157,7 @@ export const DropDown = ({
                   <ul role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
                     {optionGroup.options.map((option) => {
                       const optionName = `${name}.${optionGroup.label}`;
-                      return (<DropdownLi option={option} optionName={optionName} optionGroup={optionGroup} closeDropdown={closeDropdown} />)
+                      return (<DropdownLi key={option.label} option={option} optionName={optionName} optionGroup={optionGroup} closeDropdown={closeDropdown} />)
                     })}
                   </ul>
                   {optionGroup.options.length === 0 &&

--- a/packages/ui/src/components/DropDown/index.tsx
+++ b/packages/ui/src/components/DropDown/index.tsx
@@ -62,8 +62,6 @@ export const DropDown = ({
       }
     }), [form, name, optionGroups]);
 
-  console.log(dropDownOptions, 'dropDownOptions');
-
   const closeDropdown = useCallback(() => {
     setIsOpen(false);
   }, []);

--- a/packages/ui/src/components/DropDown/index.tsx
+++ b/packages/ui/src/components/DropDown/index.tsx
@@ -70,7 +70,7 @@ const DropdownLiComponent = ({
         }
       >
         {option.label}
-        {option.selected && (<div className="">✓</div>)}
+        {option.selected && (<div>✓</div>)}
       </div>
     </li>
   );

--- a/packages/ui/src/components/DropDown/index.tsx
+++ b/packages/ui/src/components/DropDown/index.tsx
@@ -97,13 +97,13 @@ export const DropDown = ({ optionGroups }: {optionGroups: OptionGroup[]}) => {
                         <li key={option.label} className="cursor-pointer">
                           <div
                             className="flex justify-between px-2 py-1 text-xs text-gray-700 hover:bg-gray-100"
-                            onClick={() => {
+                            onClick={(event) => {
                               if (optionGroup.selectable) {
+                                // todo: tested
+                                option.selected = !option.selected
                                 optionGroup.options.forEach((option) => {
-                                  option.selected = false
+                                  if (option.label !== option.label) option.selected = false
                                 })
-
-                                option.selected = true
                               }
 
                               option.callback({


### PR DESCRIPTION
- feat: add state for dropdown in StringableInput component
- feat: add the unselected feature to dropdown selects

Before: the dropdown selected states were stored in the row by modifying the optionGroups in props.
After: the dropdown selected states are saved in the form, like other components in Param.
   
before:

https://github.com/ajthinking/data-story/assets/20497176/be0a57e1-c26b-4a0c-829e-470a51205cde

after:

https://github.com/ajthinking/data-story/assets/20497176/97d2ae9a-6f58-45ac-a543-f9f41d0eb18e

----

**`XXXParams` primarily consists of two parts:** 
- Widget configuration (`InputWidgetConfig`: attributes of `XXXParam type` excluding `value`)
    - Options for the dropdown
    - Columns for the repeatable table
- Widget output values (`InputWidgetValue`: `value`)
    - Content entered by the user
    - User's selection in the dropdown
    - Rows added or removed by the user in the repeatable table
    
Extract the state management logic of the `Param` form and unify it under `FormFieldWrapper` and `useFormField` for centralized management:
- `FormFieldWrapper` is responsible for managing and passing the `name` of form fields.
- `useFormField` is a hook that connects fields with form management logic, facilitating the retrieval and setting of values.

refactor: use FormProvider to replace the deeply nested form props

