### PR TITLE
Drag and Drop json file

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-story/core",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "main": "dist/main/index.js",
   "type": "commonjs",
   "types": "dist/main/index.d.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,11 @@ export type { InputObserveConfig } from './types/InputObserveConfig';
 export type { InputObserver } from './types/InputObserver';
 export type { NotifyObserversCallback } from './types/NotifyObserversCallback';
 export type { ReportCallback } from './types/ReportCallback';
+export { json_ } from './Param'
+export { jsonEvaluation } from './Param/evaluations/jsonEvaluation'
+export { hjsonEvaluation } from './Param/evaluations/hjsonEvaluation'
+export { jsFunctionEvaluation } from './Param/evaluations/jsFunctionEvaluation'
+export { jsExpressionEvaluation } from './Param/evaluations/jsExpressionEvaluation'
 
 export * as nodes from './computers'
 export * from './Param'

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-story/nodejs",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "main": "dist/index.js",
   "type": "commonjs",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-story/ui",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "main": "./dist/bundle.js",
   "types": "./dist/src/index.d.ts",
   "exports": {

--- a/packages/ui/src/components/DataStory/Workbench.tsx
+++ b/packages/ui/src/components/DataStory/Workbench.tsx
@@ -1,5 +1,5 @@
 import { DataStoryControls } from './dataStoryControls';
-import { useEffect, useId, useState } from 'react';
+import { useCallback, useEffect, useId, useState } from 'react';
 import ReactFlow, { Background, BackgroundVariant, ReactFlowInstance, ReactFlowProvider, } from 'reactflow';
 import NodeComponent from '../Node/NodeComponent';
 import { RunModal } from './modals/runModal/runModal';
@@ -13,6 +13,7 @@ import { useHotkeys } from './useHotkeys';
 import TableNodeComponent from '../Node/TableNodeComponent';
 import { DataStoryProps } from './types';
 import OutputNodeComponent from '../Node/OutputNodeComponent';
+import { onDragOver, onDrop } from './onDrop';
 
 const nodeTypes = {
   commentNodeComponent: CommentNodeComponent,
@@ -43,6 +44,7 @@ export const Workbench = ({
     traverseNodes: state.traverseNodes,
     onRun: state.onRun,
     setObservers: state.setObservers,
+    addNodeFromDescription: state.addNodeFromDescription,
   });
 
   const {
@@ -56,7 +58,8 @@ export const Workbench = ({
     setOpenNodeModalId,
     traverseNodes,
     onRun,
-    setObservers
+    setObservers,
+    addNodeFromDescription,
   } = useStore(selector, shallow);
 
   const id = useId()
@@ -115,6 +118,11 @@ export const Workbench = ({
           fitViewOptions={{
             padding: 0.25,
           }}
+          onDragOver={useCallback(onDragOver, [])}
+          onDrop={useCallback(
+            (e) => onDrop(e, addNodeFromDescription),
+            [addNodeFromDescription]
+          )}
         >
           <DataStoryControls
             slotComponent={slotComponent}

--- a/packages/ui/src/components/DataStory/onDrop.ts
+++ b/packages/ui/src/components/DataStory/onDrop.ts
@@ -1,0 +1,78 @@
+import {
+  NodeDescription,
+  jsonEvaluation,
+  hjsonEvaluation,
+  jsExpressionEvaluation,
+  jsFunctionEvaluation,
+  json_
+} from '@data-story/core';
+
+export const onDrop = (event, addNodeFromDescription) => {
+  event.preventDefault();
+
+  const files = event.dataTransfer.files;
+
+  if (files.length === 0) {
+    console.error('You dragged and dropped something not supported yet.');
+    return
+  }
+
+  const file = files[0];
+  if (file.type !== 'application/json') {
+    console.error('You dragged and dropped a file type not supported yet.');
+    return
+  }
+
+  const reader = new FileReader();
+  reader.onload = (event) => {
+    try {
+      // Parse the JSON content
+      const jsonFileContent = JSON.parse(event?.target?.result as string);
+
+      // This is a hack, consider the following:
+      // The UI now hardcodes the Create node details
+      // We don't know if the server even provides a Create node
+      // Furthermore, the definition of the Create node might change
+      // Consider having datastory register DnD-ables?
+      const description: NodeDescription = {
+        name: 'Create',
+        label: file.name,
+        inputs: [],
+        outputs: [{
+          name: 'output',
+          schema: {}
+        }],
+        params: [
+          json_({
+            name: 'data',
+            help: 'You may use json, hson js function or expression',
+            value: JSON.stringify(jsonFileContent, null, 2),
+            evaluations: [
+              { ...jsonEvaluation, selected: true },
+              hjsonEvaluation,
+              jsFunctionEvaluation,
+              jsExpressionEvaluation,
+            ]
+          })
+        ],
+        tags: [],
+      }
+
+      addNodeFromDescription(description);
+    } catch (error) {
+      console.error('Error parsing JSON:', error);
+    }
+  };
+
+  reader.onerror = (error) => {
+    console.error('Error reading file:', error);
+  };
+
+  // Read the file content
+  reader.readAsText(file);
+}
+
+export const onDragOver = (event) => {
+  event.preventDefault();
+  event.dataTransfer.dropEffect = 'move';
+};


### PR DESCRIPTION
Adds feature to drag and drop on canvas.
* only support JSON file
* works by adding a Create node with the JSON file content in the data property
* For node js environments, ideally, dropping a json file would mean we would note the full path of the dropped file and have the JsonFile node added. But when dnd:ing files we won't get path, only the filename for security reasons.
* The upside of this approach is that it will also work for browser server/clients.

### Follow ups
* The implementation currently hardcodes and assumes presence of a Create node on the server.