### PR TITLE
fix: Correct error where param.value cannot be set correctly in DiagramBuilder

### DIFF
--- a/packages/core/src/DiagramBuilder.test.ts
+++ b/packages/core/src/DiagramBuilder.test.ts
@@ -65,7 +65,9 @@ describe('add', () => {
 
     expect(periodParam).toMatchObject({
       name: 'period',
-      value: 99
+      value: {
+        value: 99
+      }
     })
   })
 

--- a/packages/core/src/DiagramBuilder.ts
+++ b/packages/core/src/DiagramBuilder.ts
@@ -7,7 +7,8 @@ import { AbstractPort, Port, PortName } from './types/Port';
 import { ComputerConfig } from './types/ComputerConfig';
 import { Fake } from './computers/Fake';
 import { createDataStoryId } from './utils/createDataStoryId';
-import { Param } from './Param';
+import { Param, StringableInputValue } from './Param';
+import { isStringableParam } from './utils/isStringableParam';
 
 export class DiagramBuilder {
   diagram: Diagram
@@ -87,7 +88,7 @@ export class DiagramBuilder {
 
       if(!param) throw new Error(`Bad param: ${key}. Param not found on ${node.id}`)
 
-      param.value = param.type === 'StringableParam' ? { value } : value;
+      param.value = isStringableParam(param.type) ? { value } : value;
     }
 
     if(this.aboveDirective) {
@@ -137,7 +138,8 @@ export class DiagramBuilder {
       type: name,
       // The inputs have not yet been assigned ids, to it here
       inputs: diagram.inputNodes().map(inputNode => {
-        const inputName = inputNode.params.find(param => param.name === 'port_name')!.value as string
+        const param = inputNode.params.find(param => param.name === 'port_name');
+        const inputName = isStringableParam(param?.type) ? (param?.value as StringableInputValue).value : param?.value as string
 
         return {
           name: inputName,
@@ -147,7 +149,8 @@ export class DiagramBuilder {
       }),
       // The outputs have not yet been assigned ids, to it here
       outputs: diagram.outputNodes().map(outputNode => {
-        const outputName = outputNode.params.find(param => param.name === 'port_name')!.value as string
+        const param = outputNode.params.find(param => param.name === 'port_name');
+        const outputName = isStringableParam(param?.type) ? (param?.value as StringableInputValue).value : param?.value as string
 
         return {
           name: outputName,
@@ -165,7 +168,7 @@ export class DiagramBuilder {
 
       if(!param) throw new Error(`Bad param: ${key}. Param not found on ${node.id}`)
 
-      param.value = param.type === 'StringableParam' ? { value } : value;
+      param.value = isStringableParam(param.type) ? { value } : value;
     }
 
     if(this.aboveDirective) {

--- a/packages/core/src/DiagramBuilder.ts
+++ b/packages/core/src/DiagramBuilder.ts
@@ -87,7 +87,7 @@ export class DiagramBuilder {
 
       if(!param) throw new Error(`Bad param: ${key}. Param not found on ${node.id}`)
 
-      param.value = value
+      param.value = param.type === 'StringableParam' ? { value } : value;
     }
 
     if(this.aboveDirective) {
@@ -165,7 +165,7 @@ export class DiagramBuilder {
 
       if(!param) throw new Error(`Bad param: ${key}. Param not found on ${node.id}`)
 
-      param.value = value
+      param.value = param.type === 'StringableParam' ? { value } : value;
     }
 
     if(this.aboveDirective) {

--- a/packages/core/src/UnfoldedDiagramFactory.ts
+++ b/packages/core/src/UnfoldedDiagramFactory.ts
@@ -1,8 +1,9 @@
 import { Diagram } from './Diagram'
-import { Param } from './Param'
+import { Param, StringableInputValue } from './Param'
 import { NestedNodes } from './Registry'
 import { UnfoldedDiagram } from './UnfoldedDiagram'
 import { Node, NodeId } from './types/Node'
+import { isStringableParam } from './utils/isStringableParam';
 
 export class UnfoldedDiagramFactory {
   public unfoldedGlobalParams: Record<NodeId, Param[]> = {}
@@ -66,10 +67,11 @@ export class UnfoldedDiagramFactory {
             const isInputNode = node.type === 'Input'
             if(!isInputNode) return false;
 
-            const portName = node.params[0]?.value
+            const param = node.params[0];
+            const portName: string = isStringableParam(param?.type) ? (param?.value as StringableInputValue).value : param?.value;
             if(!portName) throw new Error(`No port name found for input node "${node.id}". The node was ${JSON.stringify(node)}`)
 
-            const matchesPortName = portName === inputPort.name
+            const matchesPortName = portName === inputPort.name;
 
             return matchesPortName
           })
@@ -92,7 +94,8 @@ export class UnfoldedDiagramFactory {
             const isOutputNode = node.type === 'Output'
             if(!isOutputNode) return false;
 
-            const portName = node.params[0]?.value
+            const param = node.params[0];
+            const portName: string = isStringableParam(param?.type) ? (param?.value as StringableInputValue).value : param?.value;
             if(!portName) throw new Error(`No port name found for output node "${node.id}. The node was ${JSON.stringify(node)}"`)
 
             const matchesPortName = portName === outputPort.name

--- a/packages/core/src/utils/isStringableParam.ts
+++ b/packages/core/src/utils/isStringableParam.ts
@@ -1,0 +1,3 @@
+export const isStringableParam = (type?: string) => {
+  return type === 'StringableParam';
+}

--- a/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/PortSelectionInput.cy.tsx
+++ b/packages/ui/src/components/DataStory/modals/nodeSettingsModal/tabs/Params/PortSelectionInput.cy.tsx
@@ -1,8 +1,12 @@
 import { PortSelectionInput } from './PortSelectionInput';
-import { FormProvider, useForm } from 'react-hook-form';
+import { FormProvider, useForm, UseFormReturn } from 'react-hook-form';
 import { FormComponentProps } from '../../../../types';
 
-const TestedPortSelectionInput = (props: {onForm: (f: FormComponentProps['form']) => any}) => {
+type FormReturn = UseFormReturn<{
+  [x: string]: any;
+}, any>;
+
+const TestedPortSelectionInput = (props: {onForm: (f: FormReturn) => any}) => {
   const form = useForm({
     defaultValues: {
       port: '',
@@ -12,7 +16,7 @@ const TestedPortSelectionInput = (props: {onForm: (f: FormComponentProps['form']
       ]),
     },
   });
-  props.onForm(form as unknown as FormComponentProps['form']);
+  props.onForm(form as unknown as FormReturn);
 
   return (
     <FormProvider {...form}>
@@ -24,7 +28,7 @@ const TestedPortSelectionInput = (props: {onForm: (f: FormComponentProps['form']
   );
 }
 
-const mountPortSelectionInput = (formRef: {val: null | FormComponentProps['form']} = { val: null }) => {
+const mountPortSelectionInput = (formRef: {val: null | FormReturn} = { val: null }) => {
   cy.mount(<TestedPortSelectionInput onForm={(f) => formRef.val = f}/>);
 }
 describe('PortSelectionInput', () => {

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -66,12 +66,6 @@ export type StoreInitOptions = {
 export type StoreInitServer = (serverConfig: ServerConfig, observers?: ServerClientObservationConfig)  => void;
 
 export type FormCommonProps = {
-  /**
-   * @deprecated Use `useFormContext` instead
-   */
-  form?: UseFormReturn<{
-    [x: string]: any;
-  }, any>;
   node: ReactFlowNode;
   name?: string;
 }

--- a/packages/ui/src/components/Node/CommentNodeComponent.tsx
+++ b/packages/ui/src/components/Node/CommentNodeComponent.tsx
@@ -19,7 +19,7 @@ const CommentNodeComponent = ({ id, data }: {
 
   const contentParam = data.params.find((param) => param.name === 'content')! as StringableParam
 
-  const htmlContent = markdown.render(contentParam.value.value);
+  const htmlContent = markdown.render(contentParam.value.value ?? '');
 
   return (
     (


### PR DESCRIPTION
- fix: Correct error where param.value cannot be set correctly in DiagramBuilder

| Before | After |
| ------ | ----- |
| ❌      | ✅    |
|![image](https://github.com/ajthinking/data-story/assets/20497176/4bc425e7-01a0-40c7-85d5-d2c36f905e90)|![image](https://github.com/ajthinking/data-story/assets/20497176/0d6b05e1-2ddc-40a0-a4bb-621571d47075)|

- feat: remove `form` attribute from `FormCommonProps` type