### PR TITLE
Get DiagramBuilder from default core app when possible

### DIFF
--- a/packages/core/src/Application.ts
+++ b/packages/core/src/Application.ts
@@ -54,7 +54,7 @@ export class Application {
     ];
   }
 
-  getBuilder() {
+  getDiagramBuilder() {
     return new DiagramBuilder();
   }
 }

--- a/packages/core/src/Diagram.test.ts
+++ b/packages/core/src/Diagram.test.ts
@@ -1,6 +1,4 @@
 import { Diagram } from './Diagram';
-import { DiagramBuilder } from './DiagramBuilder';
-import { ConsoleLog, Create, Input, Output, Pass } from './computers';
 import { Link } from './types/Link';
 import { Node } from './types/Node';
 import { Port } from './types/Port';

--- a/packages/core/src/DiagramBuilder.test.ts
+++ b/packages/core/src/DiagramBuilder.test.ts
@@ -1,10 +1,10 @@
 import { Ignore, Create, Pass, Signal } from './computers';
+import { core } from './core';
 import { Diagram } from './Diagram';
-import { DiagramBuilder } from './DiagramBuilder';
 
 describe('get', () => {
   it('returns the diagram', () => {
-    const diagram = new DiagramBuilder().get()
+    const diagram = core.getDiagramBuilder().get()
 
     expect(diagram).toBeInstanceOf(Diagram)
   })
@@ -12,7 +12,7 @@ describe('get', () => {
 
 describe('add', () => {
   it('adds a node to the diagram and ensures unique ids', () => {
-    const diagram = new DiagramBuilder()
+    const diagram = core.getDiagramBuilder()
       .add(Create)
       .add(Pass)
       .add(Pass)
@@ -54,7 +54,7 @@ describe('add', () => {
   })
 
   it('can set params', () => {
-    const diagram = new DiagramBuilder()
+    const diagram = core.getDiagramBuilder()
       .add(Signal, { period: 99 })
       .get()
 
@@ -72,7 +72,7 @@ describe('add', () => {
   })
 
   it.todo('can set params without affecting other nodes', () => {
-    const diagram = new DiagramBuilder()
+    const diagram = core.getDiagramBuilder()
       .add(Signal, { label: 'Sigge' })
       .add(Pass)
       .get()
@@ -96,7 +96,7 @@ describe('add', () => {
   })
 
   it('links nodes together if possible', () => {
-    const diagram = new DiagramBuilder()
+    const diagram = core.getDiagramBuilder()
       .add(Create)
       .add(Pass)
       .get()
@@ -110,7 +110,7 @@ describe('add', () => {
   })
 
   it('does not link nodes together if not possible', () => {
-    const diagram = new DiagramBuilder()
+    const diagram = core.getDiagramBuilder()
       .add(Create)
       .add(Create)
       .get()
@@ -121,7 +121,7 @@ describe('add', () => {
 
 describe('on', () => {
   it('can link to a previous node port', () => {
-    const diagram = new DiagramBuilder()
+    const diagram = core.getDiagramBuilder()
       .add(Create)
       .add(Pass)
       .from('Create.1.output').add(Ignore)
@@ -142,7 +142,7 @@ describe('on', () => {
 
 // describe('on', () => {
 // it('can link to specified port on most recent node', () => {
-//   const diagram = new DiagramBuilder()
+//   const diagram = core.getBuilder()
 //     .add(Merge)
 //     .from('not_merged').add(Pass)
 //     .get();

--- a/packages/core/src/DiagramBuilder.test.ts
+++ b/packages/core/src/DiagramBuilder.test.ts
@@ -142,7 +142,7 @@ describe('on', () => {
 
 // describe('on', () => {
 // it('can link to specified port on most recent node', () => {
-//   const diagram = core.getBuilder()
+//   const diagram = core.getDiagramBuilder()
 //     .add(Merge)
 //     .from('not_merged').add(Pass)
 //     .get();

--- a/packages/core/src/ExecutionMemoryFactory.test.ts
+++ b/packages/core/src/ExecutionMemoryFactory.test.ts
@@ -1,14 +1,14 @@
 import { ComputerFactory } from './ComputerFactory';
-import { DiagramBuilder } from './DiagramBuilder'
 import { ExecutionMemoryFactory } from './ExecutionMemoryFactory';
 import { InMemoryStorage } from './InMemoryStorage';
 import { Registry } from './Registry';
 import { UnfoldedDiagramFactory } from './UnfoldedDiagramFactory';
 import { ConsoleLog, Create } from './computers'
+import { core } from './core';
 
 describe('create', () => {
   it('sets empty link items and counts', () => {
-    const diagram = new DiagramBuilder()
+    const diagram = core.getDiagramBuilder()
       .add(Create)
       .add(ConsoleLog)
       .get();
@@ -32,7 +32,7 @@ describe('create', () => {
   })
 
   it('sets all nodes to available', () => {
-    const diagram = new DiagramBuilder()
+    const diagram = core.getDiagramBuilder()
       .add(Create)
       .add(ConsoleLog)
       .get();
@@ -55,7 +55,7 @@ describe('create', () => {
   })
 
   it('creates input and output devices', () => {
-    const diagram = new DiagramBuilder()
+    const diagram = core.getDiagramBuilder()
       .add(Create)
       .add(ConsoleLog)
       .get();
@@ -82,7 +82,7 @@ describe('create', () => {
   })
 
   it('sets node runners', () => {
-    const diagram = new DiagramBuilder()
+    const diagram = core.getDiagramBuilder()
       .add(Create)
       .add(ConsoleLog)
       .get();

--- a/packages/core/src/Executor.test.ts
+++ b/packages/core/src/Executor.test.ts
@@ -1,17 +1,13 @@
 import { Diagram } from './Diagram';
-import { Executor } from './Executor';
 import { Computer, RunArgs } from './types/Computer';
-import { DiagramBuilder } from './DiagramBuilder';
 import { ConsoleLog, Create, Ignore, Input, Output, Pass, Signal, Throw } from './computers';;
 import { InMemoryStorage } from './InMemoryStorage';
 import { whenRunning } from './support/diagramExecutionTester/DiagramExecutionTester';
 import { Link } from './types/Link';
 import { Node } from './types/Node';
-import { ItemValue } from './types/ItemValue';
-import { Application } from './Application';
-import { coreNodeProvider } from './coreNodeProvider';
 import { ExecutorFactory } from './ExecutorFactory';
 import { Registry } from './Registry';
+import { core } from './core';
 
 describe('execute', () => {
   it('can execute an empty diagram and return an execution update', async () => {
@@ -239,7 +235,7 @@ describe('execute', () => {
   })
 
   it('can test diagram executions like this', async () => {
-    const diagram = new DiagramBuilder()
+    const diagram = core.getDiagramBuilder()
       .add(Signal, { period: 1, count: 10 })
       .add(Ignore)
       .get()
@@ -250,7 +246,7 @@ describe('execute', () => {
   })
 
   it.todo('can test failed diagram executions like this', async () => {
-    const diagram = new DiagramBuilder()
+    const diagram = core.getDiagramBuilder()
       .add(Create)
       .add(Throw)
       .get()

--- a/packages/core/src/UnfoldedDiagramFactory.test.ts
+++ b/packages/core/src/UnfoldedDiagramFactory.test.ts
@@ -94,7 +94,7 @@ describe('unfold', () => {
   //     .add(nodes.Output, { port_name: 'passed'})
   //     .get()
 
-  //   const diagram = core.getBuilder()
+  //   const diagram = core.getDiagramBuilder()
   //     .add(Create)
   //     .addNestedNode('NestedNode', nestedNode)
   //     .add(Ignore)

--- a/packages/core/src/UnfoldedDiagramFactory.test.ts
+++ b/packages/core/src/UnfoldedDiagramFactory.test.ts
@@ -1,12 +1,11 @@
-import { UnfoldedDiagramFactory, nodes } from '.';
-import { DiagramBuilder } from './DiagramBuilder'
+import { UnfoldedDiagramFactory, core, nodes } from '.';
 import { DiagramQuery } from './DiagramQuery';
 import { str } from './Param'
 const { Create, Table, Input, Map, Output, ConsoleLog, Ignore } = nodes;
 
 describe('unfold', () => {
   it('unfolds a diagram without nested nodes without modifying the diagram', () => {
-    const diagram = new DiagramBuilder()
+    const diagram = core.getDiagramBuilder()
       .add(Create)
       .add(Table)
       .get();
@@ -17,7 +16,7 @@ describe('unfold', () => {
   })
 
   it('unfolds a diagram with simple nested node', () => {
-    const nestedNode = new DiagramBuilder()
+    const nestedNode = core.getDiagramBuilder()
       .withParams([
         str({
           name: 'stamp',
@@ -29,7 +28,7 @@ describe('unfold', () => {
       .add(nodes.Output, { port_name: 'output'})
       .get()
 
-    const diagram = new DiagramBuilder()
+    const diagram = core.getDiagramBuilder()
       .add(Create)
       .addNestedNode('NestedNode', nestedNode)
       .add(Ignore)
@@ -61,13 +60,13 @@ describe('unfold', () => {
   })
 
   it('unfolds a diagram with simple nested node with custom named ports', () => {
-    const nestedNode = new DiagramBuilder()
+    const nestedNode = core.getDiagramBuilder()
       .add(nodes.Input, { port_name: 'incoming'})
       .add(nodes.Map)
       .add(nodes.Output, { port_name: 'outgoing'})
       .get()
 
-    const diagram = new DiagramBuilder()
+    const diagram = core.getDiagramBuilder()
       .add(Create)
       .addNestedNode('NestedNode', nestedNode)
       .add(Ignore)
@@ -95,7 +94,7 @@ describe('unfold', () => {
   //     .add(nodes.Output, { port_name: 'passed'})
   //     .get()
 
-  //   const diagram = new DiagramBuilder()
+  //   const diagram = core.getBuilder()
   //     .add(Create)
   //     .addNestedNode('NestedNode', nestedNode)
   //     .add(Ignore)

--- a/packages/core/src/V2/convertJSONToDiagram.test.ts
+++ b/packages/core/src/V2/convertJSONToDiagram.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from 'vitest';
 import { convertElementsWithLinks, convertNodesToElements, convertParams } from './convertJSONToDiagram';
-import { DiagramBuilder } from '../DiagramBuilder';
 import { ConsoleLog, Signal, Sleep } from '../computers';
+import { core } from '../core';
 
 export interface JSONLink {
   id: string;
@@ -9,7 +9,7 @@ export interface JSONLink {
   targetPortId: string;
 }
 
-const diagramJSON = new DiagramBuilder()
+const diagramJSON = core.getDiagramBuilder()
   .add(Signal)
   .add(Sleep)
   .add(ConsoleLog)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,6 @@ export { jsFunctionEvaluation } from './Param/evaluations/jsFunctionEvaluation'
 export { jsExpressionEvaluation } from './Param/evaluations/jsExpressionEvaluation'
 export { numberCast } from './Param/casts/numberCast'
 export { stringCast } from './Param/casts/stringCast'
-
+export { core } from './core'
 export * as nodes from './computers'
 export * from './Param'

--- a/packages/core/src/support/benchmark.ts
+++ b/packages/core/src/support/benchmark.ts
@@ -1,9 +1,8 @@
 import { Application } from '../Application';
-import { DiagramBuilder } from '../DiagramBuilder';
-import { Executor } from '../Executor';
 import { ExecutorFactory } from '../ExecutorFactory';
 import { InMemoryStorage } from '../InMemoryStorage';
 import { Create, Ignore, CreateProperties } from '../computers';
+import { core } from '../core';
 import { coreNodeProvider } from '../coreNodeProvider';
 
 (async () => {
@@ -23,7 +22,7 @@ import { coreNodeProvider } from '../coreNodeProvider';
 
   app.boot();
 
-  const diagram = new DiagramBuilder()
+  const diagram = core.getDiagramBuilder()
     .add(Create, {json: JSON.stringify(data)})
     .add(CreateProperties)
     .add(Ignore)

--- a/packages/core/src/support/diagramExecutionTester/DiagramExecutionTester.test.ts
+++ b/packages/core/src/support/diagramExecutionTester/DiagramExecutionTester.test.ts
@@ -1,10 +1,10 @@
 import { it } from 'vitest'
 import { Create } from '../../computers'
-import { DiagramBuilder } from '../../DiagramBuilder'
 import { whenRunning } from './DiagramExecutionTester'
+import { core } from '../../core'
 
 it('can test diagram executions like this', async () => {
-  const diagram = new DiagramBuilder()
+  const diagram = core.getDiagramBuilder()
     .add(Create)
     .get()
 

--- a/packages/core/src/support/diagramExecutionTester/DiagramExecutionTester.ts
+++ b/packages/core/src/support/diagramExecutionTester/DiagramExecutionTester.ts
@@ -1,12 +1,10 @@
 import { expect } from 'vitest';
 import { Diagram } from '../../Diagram';
 import { ExecutionUpdate } from '../../types/ExecutionUpdate';
-import { Executor } from '../../Executor';
 
 import { InMemoryStorage } from '../../InMemoryStorage';
 import * as computerConfigs from '../../computers'
 import { ComputerFactory } from '../../ComputerFactory';
-import { Computer } from '../../types/Computer';
 import { ExecutorFactory } from '../../ExecutorFactory';
 import { ComputerRecord, Registry } from '../../Registry';
 
@@ -88,7 +86,7 @@ export class DiagramExecutionTester {
     .add(Throw, { message: 'Im gonna wreck it!' })
     .get()
 
-  const diagram = new DiagramBuilder()
+  const diagram = core.getBuilder()
     .add(Create)
     .get()
 

--- a/packages/core/src/support/diagramExecutionTester/DiagramExecutionTester.ts
+++ b/packages/core/src/support/diagramExecutionTester/DiagramExecutionTester.ts
@@ -86,7 +86,7 @@ export class DiagramExecutionTester {
     .add(Throw, { message: 'Im gonna wreck it!' })
     .get()
 
-  const diagram = core.getBuilder()
+  const diagram = core.getDiagramBuilder()
     .add(Create)
     .get()
 

--- a/packages/docs/components/demos/DocsFlow.tsx
+++ b/packages/docs/components/demos/DocsFlow.tsx
@@ -22,7 +22,7 @@ export default () => {
 
   const { Signal, Pass, Comment, Ignore } = nodes;
 
-  const diagram = core.getBuilder()
+  const diagram = core.getDiagramBuilder()
     .add({...Signal, label: 'DataSource'}, { period: 20, count: 100000})
     .add({...Pass, label: 'Transforms'})
     .add({...Ignore, label: 'Actions'})

--- a/packages/docs/components/demos/DocsFlow.tsx
+++ b/packages/docs/components/demos/DocsFlow.tsx
@@ -5,6 +5,7 @@ import {
   coreNodeProvider,
   nodes,
   multiline,
+  core,
 } from '@data-story/core';
 
 import useWindowDimensions from '../../hooks/useWindowDimensions';
@@ -21,7 +22,7 @@ export default () => {
 
   const { Signal, Pass, Comment, Ignore } = nodes;
 
-  const diagram = new DiagramBuilder()
+  const diagram = core.getBuilder()
     .add({...Signal, label: 'DataSource'}, { period: 20, count: 100000})
     .add({...Pass, label: 'Transforms'})
     .add({...Ignore, label: 'Actions'})

--- a/packages/docs/components/demos/HeroFlow.tsx
+++ b/packages/docs/components/demos/HeroFlow.tsx
@@ -1,10 +1,10 @@
 import { DataStory } from '@data-story/ui'
 import {
   Application,
-  DiagramBuilder,
   coreNodeProvider,
   nodes,
   multiline,
+  core,
 } from '@data-story/core';
 import useWindowDimensions from '../../hooks/useWindowDimensions';
 
@@ -27,7 +27,7 @@ export default () => {
   `
 
   // Good for computers
-  const bigDiagram = new DiagramBuilder()
+  const bigDiagram = core.getBuilder()
     .add({...Signal, label: 'Realtime'}, { period: 20, count: 100000})
     .add({...Pass, label: 'Automation'})
     .add({...Ignore, label: 'for React & NodeJS'})
@@ -40,7 +40,7 @@ export default () => {
     .get()
 
   // Good for mobile
-  const smallDiagram = new DiagramBuilder()
+  const smallDiagram = core.getBuilder()
     .add({...Signal, label: 'Realtime'}, { period: 20, count: 100000})
     .add({...Ignore, label: 'Automation'})
     .above('Signal.1').add(Comment, { content: welcomeMarkdown})

--- a/packages/docs/components/demos/HeroFlow.tsx
+++ b/packages/docs/components/demos/HeroFlow.tsx
@@ -27,7 +27,7 @@ export default () => {
   `
 
   // Good for computers
-  const bigDiagram = core.getBuilder()
+  const bigDiagram = core.getDiagramBuilder()
     .add({...Signal, label: 'Realtime'}, { period: 20, count: 100000})
     .add({...Pass, label: 'Automation'})
     .add({...Ignore, label: 'for React & NodeJS'})
@@ -40,7 +40,7 @@ export default () => {
     .get()
 
   // Good for mobile
-  const smallDiagram = core.getBuilder()
+  const smallDiagram = core.getDiagramBuilder()
     .add({...Signal, label: 'Realtime'}, { period: 20, count: 100000})
     .add({...Ignore, label: 'Automation'})
     .above('Signal.1').add(Comment, { content: welcomeMarkdown})

--- a/packages/docs/components/demos/NodeDemo.tsx
+++ b/packages/docs/components/demos/NodeDemo.tsx
@@ -8,7 +8,7 @@ export default ({ nodeName }: { nodeName: string}) => {
 
   app.boot();
 
-  const diagram = core.getBuilder()
+  const diagram = core.getDiagramBuilder()
     .add(nodes[nodeName])
     .get()
 

--- a/packages/docs/components/demos/NodeDemo.tsx
+++ b/packages/docs/components/demos/NodeDemo.tsx
@@ -1,5 +1,5 @@
 import { DataStory } from '@data-story/ui'
-import { Application, DiagramBuilder, nodes, coreNodeProvider } from '@data-story/core';
+import { Application, nodes, coreNodeProvider, core } from '@data-story/core';
 
 export default ({ nodeName }: { nodeName: string}) => {
   const app = new Application();
@@ -8,7 +8,7 @@ export default ({ nodeName }: { nodeName: string}) => {
 
   app.boot();
 
-  const diagram = new DiagramBuilder()
+  const diagram = core.getBuilder()
     .add(nodes[nodeName])
     .get()
 

--- a/packages/docs/components/demos/ObserversDemo.tsx
+++ b/packages/docs/components/demos/ObserversDemo.tsx
@@ -13,7 +13,7 @@ export default ({ mode, observers }:
     .boot();
   const { Signal, Table } = nodes;
 
-  const diagram = core.getBuilder()
+  const diagram = core.getDiagramBuilder()
     .add(Signal, { period: 5, count: 30 })
     .add(Table)
     .get();

--- a/packages/docs/components/demos/ObserversDemo.tsx
+++ b/packages/docs/components/demos/ObserversDemo.tsx
@@ -1,4 +1,4 @@
-import { Application, coreNodeProvider, Diagram, DiagramBuilder, nodes } from '@data-story/core';
+import { Application, core, coreNodeProvider, nodes } from '@data-story/core';
 import React from 'react';
 import { DataStory, type DataStoryObservers } from '@data-story/ui';
 import { ServerRequest } from '../../const';
@@ -13,7 +13,7 @@ export default ({ mode, observers }:
     .boot();
   const { Signal, Table } = nodes;
 
-  const diagram = new DiagramBuilder()
+  const diagram = core.getBuilder()
     .add(Signal, { period: 5, count: 30 })
     .add(Table)
     .get();

--- a/packages/docs/components/demos/TinkerDemo.tsx
+++ b/packages/docs/components/demos/TinkerDemo.tsx
@@ -21,7 +21,7 @@ export default () => {
 
   app.boot();
 
-  const diagram = core.getBuilder()
+  const diagram = core.getDiagramBuilder()
     .add(Create)
     .get()
 

--- a/packages/docs/components/demos/TinkerDemo.tsx
+++ b/packages/docs/components/demos/TinkerDemo.tsx
@@ -7,6 +7,7 @@ import {
   multiline,
   str,
   UnfoldedDiagramFactory,
+  core,
 } from '@data-story/core';
 
 import useWindowDimensions from '../../hooks/useWindowDimensions';
@@ -20,7 +21,7 @@ export default () => {
 
   app.boot();
 
-  const diagram = new DiagramBuilder()
+  const diagram = core.getBuilder()
     .add(Create)
     .get()
 

--- a/packages/docs/components/demos/UnfoldingDemo.tsx
+++ b/packages/docs/components/demos/UnfoldingDemo.tsx
@@ -15,7 +15,7 @@ export default ({ part }: { part: 'MAIN' | 'NESTED_NODE' | 'MAIN_UNFOLDED'}) => 
   // *************************************
   // Make a nested node
   // *************************************
-  const nestedNode = core.getBuilder()
+  const nestedNode = core.getDiagramBuilder()
     .withParams([
       str({
         name: 'stamp',
@@ -41,7 +41,7 @@ export default ({ part }: { part: 'MAIN' | 'NESTED_NODE' | 'MAIN_UNFOLDED'}) => 
   // *************************************
   // Build main diagram, use the nested node
   // *************************************
-  const diagram = core.getBuilder()
+  const diagram = core.getDiagramBuilder()
     .add({ ...Create, label: 'Users'}, { data: JSON.stringify([
       { name: 'Alice', age: 23 },
       { name: 'Bob', age: 34 },

--- a/packages/docs/components/demos/UnfoldingDemo.tsx
+++ b/packages/docs/components/demos/UnfoldingDemo.tsx
@@ -5,9 +5,8 @@ import {
   coreNodeProvider,
   nodes,
   UnfoldedDiagramFactory,
-  multiline,
   str,
-  StringableParam,
+  core,
 } from '@data-story/core';
 
 export default ({ part }: { part: 'MAIN' | 'NESTED_NODE' | 'MAIN_UNFOLDED'}) => {
@@ -16,7 +15,7 @@ export default ({ part }: { part: 'MAIN' | 'NESTED_NODE' | 'MAIN_UNFOLDED'}) => 
   // *************************************
   // Make a nested node
   // *************************************
-  const nestedNode = new DiagramBuilder()
+  const nestedNode = core.getBuilder()
     .withParams([
       str({
         name: 'stamp',
@@ -42,7 +41,7 @@ export default ({ part }: { part: 'MAIN' | 'NESTED_NODE' | 'MAIN_UNFOLDED'}) => 
   // *************************************
   // Build main diagram, use the nested node
   // *************************************
-  const diagram = new DiagramBuilder()
+  const diagram = core.getBuilder()
     .add({ ...Create, label: 'Users'}, { data: JSON.stringify([
       { name: 'Alice', age: 23 },
       { name: 'Bob', age: 34 },

--- a/packages/docs/components/demos/VisualizeDemo.tsx
+++ b/packages/docs/components/demos/VisualizeDemo.tsx
@@ -1,7 +1,6 @@
-import { Application, coreNodeProvider, Diagram, DiagramBuilder, nodes } from '@data-story/core';
+import { Application, core, coreNodeProvider, DiagramBuilder, nodes } from '@data-story/core';
 import React from 'react';
 import { DataStory, type DataStoryObservers } from '@data-story/ui';
-import { ServerRequest } from '../../const';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -48,7 +47,7 @@ export default () => {
     .boot();
   const { Signal, Table, Map, Create, Request, ConsoleLog } = nodes;
 
-  const diagram = new DiagramBuilder()
+  const diagram = core.getBuilder()
     .add(Signal, {
       period: 100,
       count: 100,
@@ -69,7 +68,7 @@ export default () => {
     selected: true,
   }]
 
-  const tableAndConsoleLog = new DiagramBuilder()
+  const tableAndConsoleLog = core.getBuilder()
     .add(Create)
     .add(Request)
     .add(ConsoleLog)

--- a/packages/docs/components/demos/VisualizeDemo.tsx
+++ b/packages/docs/components/demos/VisualizeDemo.tsx
@@ -47,7 +47,7 @@ export default () => {
     .boot();
   const { Signal, Table, Map, Create, Request, ConsoleLog } = nodes;
 
-  const diagram = core.getBuilder()
+  const diagram = core.getDiagramBuilder()
     .add(Signal, {
       period: 100,
       count: 100,
@@ -68,7 +68,7 @@ export default () => {
     selected: true,
   }]
 
-  const tableAndConsoleLog = core.getBuilder()
+  const tableAndConsoleLog = core.getDiagramBuilder()
     .add(Create)
     .add(Request)
     .add(ConsoleLog)

--- a/packages/docs/components/pitchdeck/1.tsx
+++ b/packages/docs/components/pitchdeck/1.tsx
@@ -1,5 +1,5 @@
 import { DataStory } from '@data-story/ui'
-import { coreNodeProvider, Application, DiagramBuilder, multiline, nodes } from '@data-story/core';
+import { coreNodeProvider, Application, DiagramBuilder, multiline, nodes, core } from '@data-story/core';
 
 const { Comment, Map } = nodes;
 
@@ -13,7 +13,7 @@ export default () => {
   app.boot();
 
   // HubSpot Example
-  const diagram = new DiagramBuilder()
+  const diagram = core.getBuilder()
     .addFake({
       label: 'Lime.persons',
       outputs: ['persons', 'error']

--- a/packages/docs/components/pitchdeck/1.tsx
+++ b/packages/docs/components/pitchdeck/1.tsx
@@ -13,7 +13,7 @@ export default () => {
   app.boot();
 
   // HubSpot Example
-  const diagram = core.getBuilder()
+  const diagram = core.getDiagramBuilder()
     .addFake({
       label: 'Lime.persons',
       outputs: ['persons', 'error']

--- a/packages/docs/components/pitchdeck/2.tsx
+++ b/packages/docs/components/pitchdeck/2.tsx
@@ -13,7 +13,7 @@ export default () => {
   app.boot();
 
   // HubSpot Example
-  const diagram = core.getBuilder()
+  const diagram = core.getDiagramBuilder()
     .addFake({
       label: 'Products',
       outputs: ['all', 'error']

--- a/packages/docs/components/pitchdeck/2.tsx
+++ b/packages/docs/components/pitchdeck/2.tsx
@@ -1,5 +1,5 @@
 import { DataStory } from '@data-story/ui'
-import { coreNodeProvider, Application, DiagramBuilder, multiline, nodes } from '@data-story/core';
+import { coreNodeProvider, Application, DiagramBuilder, multiline, nodes, core } from '@data-story/core';
 
 const { Comment, Map } = nodes;
 
@@ -13,7 +13,7 @@ export default () => {
   app.boot();
 
   // HubSpot Example
-  const diagram = new DiagramBuilder()
+  const diagram = core.getBuilder()
     .addFake({
       label: 'Products',
       outputs: ['all', 'error']

--- a/packages/docs/pages/docs.mdx
+++ b/packages/docs/pages/docs.mdx
@@ -31,7 +31,7 @@ const executor = ExecutorFactory.create(diagram)
 We may execute diagrams directly via the UI or in headless/serverless environments and seamlessly convert between UI rendered, JSON serialized and programmically created diagrams/nodes to build any application you can think of.
 ```ts
 // A diagram created programmatically 🤖
-const diagram = core.getBuilder()
+const diagram = core.getDiagramBuilder()
   .add(Signal)
   .add(Sleep, { duration: 500 })
   .add(ConsoleLog)

--- a/packages/docs/pages/docs.mdx
+++ b/packages/docs/pages/docs.mdx
@@ -31,7 +31,7 @@ const executor = ExecutorFactory.create(diagram)
 We may execute diagrams directly via the UI or in headless/serverless environments and seamlessly convert between UI rendered, JSON serialized and programmically created diagrams/nodes to build any application you can think of.
 ```ts
 // A diagram created programmatically 🤖
-const diagram = new DiagramBuilder()
+const diagram = core.getBuilder()
   .add(Signal)
   .add(Sleep, { duration: 500 })
   .add(ConsoleLog)


### PR DESCRIPTION
Since the DiagramBuilder soon will need to be configured in line with the application (supported nodes etc) it makes sense the app provides the builder instance. This PR shifts to use pattern `core.getDiagramBuilder()` when using the default app, instead of `new DiagramBuilder()`. 