### PR TITLE
Remove Diagram onConnectCallbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "release-nodejs": "yarn workspace @data-story/nodejs run release",
     "ci:test": "turbo test --filter=@data-story/core --filter=@data-story/ui --filter=@data-story/docs && yarn cy:component && yarn ci:e2e",
     "ci:e2e": "start-server-and-test 'yarn dev -- --port 3009' 3009 'cy:e2e' ",
+    "core:test": "turbo test --filter=@data-story/core",
     "cy:e2e": "cypress run --e2e",
     "cy:component": "cypress run --component",
     "cy:open": "cypress open"

--- a/packages/core/src/Diagram.test.ts
+++ b/packages/core/src/Diagram.test.ts
@@ -64,27 +64,36 @@ describe('connect', () => {
     diagram.connect(link)
     expect(diagram.links).toEqual([link])
   })
+})
 
-  it('calls provided onConnect handlers', () => {
-    const callback1 = vi.fn()
-    const callback2 = vi.fn()
-
-    const diagram = new Diagram({
-      onConnect: [
-        callback1,
-        callback2,
-      ]
-    })
+describe('clone', () => {
+  it('creates a deep clone of the diagram', () => {
+    const node: Node = {
+      id: 'node-id',
+      type: 'MyNode',
+      inputs: [],
+      outputs: [],
+      params: []
+    };
 
     const link: Link = {
-      id: 'fake-link-id',
-      sourcePortId: 'fake-port-id-1',
-      targetPortId: 'fake-port-id-2',
-    }
+      id: 'link-id',
+      sourcePortId: 'port-id-1',
+      targetPortId: 'port-id-2',
+    };
 
-    diagram.connect(link)
+    const viewport = { x: 10, y: 20, zoom: 2 };
+    const diagram = new Diagram({ nodes: [node], links: [link], viewport });
 
-    expect(callback1).toHaveBeenCalledWith(link, diagram)
-    expect(callback2).toHaveBeenCalledWith(link, diagram)
-  })
-})
+    const clone = diagram.clone();
+
+    expect(clone).not.toBe(diagram); // Different instances
+    expect(clone.nodes).toEqual(diagram.nodes);
+    expect(clone.links).toEqual(diagram.links);
+    expect(clone.viewport).toEqual(diagram.viewport);
+
+    // Modify clone and check original remains unchanged
+    clone.nodes[0].id = 'modified-node-id';
+    expect(diagram.nodes[0].id).toBe('node-id');
+  });
+});

--- a/packages/core/src/Diagram.ts
+++ b/packages/core/src/Diagram.ts
@@ -1,7 +1,6 @@
 import { PortId } from './types/PortId'
 import { Link } from './types/Link'
 import { Node } from './types/Node'
-import { syncPortSchemas } from './syncPortSchemas'
 import { Param } from './Param'
 
 export type OnConnectCallbacks = (link: Link, diagram: Diagram) => void
@@ -10,40 +9,31 @@ export class Diagram {
   nodes: Node[]
   links: Link[]
   params: Param[]
-  viewport: { x: number, y: number, zoom: number } = {
-    x: 0,
-    y: 0,
-    zoom: 1
-  }
-  onConnect: OnConnectCallbacks[]
+  viewport: { x: number, y: number, zoom: number }
 
   constructor(options?: {
     nodes?: Node[],
     links?: Link[],
     params?: Param[],
-    onConnect?: OnConnectCallbacks[],
+    viewport?: { x: number, y: number, zoom: number }
   }) {
     this.nodes = options?.nodes || []
     this.links = options?.links || []
     this.params = options?.params || []
-    this.onConnect = options?.onConnect || [
-      syncPortSchemas,
-    ]
+    this.viewport = options?.viewport || {
+      x: 0,
+      y: 0,
+      zoom: 1
+    }
   }
 
-  clone() {
-    // Constructable state
-    const cloned = new Diagram({
-      nodes: structuredClone(this.nodes),
-      links: structuredClone(this.links),
-      params: structuredClone(this.params),
-      onConnect: [...this.onConnect],
+  clone(): Diagram {
+    return new Diagram({
+      nodes: this.nodes.map(node => ({ ...node })),
+      links: this.links.map(link => ({ ...link })),
+      params: this.params.map(param => ({ ...param })),
+      viewport: { ...this.viewport },
     });
-
-    // Other state
-    cloned.viewport = { ...this.viewport };
-
-    return cloned;
   }
 
   add(node: Node) {
@@ -54,10 +44,6 @@ export class Diagram {
 
   connect(link: Link) {
     this.links.push(link)
-
-    for(const callback of this.onConnect) {
-      callback(link, this)
-    }
 
     return this
   }

--- a/packages/docs/components/demos/UnfoldingDemo.tsx
+++ b/packages/docs/components/demos/UnfoldingDemo.tsx
@@ -59,7 +59,7 @@ export default ({ part }: { part: 'MAIN' | 'NESTED_NODE' | 'MAIN_UNFOLDED'}) => 
   }
 
   const unfolded = new UnfoldedDiagramFactory(
-    diagram.clone(), // TODO, unfolding should not mutate the diagram
+    diagram.clone(),
     nestedNodes
   ).unfold();
 


### PR DESCRIPTION
Diagram should be more DTO-like, ie no side effects. This facilitates cleaner (de)serialization.

### Follow ups
[] Restore onConnectCallback elsewhere
[] Continue on param editor schema completion