### PR TITLE
Prepare server api

### DIFF
--- a/packages/core/src/Diagram.ts
+++ b/packages/core/src/Diagram.ts
@@ -3,8 +3,6 @@ import { Link } from './types/Link'
 import { Node } from './types/Node'
 import { Param } from './Param'
 
-export type OnConnectCallbacks = (link: Link, diagram: Diagram) => void
-
 export class Diagram {
   nodes: Node[]
   links: Link[]

--- a/packages/docs/components/demos/DocsFlow.tsx
+++ b/packages/docs/components/demos/DocsFlow.tsx
@@ -1,19 +1,13 @@
 import { DataStory } from '@data-story/ui'
 import {
   Application,
-  DiagramBuilder,
   coreNodeProvider,
   nodes,
   multiline,
   core,
 } from '@data-story/core';
 
-import useWindowDimensions from '../../hooks/useWindowDimensions';
-
 export default () => {
-  const { height, width } = useWindowDimensions();
-  const isSmallScreen = width < 768;
-
   const app = new Application();
 
   app.register(coreNodeProvider);
@@ -41,7 +35,7 @@ export default () => {
         server={{ type: 'JS', app }}
         initDiagram={diagram}
         onInitialize={(options) => options.run()}
-        hideToolbar={true}
+        hideControls={true}
       />
     </div>
   );

--- a/packages/docs/components/demos/HeroFlow.tsx
+++ b/packages/docs/components/demos/HeroFlow.tsx
@@ -57,7 +57,7 @@ export default () => {
         server={{ type: 'JS', app }}
         initDiagram={isSmallScreen ? smallDiagram : bigDiagram}
         onInitialize={(options) => options.run()}
-        hideToolbar={true}
+        hideControls={true}
       />
     </div>
   );

--- a/packages/docs/components/demos/NodeDemo.tsx
+++ b/packages/docs/components/demos/NodeDemo.tsx
@@ -17,7 +17,7 @@ export default ({ nodeName }: { nodeName: string}) => {
       <DataStory
         server={{ type: 'JS', app }}
         initDiagram={diagram}
-        hideToolbar={true}
+        hideControls={true}
       />
     </div>
   </div>

--- a/packages/ui/src/components/DataStory/DataStory.tsx
+++ b/packages/ui/src/components/DataStory/DataStory.tsx
@@ -15,6 +15,7 @@ import { useRequest } from 'ahooks';
 export const DataStory = (
   props: Omit<DataStoryProps,'setSidebarKey'>
 ) => {
+  const path = '/';
   const [selectedNode, setSelectedNode] = useState<ReactFlowNode>();
   const [isSidebarClose, setIsSidebarClose] = useState(true);
   const [updateSelectedNodeData, setUpdateSelectedNodeData] = useState<ReactFlowNode['data']>();
@@ -22,16 +23,19 @@ export const DataStory = (
   const partialStoreRef = useRef<Partial<StoreSchema>>(null);
   const { clientv2 } = props
 
-  const { data: tree, loading } = useRequest(async () => {
-    if (!clientv2) return;
-    console.log('Got a clientv2');
+  const { data: tree, loading: treeLoading } = useRequest(async () => {
+    return clientv2
+      ? await clientv2.workspacesApi.getTree({ path })
+      : undefined;
+  }, {
+    refreshDeps: [clientv2],
+    manual: !clientv2,
+  });
 
-    console.log('Loading Tree...');
-    const tree = await clientv2.workspacesApi.get({ path: '/' });
-    await sleep(5000);
-
-    console.log('Tree set!');
-    return tree;
+  const { data: nodeDescriptions, loading: nodeDescriptionsLoading } = useRequest(async () => {
+    return clientv2
+      ? await clientv2.workspacesApi.getNodeDescriptions({ path })
+      : undefined;
   }, {
     refreshDeps: [clientv2], // Will re-fetch if clientv2 changes
     manual: !clientv2, // If clientv2 is not available initially, do not run automatically

--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -67,7 +67,7 @@ export const DataStoryCanvas = forwardRef((props: DataStoryProps, ref) => {
 const Flow = ({
   server,
   initDiagram,
-  hideToolbar = false,
+  hideControls = false,
   slotComponents,
   observers,
   onInitialize,
@@ -154,7 +154,7 @@ const Flow = ({
       >
         <DataStoryControls
           slotComponents={slotComponents}
-          hideToolbar={hideToolbar}
+          hideControls={hideControls}
           setShowRun={(showRunForm: boolean) => setSidebarKey!(showRunForm ? 'run' : '')}
           setShowAddNode={(showAddNodeForm: boolean) => setSidebarKey!(showAddNodeForm ? 'addNode' : '')}
         />

--- a/packages/ui/src/components/DataStory/clients/JsClientV2.tsx
+++ b/packages/ui/src/components/DataStory/clients/JsClientV2.tsx
@@ -1,9 +1,12 @@
-import { Diagram, get } from '@data-story/core';
+import { Diagram, get, NodeDescription } from '@data-story/core';
 import { WorkspacesApi } from './WorkspacesApi';
 
 export class JsClientV2 {
   workspacesApi: WorkspacesApi = {
-    get: async ({ path }) => {
+    getNodeDescriptions: async ({ path }) => {
+      return [] as NodeDescription[]
+    },
+    getTree: async ({ path }) => {
       return {
         path: '/',
         type: 'folder',

--- a/packages/ui/src/components/DataStory/clients/WorkspacesApi.ts
+++ b/packages/ui/src/components/DataStory/clients/WorkspacesApi.ts
@@ -1,9 +1,12 @@
+import { NodeDescription } from '@data-story/core';
 import { Tree } from './Tree';
 
 export interface WorkspacesApi {
-  get: ({ path }) => Promise<Tree>
-  create: ({ path, tree }: { path: string, tree: Tree }) => Promise<Tree>;
-  update: ({ path, tree }: { path: string, tree: Tree }) => Promise<Tree>
-  destroy: ({ path }: { path: string }) => Promise<void>
-  move: ({ path, newPath }: { path: string, newPath: string}) => Promise<Tree>
+  getTree: ({ path }) => Promise<Tree>
+  createTree: ({ path, tree }: { path: string, tree: Tree }) => Promise<Tree>;
+  updateTree: ({ path, tree }: { path: string, tree: Tree }) => Promise<Tree>
+  destroyTree: ({ path }: { path: string }) => Promise<void>
+  moveTree: ({ path, newPath }: { path: string, newPath: string}) => Promise<Tree>
+
+  getNodeDescriptions: ({ path }) => Promise<NodeDescription[]>
 }

--- a/packages/ui/src/components/DataStory/dataStoryControls.tsx
+++ b/packages/ui/src/components/DataStory/dataStoryControls.tsx
@@ -22,12 +22,12 @@ export function useDataStoryControls() {
 }
 
 export function DataStoryControls({
-  hideToolbar = false,
+  hideControls = false,
   setShowRun,
   setShowAddNode,
   slotComponents
 }: {
-  hideToolbar?: boolean;
+  hideControls?: boolean;
   setShowRun: (showRun: boolean) => void;
   setShowAddNode: (showAddNode: boolean) => void;
   slotComponents?: React.ReactNode[];
@@ -48,7 +48,7 @@ export function DataStoryControls({
     }
   }), [updateDiagram, toDiagram]);
 
-  if (hideToolbar) return null;
+  if (hideControls) return null;
 
   return <Controls position={'top-left'} showInteractive={false} showZoom={false} showFitView={false}>
     <ControlButton

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -51,7 +51,7 @@ export type DataStoryProps = {
   clientv2?: JsClientV2,
   server?: ServerConfig
   initDiagram?: Diagram
-  hideToolbar?: boolean
+  hideControls?: boolean
   slotComponents?: React.ReactNode[];
   observers?: DataStoryObservers;
   onInitialize?: DataStoryCallback;


### PR DESCRIPTION
Adds workspaceApi.getNodeDescriptions. Since the nodes available will depend on the active workspace, it makes sense it is accessible via the workspace API. Compare previous concepts "availableNodes"/"describe"/"init".