### PR TITLE
feat: implement single diagram and replacing the diagram properties with the client in docs demos

### DIFF
--- a/packages/docs/components/Playground.tsx
+++ b/packages/docs/components/Playground.tsx
@@ -24,7 +24,7 @@ function Playground({ mode }: {mode?: 'js'|'node'}) {
         // TODO: avoid re-creating the client on every render
         // SyntaxError: Cannot use import statement outside a module
         // clientv2={useCreation(() => new JsClientV2(), [])}
-        clientv2={new JsClientV2()}
+        client={new JsClientV2()}
         slotComponents={[
           <SaveComponent setSaveDiagram={setSaveDiagram}/>,
         ]}

--- a/packages/docs/components/demos/DocsFlow.tsx
+++ b/packages/docs/components/demos/DocsFlow.tsx
@@ -1,11 +1,6 @@
 import { DataStory } from '@data-story/ui'
-import {
-  Application,
-  coreNodeProvider,
-  nodes,
-  multiline,
-  core,
-} from '@data-story/core';
+import { Application, core, coreNodeProvider, multiline, nodes, } from '@data-story/core';
+import { JSClient } from '../splash/MockJSClient';
 
 export default () => {
   const app = new Application();
@@ -29,11 +24,13 @@ export default () => {
     `})
     .get()
 
+  const client = new JSClient(diagram);
+
   return (
     <div className="w-full h-1/6">
       <DataStory
         server={{ type: 'JS', app }}
-        initDiagram={diagram}
+        client={client}
         onInitialize={(options) => options.run()}
         hideControls={true}
       />

--- a/packages/docs/components/demos/ObserversDemo.tsx
+++ b/packages/docs/components/demos/ObserversDemo.tsx
@@ -2,6 +2,7 @@ import { Application, core, coreNodeProvider, nodes } from '@data-story/core';
 import React from 'react';
 import { DataStory, type DataStoryObservers } from '@data-story/ui';
 import { ServerRequest } from '../../const';
+import { JSClient } from '../splash/MockJSClient';
 
 export default ({ mode, observers }:
 {
@@ -17,11 +18,12 @@ export default ({ mode, observers }:
     .add(Signal, { period: 5, count: 30 })
     .add(Table)
     .get();
+  const client = new JSClient(diagram);
 
   return (
     <div className="w-full" style={{ height: '36vh' }}>
       <DataStory
-        initDiagram={diagram}
+        client={client}
         observers={observers}
         server={mode === 'node'
           ? { type: 'SOCKET', url: ServerRequest }

--- a/packages/docs/components/demos/TinkerDemo.tsx
+++ b/packages/docs/components/demos/TinkerDemo.tsx
@@ -1,16 +1,6 @@
 import { DataStory } from '@data-story/ui'
-import {
-  Application,
-  DiagramBuilder,
-  coreNodeProvider,
-  nodes,
-  multiline,
-  str,
-  UnfoldedDiagramFactory,
-  core,
-} from '@data-story/core';
-
-import useWindowDimensions from '../../hooks/useWindowDimensions';
+import { Application, core, coreNodeProvider, nodes, str, } from '@data-story/core';
+import { JSClient } from '../splash/MockJSClient';
 
 // This component is just a place to sketch
 export default () => {
@@ -31,12 +21,13 @@ export default () => {
       help: 'A message to pass on into the execution.',
     })
   ]
+  const client = new JSClient(diagram);
 
   return (
     <div className="w-full h-1/2">
       <DataStory
         server={{ type: 'JS', app }}
-        initDiagram={diagram}
+        client={client}
       />
     </div>
   );

--- a/packages/docs/components/demos/Tree/Empty.tsx
+++ b/packages/docs/components/demos/Tree/Empty.tsx
@@ -20,7 +20,7 @@ export default () => {
   return (
     <div className="w-full h-80 border-gray-400 border-4">
       <DataStory
-        clientv2={clientv2}
+        client={clientv2}
         server={{ type: 'JS', app }}
         onInitialize={(options) => options.run()}
         hideControls={true}

--- a/packages/docs/components/demos/Tree/Loading.tsx
+++ b/packages/docs/components/demos/Tree/Loading.tsx
@@ -20,7 +20,7 @@ export default () => {
   return (
     <div className="w-full h-80 border-gray-400 border-4">
       <DataStory
-        clientv2={clientv2}
+        client={clientv2}
         server={{ type: 'JS', app }}
         onInitialize={(options) => options.run()}
         hideControls={true}

--- a/packages/docs/components/demos/Tree/SingleDiagram.tsx
+++ b/packages/docs/components/demos/Tree/SingleDiagram.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { DataStory } from '@data-story/ui';
+import { Application, core, coreNodeProvider, nodes } from '@data-story/core';
+import { JSClient } from '../../splash/MockJSClient';
+
+export default () => {
+  const app = new Application();
+  app.register(coreNodeProvider);
+  app.boot();
+
+  const { Signal, Comment, Ignore } = nodes;
+
+  const diagram = core.getDiagramBuilder()
+    .add({...Signal, label: 'DataSource'}, { period: 200, count: 100})
+    .add({...Ignore, label: 'Storage'})
+    .above('Signal.1').add(Comment, { content:'### Single Diagram 🔥'})
+    .get();
+
+  const client = new JSClient(diagram);
+
+  return (
+    <div className="w-full h-80 border-gray-400 border-4">
+      <DataStory
+        client={client}
+        server={{ type: 'JS', app }}
+        hideControls={true}
+        // hideActivityBar={true}
+        hideSidebar={true}
+        mode={'Workspace'}
+      />
+    </div>
+  );
+};

--- a/packages/docs/components/demos/UnfoldingDemo.tsx
+++ b/packages/docs/components/demos/UnfoldingDemo.tsx
@@ -8,6 +8,7 @@ import {
   str,
   core,
 } from '@data-story/core';
+import { JSClient } from '../splash/MockJSClient';
 
 export default ({ part }: { part: 'MAIN' | 'NESTED_NODE' | 'MAIN_UNFOLDED'}) => {
   const { Create, Table, Input, Map, Output, ConsoleLog } = nodes;
@@ -63,6 +64,10 @@ export default ({ part }: { part: 'MAIN' | 'NESTED_NODE' | 'MAIN_UNFOLDED'}) => 
     nestedNodes
   ).unfold();
 
+  const mainClient = new JSClient(diagram);
+  const mainUnfoldedClient = new JSClient(unfolded.diagram);
+  const nestedNodeClient = new JSClient(nestedNode);
+
   // *************************************
   // Render requested part
   // *************************************
@@ -71,17 +76,15 @@ export default ({ part }: { part: 'MAIN' | 'NESTED_NODE' | 'MAIN_UNFOLDED'}) => 
       {part === 'MAIN' && <DataStory
         server={{ type: 'JS', app }}
         onInitialize={({ run }) => run()}
-        initDiagram={diagram}
+        client={mainClient}
       />}
       {part === 'NESTED_NODE' && <DataStory
         server={{ type: 'JS', app }}
-        initDiagram={nestedNode}
+        client={nestedNodeClient}
       />}
       {part === 'MAIN_UNFOLDED' && <DataStory
         server={{ type: 'JS', app }}
-        initDiagram={
-          unfolded.diagram
-        }
+        client={mainUnfoldedClient}
       />}
     </div>
   );

--- a/packages/docs/components/demos/VisualizeDemo.tsx
+++ b/packages/docs/components/demos/VisualizeDemo.tsx
@@ -1,5 +1,5 @@
 import { Application, core, coreNodeProvider, DiagramBuilder, nodes } from '@data-story/core';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { DataStory  } from '@data-story/ui';
 import {
   Chart as ChartJS,
@@ -12,6 +12,7 @@ import {
   Legend,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
+import { JSClient } from '../splash/MockJSClient';
 
 ChartJS.register(
   CategoryScale,
@@ -42,19 +43,25 @@ export const options = {
 export default () => {
   const [points, setPoints] = React.useState([]);
 
-  const app = new Application()
-    .register(coreNodeProvider)
-    .boot();
+  const app = useMemo(() => {
+    return new Application()
+      .register(coreNodeProvider)
+      .boot();
+  }, []);
   const { Signal, Table, Map, Create, Request, ConsoleLog } = nodes;
 
-  const diagram = core.getDiagramBuilder()
-    .add(Signal, {
-      period: 100,
-      count: 100,
-      expression: '{ x: ${i} }' })
-    .add(Map, { json: '{ y: Math.cos(${x}/4) }' })
-    .add(Table)
-    .get();
+  const diagram = useMemo(() => {
+    return core.getDiagramBuilder()
+      .add(Signal, {
+        period: 100,
+        count: 100,
+        expression: '{ x: ${i} }' })
+      .add(Map, { json: '{ y: Math.cos(${x}/4) }' })
+      .add(Table)
+      .get();
+  }, []);
+
+  const client = useMemo(() =>  new JSClient(diagram), [diagram]);
 
   const mapNode = diagram.nodes.find(n => n.type === 'Map');
   const jsonParam = mapNode.params.find(p => p.name === 'json') as any;
@@ -100,7 +107,7 @@ export default () => {
             setPoints([])
             run()
           }}
-          initDiagram={diagram}
+          client={client}
           observers={{
             inputObservers: [{ nodeId: 'Table.1', portId: 'input'}],
             onDataChange: (items) => {

--- a/packages/docs/components/splash/MockJSClient.tsx
+++ b/packages/docs/components/splash/MockJSClient.tsx
@@ -17,6 +17,9 @@ export class JSClient {
         path: '/',
         type: 'file',
         content: this.digram,
+        id: 'root',
+        name: '/',
+        children: [],
       });
     }
   } as WorkspacesApi;

--- a/packages/docs/components/splash/MockJSClient.tsx
+++ b/packages/docs/components/splash/MockJSClient.tsx
@@ -1,0 +1,23 @@
+import { Diagram, NodeDescription } from '@data-story/core';
+import { WorkspacesApi } from '@data-story/ui';
+
+export class JSClient {
+  private digram: Diagram;
+
+  constructor(digram: Diagram) {
+    this.digram = digram;
+  }
+
+  workspacesApi: WorkspacesApi = {
+    getNodeDescriptions: async({ path }) => {
+      return [] as NodeDescription[]
+    },
+    getTree: async({ path }) => {
+      return Promise.resolve({
+        path: '/',
+        type: 'file',
+        content: this.digram,
+      });
+    }
+  } as WorkspacesApi;
+}

--- a/packages/docs/pages/Tree.mdx
+++ b/packages/docs/pages/Tree.mdx
@@ -13,6 +13,7 @@ import SingleDiagram from '../components/demos/Tree/SingleDiagram';
 
 <EmptyTree />
 
+## Case 2
 ### Single Diagram
 
 <SingleDiagram />

--- a/packages/docs/pages/Tree.mdx
+++ b/packages/docs/pages/Tree.mdx
@@ -1,5 +1,6 @@
 import LoadingTree from '../components/demos/Tree/Loading';
 import EmptyTree from '../components/demos/Tree/Empty';
+import SingleDiagram from '../components/demos/Tree/SingleDiagram';
 
 # Tree
 
@@ -11,3 +12,7 @@ import EmptyTree from '../components/demos/Tree/Empty';
 ### Empty Tree demo
 
 <EmptyTree />
+
+### Single Diagram
+
+<SingleDiagram />

--- a/packages/ui/src/components/DataStory/DataStory.tsx
+++ b/packages/ui/src/components/DataStory/DataStory.tsx
@@ -12,28 +12,29 @@ import { useLatest, useRequest } from 'ahooks';
 import { LoadingMask } from './common/loadingMask';
 import { Diagram } from '@data-story/core';
 
+const path = '/';
+
 export const DataStory = (
   props: DataStoryProps
 ) => {
-  const path = '/';
   const [selectedNode, setSelectedNode] = useState<ReactFlowNode>();
   const [isSidebarClose, setIsSidebarClose] = useState(!!props.hideSidebar);
   const [updateSelectedNodeData, setUpdateSelectedNodeData] = useState<ReactFlowNode['data']>();
   const [sidebarKey, setSidebarKey] = useState('');
   const partialStoreRef = useRef<Partial<StoreSchema>>(null);
-  const { clientv2 } = props
+  const { client } = props
   const initDiagramRef = useLatest(props.initDiagram);
   const [diagram, setDiagram] = useState<Diagram | undefined>(() => {
     return props.mode === 'Workspace' ? undefined : initDiagramRef.current;
   });
 
   const { data: tree, loading: treeLoading } = useRequest(async() => {
-    return clientv2
-      ? await clientv2.workspacesApi.getTree({ path })
+    return client
+      ? await client.workspacesApi.getTree({ path })
       : undefined;
   }, {
-    refreshDeps: [clientv2],
-    manual: !clientv2,
+    refreshDeps: [client],
+    manual: !client,
   });
 
   useEffect(() => {
@@ -43,12 +44,12 @@ export const DataStory = (
   }, [props.mode, tree]);
 
   const { data: nodeDescriptions, loading: nodeDescriptionsLoading } = useRequest(async() => {
-    return clientv2
-      ? await clientv2.workspacesApi.getNodeDescriptions({ path })
+    return client
+      ? await client.workspacesApi.getNodeDescriptions({ path })
       : undefined;
   }, {
-    refreshDeps: [clientv2], // Will re-fetch if clientv2 changes
-    manual: !clientv2, // If clientv2 is not available initially, do not run automatically
+    refreshDeps: [client], // Will re-fetch if clientv2 changes
+    manual: !client, // If clientv2 is not available initially, do not run automatically
   });
 
   useEffect(() => {

--- a/packages/ui/src/components/DataStory/DataStory.tsx
+++ b/packages/ui/src/components/DataStory/DataStory.tsx
@@ -50,14 +50,14 @@ export const DataStory = (
     }
   }, [tree]);
 
-  const { data: nodeDescriptions, loading: nodeDescriptionsLoading } = useRequest(async() => {
-    return client
-      ? await client.workspacesApi.getNodeDescriptions({ path })
-      : undefined;
-  }, {
-    refreshDeps: [client], // Will re-fetch if clientv2 changes
-    manual: !client, // If clientv2 is not available initially, do not run automatically
-  });
+  // const { data: nodeDescriptions, loading: nodeDescriptionsLoading } = useRequest(async() => {
+  //   return client
+  //     ? await client.workspacesApi.getNodeDescriptions({ path })
+  //     : undefined;
+  // }, {
+  //   refreshDeps: [client], // Will re-fetch if clientv2 changes
+  //   manual: !client, // If clientv2 is not available initially, do not run automatically
+  // });
 
   useEffect(() => {
     if (sidebarKey !== 'node') {

--- a/packages/ui/src/components/DataStory/DataStory.tsx
+++ b/packages/ui/src/components/DataStory/DataStory.tsx
@@ -50,15 +50,14 @@ export const DataStory = (
     }
   }, [tree]);
 
-  // console.log('tree: ', tree, 'diagram: ', diagram);
-  // const { data: nodeDescriptions, loading: nodeDescriptionsLoading } = useRequest(async() => {
-  //   return client
-  //     ? await client.workspacesApi.getNodeDescriptions({ path })
-  //     : undefined;
-  // }, {
-  //   refreshDeps: [client], // Will re-fetch if clientv2 changes
-  //   manual: !client, // If clientv2 is not available initially, do not run automatically
-  // });
+  const { data: nodeDescriptions, loading: nodeDescriptionsLoading } = useRequest(async() => {
+    return client
+      ? await client.workspacesApi.getNodeDescriptions({ path })
+      : undefined;
+  }, {
+    refreshDeps: [client], // Will re-fetch if clientv2 changes
+    manual: !client, // If clientv2 is not available initially, do not run automatically
+  });
 
   useEffect(() => {
     if (sidebarKey !== 'node') {

--- a/packages/ui/src/components/DataStory/DataStory.tsx
+++ b/packages/ui/src/components/DataStory/DataStory.tsx
@@ -24,24 +24,20 @@ export const DataStory = (
   const partialStoreRef = useRef<Partial<StoreSchema>>(null);
   const { client } = props
   const initDiagramRef = useLatest(props.initDiagram);
-  const [diagram, setDiagram] = useState<Diagram | undefined>(() => {
-    return props.mode === 'Workspace' ? undefined : initDiagramRef.current;
-  });
+  const [diagram, setDiagram] = useState<Diagram | undefined>(undefined);
 
   const { data: tree, loading: treeLoading } = useRequest(async() => {
     return client
       ? await client.workspacesApi.getTree({ path })
-      : undefined;
+      : Promise.resolve(null);
   }, {
     refreshDeps: [client],
     manual: !client,
   });
 
   useEffect(() => {
-    if (props.mode === 'Workspace') {
-      tree && setDiagram(tree.content);
-    }
-  }, [props.mode, tree]);
+    tree && setDiagram(tree.content);
+  }, [tree]);
 
   const { data: nodeDescriptions, loading: nodeDescriptionsLoading } = useRequest(async() => {
     return client
@@ -87,15 +83,17 @@ export const DataStory = (
               onUpdateNodeData={setUpdateSelectedNodeData} onClose={setIsSidebarClose}/>
           </Allotment.Pane>
           <Allotment.Pane minSize={300}>
-            <DataStoryCanvas {...props}
-              treeLoading={treeLoading}
-              initDiagram={diagram}
-              ref={partialStoreRef}
-              setSidebarKey={setSidebarKey}
-              sidebarKey={sidebarKey}
-              selectedNode={selectedNode}
-              selectedNodeData={updateSelectedNodeData}
-              onNodeSelected={setSelectedNode}/>
+            {
+              !treeLoading &&
+              <DataStoryCanvas {...props}
+                initDiagram={diagram}
+                ref={partialStoreRef}
+                setSidebarKey={setSidebarKey}
+                sidebarKey={sidebarKey}
+                selectedNode={selectedNode}
+                selectedNodeData={updateSelectedNodeData}
+                onNodeSelected={setSelectedNode}/>
+            }
           </Allotment.Pane>
         </Allotment>
       </div>

--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -26,13 +26,12 @@ const nodeTypes = {
 
 export const DataStoryCanvas = forwardRef((props: DataStoryCanvasProps, ref) => {
   useGetStore(ref);
-  const showPlaceholder = !props.initDiagram && !props.treeLoading && props.mode === 'Workspace';
-
+  const showPlaceholder = !props.initDiagram;
+  console.log('DataStoryCanvas', props.initDiagram);
   return (
     <>
       <ReactFlowProvider>
-        { showPlaceholder && <Placeholder content={'No diagram found'}/> }
-        <Flow {...props}/>
+        { showPlaceholder ? <Placeholder content={'No diagram found'}/> : <Flow {...props}/> }
       </ReactFlowProvider>
     </>
   );

--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -27,7 +27,7 @@ const nodeTypes = {
 export const DataStoryCanvas = forwardRef((props: DataStoryCanvasProps, ref) => {
   useGetStore(ref);
   const showPlaceholder = !props.initDiagram;
-  console.log('DataStoryCanvas', props.initDiagram);
+
   return (
     <>
       <ReactFlowProvider>

--- a/packages/ui/src/components/DataStory/clients/JsClientV2.tsx
+++ b/packages/ui/src/components/DataStory/clients/JsClientV2.tsx
@@ -8,25 +8,44 @@ export class JsClientV2 {
       return [] as NodeDescription[]
     },
     getTree: async ({ path }) => {
-      const treeJson = localStorage.getItem(path)
-      if(treeJson) return parseDiagramTree(treeJson)
+      // const treeJson = localStorage.getItem(path)
+      // console.log('treeJson', treeJson)
+      // if(treeJson) return parseDiagramTree(treeJson)
 
-      console.log('No tree found at path', path)
+      // console.log('No tree found at path', path)
       // If no tree at path
       // For testing purposes: Persist and return a default tree
       const defaultTree = {
         path: '/',
         type: 'folder',
+        name: '/',
+        id: 'root',
         children: [
           {
+            name: 'main',
+            id: 'main',
             path: '/main',
+            type: 'file',
+            content: new Diagram(),
+          },
+          {
+            name: 'dev',
+            id: 'dev',
+            path: '/dev',
             type: 'file',
             content: new Diagram(),
           }
         ],
       }
+      // single diagram
+      // const singleDiagram = {
+      //   path: '/',
+      //   type: 'file',
+      //   content: new Diagram(),
+      //   children: [],
+      // }
 
-      localStorage.setItem(path, JSON.stringify(defaultTree))
+      // localStorage.setItem(path, JSON.stringify(defaultTree))
       return defaultTree
     },
   } as WorkspacesApi

--- a/packages/ui/src/components/DataStory/clients/JsClientV2.tsx
+++ b/packages/ui/src/components/DataStory/clients/JsClientV2.tsx
@@ -37,13 +37,6 @@ export class JsClientV2 {
           }
         ],
       }
-      // single diagram
-      // const singleDiagram = {
-      //   path: '/',
-      //   type: 'file',
-      //   content: new Diagram(),
-      //   children: [],
-      // }
 
       // localStorage.setItem(path, JSON.stringify(defaultTree))
       return defaultTree

--- a/packages/ui/src/components/DataStory/clients/Tree.ts
+++ b/packages/ui/src/components/DataStory/clients/Tree.ts
@@ -5,4 +5,6 @@ export interface Tree<TreeNodeType = Diagram> {
   type: 'file' | 'folder';
   content?: TreeNodeType;
   children?: Tree[];
+  name: string;
+  id: string;
 }

--- a/packages/ui/src/components/DataStory/common/method.ts
+++ b/packages/ui/src/components/DataStory/common/method.ts
@@ -1,0 +1,30 @@
+import { Tree } from '../clients/Tree';
+import { Activity } from '../types';
+import { NodeIcon } from '../icons/nodeIcon';
+import { DiagramIcon } from '../icons/diagramIcon';
+import { ConfigIcon } from '../icons/configIcon';
+
+export const path = '/';
+
+export const findFirstFileNode = (tree: Tree): Tree | null => {
+  if (tree.type === 'file') return tree;
+  if (!tree.children || tree?.children?.length === 0) return null;
+
+  for(const child of tree.children) {
+    if (child.type === 'file') return child;
+    return findFirstFileNode(child);
+  }
+  return null;
+}
+
+export const isSingleFile = (tree: Tree): boolean => {
+  if (tree.type === 'file' && (!tree.children || tree?.children?.length === 0)) return true;
+  return false;
+}
+
+export const ActivityGroups: Activity[] = [
+  { id: 'node', name: 'Node Config', icon: NodeIcon, position: 'top' },
+  { id: 'diagram', name: 'Diagram Config', icon: DiagramIcon, position: 'top' },
+  { id: 'settings', name: 'Settings', icon: ConfigIcon, position: 'top' },
+  { id: 'explorer', name: 'Explorer', icon: ConfigIcon, position: 'top' },
+];

--- a/packages/ui/src/components/DataStory/sidebar/activityBar.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/activityBar.tsx
@@ -1,33 +1,19 @@
 import React, { useEffect } from 'react';
 import { ReactFlowNode } from '../../Node/ReactFlowNode';
-import { DiagramIcon } from '../icons/diagramIcon';
-import { ConfigIcon } from '../icons/configIcon';
-import { NodeIcon } from '../icons/nodeIcon';
-
-type Activity = {
-  id: string;
-  name: string;
-  icon: React.FC<{}>;
-  position: 'top' | 'bottom';
-};
-
-const activityGroups: Activity[] = [
-  { id: 'node', name: 'Node Config', icon: NodeIcon, position: 'top' },
-  { id: 'diagram', name: 'Diagram Config', icon: DiagramIcon, position: 'top' },
-  { id: 'settings', name: 'Settings', icon: ConfigIcon, position: 'top' },
-  { id: 'experiment', name: 'Experiment', icon: ConfigIcon, position: 'top' },
-]
+import { Activity } from '../types';
 
 export const ActivityBar = ({
   setActiveKey,
   onClose,
   activeKey,
   selectedNode,
+  activityGroups,
 }: {
   onClose: React.Dispatch<React.SetStateAction<boolean>>;
   setActiveKey: (activity: string) => void;
   activeKey: string;
   selectedNode?: ReactFlowNode;
+  activityGroups: Activity[];
 }) => {
   const handleActivityClick = (id: string) => {
     // 1. when click the same activity, switch sidebar status

--- a/packages/ui/src/components/DataStory/sidebar/explorer.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/explorer.tsx
@@ -33,25 +33,27 @@ export const Explorer = ({
 }: {
   tree?: Tree,
 }) => {
+  if (!tree || tree.type !== 'folder') {
+    return <Placeholder content={'No data available'}/>;
+  }
+
   return (
     <div className="h-full">
       <div className="uppercase text-xs px-8 py-2 text-gray-600">
         Explorer
       </div>
-      {tree
-        ? <div className="px-2 py-2">
-          <ArboristTree
-            initialData={[tree]}
-            openByDefault={true}
-            width={600}
-            height={1000}
-            indent={18}
-            rowHeight={24}
-          >
-            {Node}
-          </ArboristTree>
-        </div>
-        :  <Placeholder content={'No data available'}/>}
+      <div className="px-2 py-2">
+        <ArboristTree
+          initialData={[tree]}
+          openByDefault={true}
+          width={600}
+          height={1000}
+          indent={18}
+          rowHeight={24}
+        >
+          {Node}
+        </ArboristTree>
+      </div>
     </div>
   );
 };

--- a/packages/ui/src/components/DataStory/sidebar/explorer.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/explorer.tsx
@@ -33,7 +33,7 @@ export const Explorer = ({
 }: {
   tree?: Tree,
 }) => {
-  if (!tree || tree.type !== 'folder') {
+  if (!tree || tree.type === 'file') {
     return <Placeholder content={'No data available'}/>;
   }
 

--- a/packages/ui/src/components/DataStory/sidebar/explorer.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/explorer.tsx
@@ -33,23 +33,6 @@ export const Explorer = ({
 }: {
   tree?: Tree,
 }) => {
-  const data = [
-    {
-      id: 'fake-project',
-      name: 'fake-project',
-      children: [
-        {
-          id: 'nodes',
-          name: 'nodes',
-          children: [
-            { id: 'todos.get', name: 'todos.get' },
-          ],
-        },
-        { id: 'main', name: 'main' },
-      ]
-    },
-  ];
-
   return (
     <div className="h-full">
       <div className="uppercase text-xs px-8 py-2 text-gray-600">
@@ -58,7 +41,7 @@ export const Explorer = ({
       {tree
         ? <div className="px-2 py-2">
           <ArboristTree
-            initialData={data}
+            initialData={[tree]}
             openByDefault={true}
             width={600}
             height={1000}
@@ -69,7 +52,6 @@ export const Explorer = ({
           </ArboristTree>
         </div>
         :  <Placeholder content={'No data available'}/>}
-
     </div>
   );
 };

--- a/packages/ui/src/components/DataStory/sidebar/sidebar.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/sidebar.tsx
@@ -9,7 +9,7 @@ import { AddNode } from './addNode';
 export const Sidebar = (props: NodeSettingsSidebarProps) => {
   const {
     tree, node, onClose, onUpdateNodeData, sidebarKey, setSidebarKey,
-    partialStoreRef, treeLoading
+    partialStoreRef
   } = props;
 
   const renderContent = () => {

--- a/packages/ui/src/components/DataStory/sidebar/sidebar.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/sidebar.tsx
@@ -23,7 +23,7 @@ export const Sidebar = (props: NodeSettingsSidebarProps) => {
           availableNodes={partialStoreRef.current?.availableNodes || []}
           addNodeFromDescription={(nodeDescription: NodeDescription) => partialStoreRef.current?.addNodeFromDescription?.(nodeDescription)}
           setSidebarKey={setSidebarKey}/>;
-      case 'experiment':
+      case 'explorer':
         return <Explorer tree={tree} />;
       case 'diagram':
         return <Placeholder content={'todo: show diagram configuration'}/>;

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -48,7 +48,7 @@ export type SocketClientOptions = ClientOptions & {
 }
 
 export type DataStoryProps = {
-  clientv2?: JsClientV2,
+  client?: JsClientV2,
   server?: ServerConfig
   initDiagram?: Diagram
   hideControls?: boolean

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -16,6 +16,7 @@ import { Direction } from './getNodesWithNewSelection';
 import { ServerClient } from './clients/ServerClient';
 import { JsClientV2 } from './clients/JsClientV2';
 import { Tree } from './clients/Tree';
+import React from 'react';
 
 export type DataStoryCallback = (options: {run: () => void}) => void;
 
@@ -156,7 +157,6 @@ export type StoreSchema = {
 };
 export type NodeSettingsSidebarProps = Omit<NodeSettingsFormProps, 'node'> & {
   tree?: Tree;
-  treeLoading?: boolean;
   activeBar?: string;
   sidebarKey: string;
   node?: ReactFlowNode;
@@ -164,6 +164,9 @@ export type NodeSettingsSidebarProps = Omit<NodeSettingsFormProps, 'node'> & {
   partialStoreRef: React.RefObject<Partial<StoreSchema>>;
 };
 
-export type IconProps = {
-  isActive?: boolean;
+export type Activity = {
+  id: string;
+  name: string;
+  icon: React.FC<{}>;
+  position: 'top' | 'bottom';
 };

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -9,3 +9,4 @@ export type { DataStoryObservers } from './components/DataStory/types'
 export { Explorer } from './components/DataStory/sidebar/explorer';
 export { default as NodeComponent } from './components/Node/NodeComponent';
 export { JsClientV2 } from './components/DataStory/clients/JsClientV2';
+export type { WorkspacesApi } from './components/DataStory/clients/WorkspacesApi';


### PR DESCRIPTION
- feat: implement single diagram

![image](https://github.com/user-attachments/assets/3eb48b85-df4c-4340-8835-7f9df3c8c9c4)

- [docs: replacing the diagram properties with the client in docs demos](https://github.com/ajthinking/data-story/commit/e2a8e246540bee9e369fc2a1758fd3a1d3e5cdc3)