### PR TITLE
feat: implement support for multiple diagrams(workspace) in DataStory and sidebar switching

### DIFF
--- a/packages/docs/components/Playground.tsx
+++ b/packages/docs/components/Playground.tsx
@@ -2,21 +2,29 @@
 
 import { Application, coreNodeProvider, Diagram } from '@data-story/core';
 import React, { useMemo } from 'react';
-import { DataStory, JsClientV2 } from '@data-story/ui';
-import { loadDiagram, LocalStorageKey,  SaveComponent } from './Save';
+import { DataStory, WorkspaceApiClient, ServerConfig } from '@data-story/ui';
+import { loadDiagram, LocalStorageKey, SaveComponent } from './Save';
 import { ServerRequest } from '../const';
 
 export default Playground;
 
-function Playground({ mode }: {mode?: 'js'|'node'}) {
-  const app = new Application()
-    .register(coreNodeProvider)
-    .boot();
+function getServer(mode: 'js' | 'node', app: Application): ServerConfig {
+  return mode === 'node'
+    ? { type: 'SOCKET', url: ServerRequest }
+    : { type: 'JS', app };
+}
 
+const app = new Application()
+  .register(coreNodeProvider)
+  .boot();
+
+function Playground({ mode }: {mode?: 'js' | 'node'}) {
   const { diagram } = loadDiagram(LocalStorageKey);
   const [initDiagram] = React.useState<Diagram>(diagram);
-  const [saveDiagram, setSaveDiagram] = React.useState<() => void>(() => {});
-  const client = useMemo(() => new JsClientV2(), []);
+  const [saveDiagram, setSaveDiagram] = React.useState<() => void>(() => {
+  });
+  const client = useMemo(() => new WorkspaceApiClient(), []);
+  const server = useMemo(() => getServer(mode, app), [mode])
 
   return (
     <div className="w-full" style={{ height: 'calc(100vh - 72px)' }} data-cy="playground">
@@ -30,9 +38,7 @@ function Playground({ mode }: {mode?: 'js'|'node'}) {
           <SaveComponent setSaveDiagram={setSaveDiagram}/>,
         ]}
         initDiagram={initDiagram}
-        server={mode === 'node'
-          ? { type: 'SOCKET', url: ServerRequest }
-          : { type: 'JS', app }}
+        server={server}
       />
     </div>
   );

--- a/packages/docs/components/Playground.tsx
+++ b/packages/docs/components/Playground.tsx
@@ -24,7 +24,7 @@ function Playground({ mode }: {mode?: 'js'|'node'}) {
         // TODO: avoid re-creating the client on every render
         // SyntaxError: Cannot use import statement outside a module
         // clientv2={useCreation(() => new JsClientV2(), [])}
-        clientv2={new JsClientV2()}
+        client={new JsClientV2()}
         slotComponents={[
           <SaveComponent setSaveDiagram={setSaveDiagram}/>,
         ]}

--- a/packages/docs/components/Playground.tsx
+++ b/packages/docs/components/Playground.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Application, coreNodeProvider, Diagram } from '@data-story/core';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { DataStory, JsClientV2 } from '@data-story/ui';
 import { loadDiagram, LocalStorageKey,  SaveComponent } from './Save';
 import { ServerRequest } from '../const';
@@ -16,6 +16,7 @@ function Playground({ mode }: {mode?: 'js'|'node'}) {
   const { diagram } = loadDiagram(LocalStorageKey);
   const [initDiagram] = React.useState<Diagram>(diagram);
   const [saveDiagram, setSaveDiagram] = React.useState<() => void>(() => {});
+  const client = useMemo(() => new JsClientV2(), []);
 
   return (
     <div className="w-full" style={{ height: 'calc(100vh - 72px)' }} data-cy="playground">
@@ -24,7 +25,7 @@ function Playground({ mode }: {mode?: 'js'|'node'}) {
         // TODO: avoid re-creating the client on every render
         // SyntaxError: Cannot use import statement outside a module
         // clientv2={useCreation(() => new JsClientV2(), [])}
-        client={new JsClientV2()}
+        client={client}
         slotComponents={[
           <SaveComponent setSaveDiagram={setSaveDiagram}/>,
         ]}

--- a/packages/docs/components/demos/DocsFlow.tsx
+++ b/packages/docs/components/demos/DocsFlow.tsx
@@ -1,11 +1,6 @@
 import { DataStory } from '@data-story/ui'
-import {
-  Application,
-  coreNodeProvider,
-  nodes,
-  multiline,
-  core,
-} from '@data-story/core';
+import { Application, core, coreNodeProvider, multiline, nodes, } from '@data-story/core';
+import { JSClient } from '../splash/MockJSClient';
 
 export default () => {
   const app = new Application();
@@ -29,11 +24,13 @@ export default () => {
     `})
     .get()
 
+  const client = new JSClient(diagram);
+
   return (
     <div className="w-full h-1/6">
       <DataStory
         server={{ type: 'JS', app }}
-        initDiagram={diagram}
+        client={client}
         onInitialize={(options) => options.run()}
         hideControls={true}
       />

--- a/packages/docs/components/demos/ObserversDemo.tsx
+++ b/packages/docs/components/demos/ObserversDemo.tsx
@@ -2,6 +2,7 @@ import { Application, core, coreNodeProvider, nodes } from '@data-story/core';
 import React from 'react';
 import { DataStory, type DataStoryObservers } from '@data-story/ui';
 import { ServerRequest } from '../../const';
+import { JSClient } from '../splash/MockJSClient';
 
 export default ({ mode, observers }:
 {
@@ -17,11 +18,12 @@ export default ({ mode, observers }:
     .add(Signal, { period: 5, count: 30 })
     .add(Table)
     .get();
+  const client = new JSClient(diagram);
 
   return (
     <div className="w-full" style={{ height: '36vh' }}>
       <DataStory
-        initDiagram={diagram}
+        client={client}
         observers={observers}
         server={mode === 'node'
           ? { type: 'SOCKET', url: ServerRequest }

--- a/packages/docs/components/demos/TinkerDemo.tsx
+++ b/packages/docs/components/demos/TinkerDemo.tsx
@@ -1,16 +1,6 @@
 import { DataStory } from '@data-story/ui'
-import {
-  Application,
-  DiagramBuilder,
-  coreNodeProvider,
-  nodes,
-  multiline,
-  str,
-  UnfoldedDiagramFactory,
-  core,
-} from '@data-story/core';
-
-import useWindowDimensions from '../../hooks/useWindowDimensions';
+import { Application, core, coreNodeProvider, nodes, str, } from '@data-story/core';
+import { JSClient } from '../splash/MockJSClient';
 
 // This component is just a place to sketch
 export default () => {
@@ -31,12 +21,13 @@ export default () => {
       help: 'A message to pass on into the execution.',
     })
   ]
+  const client = new JSClient(diagram);
 
   return (
     <div className="w-full h-1/2">
       <DataStory
         server={{ type: 'JS', app }}
-        initDiagram={diagram}
+        client={client}
       />
     </div>
   );

--- a/packages/docs/components/demos/Tree/Empty.tsx
+++ b/packages/docs/components/demos/Tree/Empty.tsx
@@ -24,7 +24,6 @@ export default () => {
         server={{ type: 'JS', app }}
         onInitialize={(options) => options.run()}
         hideControls={true}
-        mode={'Workspace'}
       />
     </div>
   );

--- a/packages/docs/components/demos/Tree/Empty.tsx
+++ b/packages/docs/components/demos/Tree/Empty.tsx
@@ -20,7 +20,7 @@ export default () => {
   return (
     <div className="w-full h-80 border-gray-400 border-4">
       <DataStory
-        clientv2={clientv2}
+        client={clientv2}
         server={{ type: 'JS', app }}
         onInitialize={(options) => options.run()}
         hideControls={true}

--- a/packages/docs/components/demos/Tree/Loading.tsx
+++ b/packages/docs/components/demos/Tree/Loading.tsx
@@ -24,7 +24,6 @@ export default () => {
         server={{ type: 'JS', app }}
         onInitialize={(options) => options.run()}
         hideControls={true}
-        mode={'Workspace'}
       />
     </div>
   );

--- a/packages/docs/components/demos/Tree/Loading.tsx
+++ b/packages/docs/components/demos/Tree/Loading.tsx
@@ -20,7 +20,7 @@ export default () => {
   return (
     <div className="w-full h-80 border-gray-400 border-4">
       <DataStory
-        clientv2={clientv2}
+        client={clientv2}
         server={{ type: 'JS', app }}
         onInitialize={(options) => options.run()}
         hideControls={true}

--- a/packages/docs/components/demos/Tree/MultipleDiagram.tsx
+++ b/packages/docs/components/demos/Tree/MultipleDiagram.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { DataStory, WorkspaceApiClient } from '@data-story/ui';
+import { Application, coreNodeProvider, nodes } from '@data-story/core';
+import { useMemo } from 'react';
+
+export default () => {
+  const app = new Application();
+  app.register(coreNodeProvider);
+  app.boot();
+
+  const client = useMemo(() =>  new WorkspaceApiClient(), []);
+
+  return (
+    <div className="w-full h-80 border-gray-400 border-4">
+      <DataStory
+        client={client}
+        server={{ type: 'JS', app }}
+      />
+    </div>
+  );
+};

--- a/packages/docs/components/demos/Tree/SingleDiagram.tsx
+++ b/packages/docs/components/demos/Tree/SingleDiagram.tsx
@@ -25,9 +25,7 @@ export default () => {
         client={client}
         server={{ type: 'JS', app }}
         hideControls={true}
-        // hideActivityBar={true}
         hideSidebar={true}
-        mode={'Workspace'}
       />
     </div>
   );

--- a/packages/docs/components/demos/Tree/SingleDiagram.tsx
+++ b/packages/docs/components/demos/Tree/SingleDiagram.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { DataStory } from '@data-story/ui';
+import { Application, core, coreNodeProvider, nodes } from '@data-story/core';
+import { JSClient } from '../../splash/MockJSClient';
+
+export default () => {
+  const app = new Application();
+  app.register(coreNodeProvider);
+  app.boot();
+
+  const { Signal, Comment, Ignore } = nodes;
+
+  const diagram = core.getDiagramBuilder()
+    .add({...Signal, label: 'DataSource'}, { period: 200, count: 100})
+    .add({...Ignore, label: 'Storage'})
+    .above('Signal.1').add(Comment, { content:'### Single Diagram 🔥'})
+    .get();
+
+  const client = new JSClient(diagram);
+
+  return (
+    <div className="w-full h-80 border-gray-400 border-4">
+      <DataStory
+        client={client}
+        server={{ type: 'JS', app }}
+        hideControls={true}
+        // hideActivityBar={true}
+        hideSidebar={true}
+        mode={'Workspace'}
+      />
+    </div>
+  );
+};

--- a/packages/docs/components/demos/UnfoldingDemo.tsx
+++ b/packages/docs/components/demos/UnfoldingDemo.tsx
@@ -8,6 +8,7 @@ import {
   str,
   core,
 } from '@data-story/core';
+import { JSClient } from '../splash/MockJSClient';
 
 export default ({ part }: { part: 'MAIN' | 'NESTED_NODE' | 'MAIN_UNFOLDED'}) => {
   const { Create, Table, Input, Map, Output, ConsoleLog } = nodes;
@@ -63,6 +64,10 @@ export default ({ part }: { part: 'MAIN' | 'NESTED_NODE' | 'MAIN_UNFOLDED'}) => 
     nestedNodes
   ).unfold();
 
+  const mainClient = new JSClient(diagram);
+  const mainUnfoldedClient = new JSClient(unfolded.diagram);
+  const nestedNodeClient = new JSClient(nestedNode);
+
   // *************************************
   // Render requested part
   // *************************************
@@ -71,17 +76,15 @@ export default ({ part }: { part: 'MAIN' | 'NESTED_NODE' | 'MAIN_UNFOLDED'}) => 
       {part === 'MAIN' && <DataStory
         server={{ type: 'JS', app }}
         onInitialize={({ run }) => run()}
-        initDiagram={diagram}
+        client={mainClient}
       />}
       {part === 'NESTED_NODE' && <DataStory
         server={{ type: 'JS', app }}
-        initDiagram={nestedNode}
+        client={nestedNodeClient}
       />}
       {part === 'MAIN_UNFOLDED' && <DataStory
         server={{ type: 'JS', app }}
-        initDiagram={
-          unfolded.diagram
-        }
+        client={mainUnfoldedClient}
       />}
     </div>
   );

--- a/packages/docs/components/demos/VisualizeDemo.tsx
+++ b/packages/docs/components/demos/VisualizeDemo.tsx
@@ -1,5 +1,5 @@
 import { Application, core, coreNodeProvider, DiagramBuilder, nodes } from '@data-story/core';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { DataStory  } from '@data-story/ui';
 import {
   Chart as ChartJS,
@@ -12,6 +12,7 @@ import {
   Legend,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
+import { JSClient } from '../splash/MockJSClient';
 
 ChartJS.register(
   CategoryScale,
@@ -42,19 +43,25 @@ export const options = {
 export default () => {
   const [points, setPoints] = React.useState([]);
 
-  const app = new Application()
-    .register(coreNodeProvider)
-    .boot();
+  const app = useMemo(() => {
+    return new Application()
+      .register(coreNodeProvider)
+      .boot();
+  }, []);
   const { Signal, Table, Map, Create, Request, ConsoleLog } = nodes;
 
-  const diagram = core.getDiagramBuilder()
-    .add(Signal, {
-      period: 100,
-      count: 100,
-      expression: '{ x: ${i} }' })
-    .add(Map, { json: '{ y: Math.cos(${x}/4) }' })
-    .add(Table)
-    .get();
+  const diagram = useMemo(() => {
+    return core.getDiagramBuilder()
+      .add(Signal, {
+        period: 100,
+        count: 100,
+        expression: '{ x: ${i} }' })
+      .add(Map, { json: '{ y: Math.cos(${x}/4) }' })
+      .add(Table)
+      .get();
+  }, []);
+
+  const client = useMemo(() =>  new JSClient(diagram), [diagram]);
 
   const mapNode = diagram.nodes.find(n => n.type === 'Map');
   const jsonParam = mapNode.params.find(p => p.name === 'json') as any;
@@ -100,7 +107,7 @@ export default () => {
             setPoints([])
             run()
           }}
-          initDiagram={diagram}
+          client={client}
           observers={{
             inputObservers: [{ nodeId: 'Table.1', portId: 'input'}],
             onDataChange: (items) => {

--- a/packages/docs/components/splash/MockJSClient.tsx
+++ b/packages/docs/components/splash/MockJSClient.tsx
@@ -17,6 +17,9 @@ export class JSClient {
         path: '/',
         type: 'file',
         content: this.digram,
+        id: 'root',
+        name: '/',
+        children: [],
       });
     }
   } as WorkspacesApi;

--- a/packages/docs/components/splash/MockJSClient.tsx
+++ b/packages/docs/components/splash/MockJSClient.tsx
@@ -1,0 +1,23 @@
+import { Diagram, NodeDescription } from '@data-story/core';
+import { WorkspacesApi } from '@data-story/ui';
+
+export class JSClient {
+  private digram: Diagram;
+
+  constructor(digram: Diagram) {
+    this.digram = digram;
+  }
+
+  workspacesApi: WorkspacesApi = {
+    getNodeDescriptions: async({ path }) => {
+      return [] as NodeDescription[]
+    },
+    getTree: async({ path }) => {
+      return Promise.resolve({
+        path: '/',
+        type: 'file',
+        content: this.digram,
+      });
+    }
+  } as WorkspacesApi;
+}

--- a/packages/docs/components/splash/MockJSClient.tsx
+++ b/packages/docs/components/splash/MockJSClient.tsx
@@ -2,10 +2,10 @@ import { Diagram, NodeDescription } from '@data-story/core';
 import { WorkspacesApi } from '@data-story/ui';
 
 export class JSClient {
-  private digram: Diagram;
+  private diagram: Diagram;
 
-  constructor(digram: Diagram) {
-    this.digram = digram;
+  constructor(diagram: Diagram) {
+    this.diagram = diagram;
   }
 
   workspacesApi: WorkspacesApi = {
@@ -16,7 +16,7 @@ export class JSClient {
       return Promise.resolve({
         path: '/',
         type: 'file',
-        content: this.digram,
+        content: this.diagram,
         id: 'root',
         name: '/',
         children: [],

--- a/packages/docs/components/splash/MockJSClient.tsx
+++ b/packages/docs/components/splash/MockJSClient.tsx
@@ -13,14 +13,14 @@ export class JSClient {
       return [] as NodeDescription[]
     },
     getTree: async({ path }) => {
-      return Promise.resolve({
+      return Promise.resolve([{
         path: '/',
         type: 'file',
         content: this.diagram,
         id: 'root',
         name: '/',
         children: [],
-      });
+      }]);
     }
   } as WorkspacesApi;
 }

--- a/packages/docs/pages/Tree.mdx
+++ b/packages/docs/pages/Tree.mdx
@@ -1,10 +1,11 @@
 import LoadingTree from '../components/demos/Tree/Loading';
 import EmptyTree from '../components/demos/Tree/Empty';
 import SingleDiagram from '../components/demos/Tree/SingleDiagram';
+import MultipleDiagram from '../components/demos/Tree/MultipleDiagram';
 
 # Tree
 
-## Case1
+## Case0
 ### Loading Tree demo
 
 <LoadingTree />
@@ -13,7 +14,12 @@ import SingleDiagram from '../components/demos/Tree/SingleDiagram';
 
 <EmptyTree />
 
-## Case 2
+## Case 1
 ### Single Diagram
 
 <SingleDiagram />
+
+## Case 3
+### Multiple Diagram
+
+<MultipleDiagram />

--- a/packages/docs/pages/Tree.mdx
+++ b/packages/docs/pages/Tree.mdx
@@ -13,6 +13,7 @@ import SingleDiagram from '../components/demos/Tree/SingleDiagram';
 
 <EmptyTree />
 
+## Case 2
 ### Single Diagram
 
 <SingleDiagram />

--- a/packages/docs/pages/Tree.mdx
+++ b/packages/docs/pages/Tree.mdx
@@ -1,5 +1,6 @@
 import LoadingTree from '../components/demos/Tree/Loading';
 import EmptyTree from '../components/demos/Tree/Empty';
+import SingleDiagram from '../components/demos/Tree/SingleDiagram';
 
 # Tree
 
@@ -11,3 +12,7 @@ import EmptyTree from '../components/demos/Tree/Empty';
 ### Empty Tree demo
 
 <EmptyTree />
+
+### Single Diagram
+
+<SingleDiagram />

--- a/packages/ui/src/components/DataStory/DataStory.tsx
+++ b/packages/ui/src/components/DataStory/DataStory.tsx
@@ -44,12 +44,6 @@ export const DataStoryComponent = (
   }, [tree]);
 
   useEffect(() => {
-    if (!tree || !diagramKey) return;
-    const node = findNodeById(tree, diagramKey);
-    setDiagram(node?.content ?? null);
-  }, [diagramKey, tree]);
-
-  useEffect(() => {
     if (!tree?.length || isSingleFile(tree)) {
       setActivityGroups(ActivityGroups.filter((activity) => activity.id !== 'explorer'));
     } else {

--- a/packages/ui/src/components/DataStory/DataStory.tsx
+++ b/packages/ui/src/components/DataStory/DataStory.tsx
@@ -12,28 +12,29 @@ import { useLatest, useRequest } from 'ahooks';
 import { LoadingMask } from './common/loadingMask';
 import { Diagram } from '@data-story/core';
 
+const path = '/';
+
 export const DataStory = (
   props: DataStoryProps
 ) => {
-  const path = '/';
   const [selectedNode, setSelectedNode] = useState<ReactFlowNode>();
   const [isSidebarClose, setIsSidebarClose] = useState(!!props.hideSidebar);
   const [updateSelectedNodeData, setUpdateSelectedNodeData] = useState<ReactFlowNode['data']>();
   const [sidebarKey, setSidebarKey] = useState('');
   const partialStoreRef = useRef<Partial<StoreSchema>>(null);
-  const { clientv2 } = props
+  const { client } = props
   const initDiagramRef = useLatest(props.initDiagram);
   const [diagram, setDiagram] = useState<Diagram | undefined>(() => {
     return props.mode === 'Workspace' ? undefined : initDiagramRef.current;
   });
 
   const { data: tree, loading: treeLoading } = useRequest(async() => {
-    return clientv2
-      ? await clientv2.workspacesApi.getTree({ path })
+    return client
+      ? await client.workspacesApi.getTree({ path })
       : undefined;
   }, {
-    refreshDeps: [clientv2],
-    manual: !clientv2,
+    refreshDeps: [client],
+    manual: !client,
   });
 
   useEffect(() => {
@@ -43,12 +44,12 @@ export const DataStory = (
   }, [props.mode, tree]);
 
   const { data: nodeDescriptions, loading: nodeDescriptionsLoading } = useRequest(async() => {
-    return clientv2
-      ? await clientv2.workspacesApi.getNodeDescriptions({ path })
+    return client
+      ? await client.workspacesApi.getNodeDescriptions({ path })
       : undefined;
   }, {
-    refreshDeps: [clientv2], // Will re-fetch if clientv2 changes
-    manual: !clientv2, // If clientv2 is not available initially, do not run automatically
+    refreshDeps: [client], // Will re-fetch if clientv2 changes
+    manual: !client, // If clientv2 is not available initially, do not run automatically
   });
 
   useEffect(() => {

--- a/packages/ui/src/components/DataStory/DataStory.tsx
+++ b/packages/ui/src/components/DataStory/DataStory.tsx
@@ -50,14 +50,14 @@ export const DataStory = (
     }
   }, [tree]);
 
-  const { data: nodeDescriptions, loading: nodeDescriptionsLoading } = useRequest(async() => {
-    return client
-      ? await client.workspacesApi.getNodeDescriptions({ path })
-      : undefined;
-  }, {
-    refreshDeps: [client], // Will re-fetch if clientv2 changes
-    manual: !client, // If clientv2 is not available initially, do not run automatically
-  });
+  // const { data: nodeDescriptions, loading: nodeDescriptionsLoading } = useRequest(async() => {
+  //   return client
+  //     ? await client.workspacesApi.getNodeDescriptions({ path })
+  //     : undefined;
+  // }, {
+  //   refreshDeps: [client], // Will re-fetch if clientv2 changes
+  //   manual: !client, // If clientv2 is not available initially, do not run automatically
+  // });
 
   useEffect(() => {
     if (sidebarKey !== 'node') {

--- a/packages/ui/src/components/DataStory/DataStory.tsx
+++ b/packages/ui/src/components/DataStory/DataStory.tsx
@@ -50,15 +50,14 @@ export const DataStory = (
     }
   }, [tree]);
 
-  // console.log('tree: ', tree, 'diagram: ', diagram);
-  // const { data: nodeDescriptions, loading: nodeDescriptionsLoading } = useRequest(async() => {
-  //   return client
-  //     ? await client.workspacesApi.getNodeDescriptions({ path })
-  //     : undefined;
-  // }, {
-  //   refreshDeps: [client], // Will re-fetch if clientv2 changes
-  //   manual: !client, // If clientv2 is not available initially, do not run automatically
-  // });
+  const { data: nodeDescriptions, loading: nodeDescriptionsLoading } = useRequest(async() => {
+    return client
+      ? await client.workspacesApi.getNodeDescriptions({ path })
+      : undefined;
+  }, {
+    refreshDeps: [client], // Will re-fetch if clientv2 changes
+    manual: !client, // If clientv2 is not available initially, do not run automatically
+  });
 
   useEffect(() => {
     if (sidebarKey !== 'node') {

--- a/packages/ui/src/components/DataStory/DataStory.tsx
+++ b/packages/ui/src/components/DataStory/DataStory.tsx
@@ -24,24 +24,20 @@ export const DataStory = (
   const partialStoreRef = useRef<Partial<StoreSchema>>(null);
   const { client } = props
   const initDiagramRef = useLatest(props.initDiagram);
-  const [diagram, setDiagram] = useState<Diagram | undefined>(() => {
-    return props.mode === 'Workspace' ? undefined : initDiagramRef.current;
-  });
+  const [diagram, setDiagram] = useState<Diagram | undefined>(undefined);
 
   const { data: tree, loading: treeLoading } = useRequest(async() => {
     return client
       ? await client.workspacesApi.getTree({ path })
-      : undefined;
+      : Promise.resolve(null);
   }, {
     refreshDeps: [client],
     manual: !client,
   });
 
   useEffect(() => {
-    if (props.mode === 'Workspace') {
-      tree && setDiagram(tree.content);
-    }
-  }, [props.mode, tree]);
+    tree && setDiagram(tree.content);
+  }, [tree]);
 
   const { data: nodeDescriptions, loading: nodeDescriptionsLoading } = useRequest(async() => {
     return client
@@ -87,15 +83,17 @@ export const DataStory = (
               onUpdateNodeData={setUpdateSelectedNodeData} onClose={setIsSidebarClose}/>
           </Allotment.Pane>
           <Allotment.Pane minSize={300}>
-            <DataStoryCanvas {...props}
-              treeLoading={treeLoading}
-              initDiagram={diagram}
-              ref={partialStoreRef}
-              setSidebarKey={setSidebarKey}
-              sidebarKey={sidebarKey}
-              selectedNode={selectedNode}
-              selectedNodeData={updateSelectedNodeData}
-              onNodeSelected={setSelectedNode}/>
+            {
+              !treeLoading &&
+              <DataStoryCanvas {...props}
+                initDiagram={diagram}
+                ref={partialStoreRef}
+                setSidebarKey={setSidebarKey}
+                sidebarKey={sidebarKey}
+                selectedNode={selectedNode}
+                selectedNodeData={updateSelectedNodeData}
+                onNodeSelected={setSelectedNode}/>
+            }
           </Allotment.Pane>
         </Allotment>
       </div>

--- a/packages/ui/src/components/DataStory/DataStory.tsx
+++ b/packages/ui/src/components/DataStory/DataStory.tsx
@@ -50,7 +50,7 @@ export const DataStoryComponent = (
   }, [diagramKey, tree]);
 
   useEffect(() => {
-    if (!tree || isSingleFile(tree)) {
+    if (!tree?.length || isSingleFile(tree)) {
       setActivityGroups(ActivityGroups.filter((activity) => activity.id !== 'explorer'));
     } else {
       setActivityGroups(ActivityGroups);

--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -1,5 +1,5 @@
 import { DataStoryControls } from './dataStoryControls';
-import { forwardRef, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { Background, BackgroundVariant, ReactFlow, ReactFlowProvider, } from '@xyflow/react';
 import NodeComponent from '../Node/NodeComponent';
 import { useGetStore, useStore } from './store/store';
@@ -24,18 +24,20 @@ const nodeTypes = {
   tableNodeComponent: TableNodeComponent,
 };
 
-export const DataStoryCanvas = forwardRef((props: DataStoryCanvasProps, ref) => {
+const DataStoryCanvasComponent = forwardRef((props: DataStoryCanvasProps, ref) => {
   useGetStore(ref);
   const showPlaceholder = !props.initDiagram;
 
   return (
     <>
       <ReactFlowProvider>
-        { showPlaceholder ? <Placeholder content={'No diagram found'}/> : <Flow {...props}/> }
+        {showPlaceholder ? <Placeholder content={'No diagram found'}/> : <Flow {...props}/>}
       </ReactFlowProvider>
     </>
   );
 });
+
+export const DataStoryCanvas = React.memo(DataStoryCanvasComponent);
 
 const Flow = ({
   server,
@@ -100,7 +102,7 @@ const Flow = ({
 
   const flowRef = useRef<HTMLDivElement>(null);
 
-  const hotkeyManager =  useMemo(() => new HotkeyManager(flowRef), []);
+  const hotkeyManager = useMemo(() => new HotkeyManager(flowRef), []);
   const setShowRun = useCallback((show: boolean) => setSidebarKey!(show ? 'run' : ''), [setSidebarKey]);
   const setShowAddNode = useCallback((show: boolean) => setSidebarKey!(show ? 'addNode' : ''), [setSidebarKey]);
 

--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -26,13 +26,12 @@ const nodeTypes = {
 
 export const DataStoryCanvas = forwardRef((props: DataStoryCanvasProps, ref) => {
   useGetStore(ref);
-  const showPlaceholder = !props.initDiagram && !props.treeLoading && props.mode === 'Workspace';
-
+  const showPlaceholder = !props.initDiagram;
+  console.log('DataStoryCanvas', props.initDiagram);
   return (
     <>
       <ReactFlowProvider>
-        { showPlaceholder && <Placeholder content={'No diagram found'}/> }
-        <Flow {...props}/>
+        { showPlaceholder ? <Placeholder content={'No diagram found'}/> : <Flow {...props}/> }
       </ReactFlowProvider>
     </>
   );

--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -27,7 +27,7 @@ const nodeTypes = {
 export const DataStoryCanvas = forwardRef((props: DataStoryCanvasProps, ref) => {
   useGetStore(ref);
   const showPlaceholder = !props.initDiagram;
-  console.log('DataStoryCanvas', props.initDiagram);
+
   return (
     <>
       <ReactFlowProvider>

--- a/packages/ui/src/components/DataStory/clients/JsClientV2.tsx
+++ b/packages/ui/src/components/DataStory/clients/JsClientV2.tsx
@@ -8,25 +8,44 @@ export class JsClientV2 {
       return [] as NodeDescription[]
     },
     getTree: async ({ path }) => {
-      const treeJson = localStorage.getItem(path)
-      if(treeJson) return parseDiagramTree(treeJson)
+      // const treeJson = localStorage.getItem(path)
+      // console.log('treeJson', treeJson)
+      // if(treeJson) return parseDiagramTree(treeJson)
 
-      console.log('No tree found at path', path)
+      // console.log('No tree found at path', path)
       // If no tree at path
       // For testing purposes: Persist and return a default tree
       const defaultTree = {
         path: '/',
         type: 'folder',
+        name: '/',
+        id: 'root',
         children: [
           {
+            name: 'main',
+            id: 'main',
             path: '/main',
+            type: 'file',
+            content: new Diagram(),
+          },
+          {
+            name: 'dev',
+            id: 'dev',
+            path: '/dev',
             type: 'file',
             content: new Diagram(),
           }
         ],
       }
+      // single diagram
+      // const singleDiagram = {
+      //   path: '/',
+      //   type: 'file',
+      //   content: new Diagram(),
+      //   children: [],
+      // }
 
-      localStorage.setItem(path, JSON.stringify(defaultTree))
+      // localStorage.setItem(path, JSON.stringify(defaultTree))
       return defaultTree
     },
   } as WorkspacesApi

--- a/packages/ui/src/components/DataStory/clients/JsClientV2.tsx
+++ b/packages/ui/src/components/DataStory/clients/JsClientV2.tsx
@@ -1,13 +1,25 @@
-import { Diagram, get, NodeDescription } from '@data-story/core';
+import { core, Diagram, multiline, NodeDescription, nodes } from '@data-story/core';
 import { WorkspacesApi } from './WorkspacesApi';
-import { parseDiagramTree } from './parseDiagramTree';
+
+export const createDiagram = () => {
+  const { Signal, Comment, Ignore } = nodes;
+
+  const diagram = core.getDiagramBuilder()
+    .add({...Signal, label: 'DataSource'}, { period: 200, count: 100})
+    .add({...Ignore, label: 'Storage'})
+    .above('Signal.1').add(Comment, { content:'### Single Diagram 🔥'})
+    .get();
+
+  return diagram;
+}
 
 export class JsClientV2 {
   workspacesApi: WorkspacesApi = {
-    getNodeDescriptions: async ({ path }) => {
+    getNodeDescriptions: async({ path }) => {
       return [] as NodeDescription[]
     },
-    getTree: async ({ path }) => {
+    getTree: async({ path }) => {
+      const mockDiagram = createDiagram();
       // const treeJson = localStorage.getItem(path)
       // console.log('treeJson', treeJson)
       // if(treeJson) return parseDiagramTree(treeJson)
@@ -26,7 +38,7 @@ export class JsClientV2 {
             id: 'main',
             path: '/main',
             type: 'file',
-            content: new Diagram(),
+            content: mockDiagram,
           },
           {
             name: 'dev',

--- a/packages/ui/src/components/DataStory/clients/JsClientV2.tsx
+++ b/packages/ui/src/components/DataStory/clients/JsClientV2.tsx
@@ -37,13 +37,6 @@ export class JsClientV2 {
           }
         ],
       }
-      // single diagram
-      // const singleDiagram = {
-      //   path: '/',
-      //   type: 'file',
-      //   content: new Diagram(),
-      //   children: [],
-      // }
 
       // localStorage.setItem(path, JSON.stringify(defaultTree))
       return defaultTree

--- a/packages/ui/src/components/DataStory/clients/Tree.ts
+++ b/packages/ui/src/components/DataStory/clients/Tree.ts
@@ -5,4 +5,6 @@ export interface Tree<TreeNodeType = Diagram> {
   type: 'file' | 'folder';
   content?: TreeNodeType;
   children?: Tree[];
+  name: string;
+  id: string;
 }

--- a/packages/ui/src/components/DataStory/clients/WorkspaceApiClient.tsx
+++ b/packages/ui/src/components/DataStory/clients/WorkspaceApiClient.tsx
@@ -1,13 +1,13 @@
 import { core, Diagram, multiline, NodeDescription, nodes } from '@data-story/core';
 import { WorkspacesApi } from './WorkspacesApi';
 
-export const createDiagram = () => {
+export const createDiagram = (content = 'Diagram') => {
   const { Signal, Comment, Ignore } = nodes;
 
   const diagram = core.getDiagramBuilder()
     .add({...Signal, label: 'DataSource'}, { period: 200, count: 100})
     .add({...Ignore, label: 'Storage'})
-    .above('Signal.1').add(Comment, { content:'### Single Diagram 🔥'})
+    .above('Signal.1').add(Comment, { content: `### ${content} 🔥`})
     .get();
 
   return diagram;
@@ -19,7 +19,6 @@ export class WorkspaceApiClient {
       return [] as NodeDescription[]
     },
     getTree: async({ path }) => {
-      const mockDiagram = createDiagram();
       // const treeJson = localStorage.getItem(path)
       // console.log('treeJson', treeJson)
       // if(treeJson) return parseDiagramTree(treeJson)
@@ -27,7 +26,7 @@ export class WorkspaceApiClient {
       // console.log('No tree found at path', path)
       // If no tree at path
       // For testing purposes: Persist and return a default tree
-      const defaultTree = {
+      const defaultTree = [{
         path: '/',
         type: 'folder',
         name: '/',
@@ -38,7 +37,7 @@ export class WorkspaceApiClient {
             id: 'main',
             path: '/main',
             type: 'file',
-            content: mockDiagram,
+            content: createDiagram('main diagram'),
           },
           {
             name: 'dev',
@@ -48,8 +47,15 @@ export class WorkspaceApiClient {
             content: new Diagram(),
           }
         ],
+      },
+      {
+        path: '/branch',
+        type: 'file',
+        id: 'branch',
+        name: 'branch',
+        content: createDiagram(' branch diagram'),
       }
-
+      ];
       // localStorage.setItem(path, JSON.stringify(defaultTree))
       return defaultTree
     },

--- a/packages/ui/src/components/DataStory/clients/WorkspaceApiClient.tsx
+++ b/packages/ui/src/components/DataStory/clients/WorkspaceApiClient.tsx
@@ -13,7 +13,7 @@ export const createDiagram = () => {
   return diagram;
 }
 
-export class JsClientV2 {
+export class WorkspaceApiClient {
   workspacesApi: WorkspacesApi = {
     getNodeDescriptions: async({ path }) => {
       return [] as NodeDescription[]

--- a/packages/ui/src/components/DataStory/clients/WorkspacesApi.ts
+++ b/packages/ui/src/components/DataStory/clients/WorkspacesApi.ts
@@ -2,7 +2,7 @@ import { NodeDescription } from '@data-story/core';
 import { Tree } from './Tree';
 
 export interface WorkspacesApi {
-  getTree: ({ path }) => Promise<Tree>
+  getTree: ({ path }) => Promise<Tree[]>
   createTree: ({ path, tree }: { path: string, tree: Tree }) => Promise<Tree>;
   updateTree: ({ path, tree }: { path: string, tree: Tree }) => Promise<Tree>
   destroyTree: ({ path }: { path: string }) => Promise<void>

--- a/packages/ui/src/components/DataStory/common/method.ts
+++ b/packages/ui/src/components/DataStory/common/method.ts
@@ -1,0 +1,30 @@
+import { Tree } from '../clients/Tree';
+import { Activity } from '../types';
+import { NodeIcon } from '../icons/nodeIcon';
+import { DiagramIcon } from '../icons/diagramIcon';
+import { ConfigIcon } from '../icons/configIcon';
+
+export const path = '/';
+
+export const findFirstFileNode = (tree: Tree): Tree | null => {
+  if (tree.type === 'file') return tree;
+  if (!tree.children || tree?.children?.length === 0) return null;
+
+  for(const child of tree.children) {
+    if (child.type === 'file') return child;
+    return findFirstFileNode(child);
+  }
+  return null;
+}
+
+export const isSingleFile = (tree: Tree): boolean => {
+  if (tree.type === 'file' && (!tree.children || tree?.children?.length === 0)) return true;
+  return false;
+}
+
+export const ActivityGroups: Activity[] = [
+  { id: 'node', name: 'Node Config', icon: NodeIcon, position: 'top' },
+  { id: 'diagram', name: 'Diagram Config', icon: DiagramIcon, position: 'top' },
+  { id: 'settings', name: 'Settings', icon: ConfigIcon, position: 'top' },
+  { id: 'explorer', name: 'Explorer', icon: ConfigIcon, position: 'top' },
+];

--- a/packages/ui/src/components/DataStory/common/method.ts
+++ b/packages/ui/src/components/DataStory/common/method.ts
@@ -17,6 +17,23 @@ export const findFirstFileNode = (tree: Tree): Tree | null => {
   return null;
 }
 
+export const findNodeById = (tree: Tree, id: string): Tree | null => {
+  if (tree.id === id) {
+    return tree;
+  }
+
+  if (tree.type === 'folder' && tree.children) {
+    for (const child of tree.children) {
+      const result = findNodeById(child, id);
+      if (result) {
+        return result;
+      }
+    }
+  }
+
+  return null;
+};
+
 export const isSingleFile = (tree: Tree): boolean => {
   if (tree.type === 'file' && (!tree.children || tree?.children?.length === 0)) return true;
   return false;
@@ -28,3 +45,15 @@ export const ActivityGroups: Activity[] = [
   { id: 'settings', name: 'Settings', icon: ConfigIcon, position: 'top' },
   { id: 'explorer', name: 'Explorer', icon: ConfigIcon, position: 'top' },
 ];
+
+// for debugging.
+export const areEqual = (prevProps, nextProps) => {
+  Object.entries(nextProps).forEach(([key, val]) => {
+    if (prevProps[key] !== val) {
+      console.log(`Prop '${key}' changed DataStory`);
+    }
+  });
+
+  // Returning false means the component will always re-render, primarily for debugging purposes.
+  return false;
+}

--- a/packages/ui/src/components/DataStory/common/method.ts
+++ b/packages/ui/src/components/DataStory/common/method.ts
@@ -6,36 +6,35 @@ import { ConfigIcon } from '../icons/configIcon';
 
 export const path = '/';
 
-export const findFirstFileNode = (tree: Tree): Tree | null => {
-  if (tree.type === 'file') return tree;
-  if (!tree.children || tree?.children?.length === 0) return null;
+export const findFirstFileNode = (tree: Tree[]): Tree | null => {
+  for(const node of tree) {
+    if (node.type === 'file') return node;
 
-  for(const child of tree.children) {
-    if (child.type === 'file') return child;
-    return findFirstFileNode(child);
+    if(node.type === 'folder' && node.children) {
+      const found = findFirstFileNode(node.children);
+      if (found) return found;
+    }
   }
   return null;
 }
 
-export const findNodeById = (tree: Tree, id: string): Tree | null => {
-  if (tree.id === id) {
-    return tree;
-  }
+export const findNodeById = (tree: Tree[], id: string): Tree | null => {
+  for (const node of tree) {
+    if (node.id === id) {
+      return node;
+    }
 
-  if (tree.type === 'folder' && tree.children) {
-    for (const child of tree.children) {
-      const result = findNodeById(child, id);
-      if (result) {
-        return result;
-      }
+    if (node.type === 'folder' && node.children) {
+      const found = findNodeById(node.children, id);
+      if (found) return found;
     }
   }
 
   return null;
 };
 
-export const isSingleFile = (tree: Tree): boolean => {
-  if (tree.type === 'file' && (!tree.children || tree?.children?.length === 0)) return true;
+export const isSingleFile = (trees: Tree[]): boolean => {
+  if (trees.length === 1 && trees[0].type === 'file') return true;
   return false;
 }
 

--- a/packages/ui/src/components/DataStory/sidebar/activityBar.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/activityBar.tsx
@@ -1,33 +1,19 @@
 import React, { useEffect } from 'react';
 import { ReactFlowNode } from '../../Node/ReactFlowNode';
-import { DiagramIcon } from '../icons/diagramIcon';
-import { ConfigIcon } from '../icons/configIcon';
-import { NodeIcon } from '../icons/nodeIcon';
-
-type Activity = {
-  id: string;
-  name: string;
-  icon: React.FC<{}>;
-  position: 'top' | 'bottom';
-};
-
-const activityGroups: Activity[] = [
-  { id: 'node', name: 'Node Config', icon: NodeIcon, position: 'top' },
-  { id: 'diagram', name: 'Diagram Config', icon: DiagramIcon, position: 'top' },
-  { id: 'settings', name: 'Settings', icon: ConfigIcon, position: 'top' },
-  { id: 'experiment', name: 'Experiment', icon: ConfigIcon, position: 'top' },
-]
+import { Activity } from '../types';
 
 export const ActivityBar = ({
   setActiveKey,
   onClose,
   activeKey,
   selectedNode,
+  activityGroups,
 }: {
   onClose: React.Dispatch<React.SetStateAction<boolean>>;
   setActiveKey: (activity: string) => void;
   activeKey: string;
   selectedNode?: ReactFlowNode;
+  activityGroups: Activity[];
 }) => {
   const handleActivityClick = (id: string) => {
     // 1. when click the same activity, switch sidebar status

--- a/packages/ui/src/components/DataStory/sidebar/activityBar.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/activityBar.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect } from 'react';
+import React, { memo, useEffect } from 'react';
 import { ReactFlowNode } from '../../Node/ReactFlowNode';
 import { Activity } from '../types';
 
-export const ActivityBar = ({
+export const ActivityBarComponent = ({
   setActiveKey,
   onClose,
   activeKey,
@@ -63,3 +63,5 @@ export const ActivityBar = ({
     </aside>
   );
 };
+
+export const ActivityBar = React.memo(ActivityBarComponent)

--- a/packages/ui/src/components/DataStory/sidebar/explorer.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/explorer.tsx
@@ -33,25 +33,27 @@ export const Explorer = ({
 }: {
   tree?: Tree,
 }) => {
+  if (!tree || tree.type !== 'folder') {
+    return <Placeholder content={'No data available'}/>;
+  }
+
   return (
     <div className="h-full">
       <div className="uppercase text-xs px-8 py-2 text-gray-600">
         Explorer
       </div>
-      {tree
-        ? <div className="px-2 py-2">
-          <ArboristTree
-            initialData={[tree]}
-            openByDefault={true}
-            width={600}
-            height={1000}
-            indent={18}
-            rowHeight={24}
-          >
-            {Node}
-          </ArboristTree>
-        </div>
-        :  <Placeholder content={'No data available'}/>}
+      <div className="px-2 py-2">
+        <ArboristTree
+          initialData={[tree]}
+          openByDefault={true}
+          width={600}
+          height={1000}
+          indent={18}
+          rowHeight={24}
+        >
+          {Node}
+        </ArboristTree>
+      </div>
     </div>
   );
 };

--- a/packages/ui/src/components/DataStory/sidebar/explorer.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/explorer.tsx
@@ -33,7 +33,7 @@ export const Explorer = ({
 }: {
   tree?: Tree,
 }) => {
-  if (!tree || tree.type !== 'folder') {
+  if (!tree || tree.type === 'file') {
     return <Placeholder content={'No data available'}/>;
   }
 

--- a/packages/ui/src/components/DataStory/sidebar/explorer.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/explorer.tsx
@@ -1,11 +1,12 @@
-import { NodeRendererProps, Tree as ArboristTree } from 'react-arborist';
+import { NodeApi, NodeRendererProps, Tree as ArboristTree } from 'react-arborist';
 import { ChevronRight } from '../icons/chevronRight';
 import { ChevronDown } from '../icons/chevronDown';
 import { LogoIcon } from '../icons/logoIcon';
 import { Tree } from '../clients/Tree';
 import { Placeholder } from '../common/placeholder';
+import { Dispatch, SetStateAction } from 'react';
 
-function Node({ node, style, dragHandle }: NodeRendererProps<any>) {
+function Node({ node, style, dragHandle }: NodeRendererProps<Tree>) {
   const Icon = node.isOpen ? ChevronDown : (node.isLeaf ? LogoIcon : ChevronRight);
   const isActualRoot = node.data.id === 'fake-project';
 
@@ -29,12 +30,17 @@ function Node({ node, style, dragHandle }: NodeRendererProps<any>) {
 }
 
 export const Explorer = ({
-  tree
+  tree, setDiagramKey
 }: {
   tree?: Tree,
+  setDiagramKey: Dispatch<SetStateAction<string | undefined>>
 }) => {
   if (!tree || tree.type === 'file') {
     return <Placeholder content={'No data available'}/>;
+  }
+  const handleClick = (node:  NodeApi<Tree>) =>  {
+    console.log('handle click', node);
+    setDiagramKey(node.id);
   }
 
   return (
@@ -50,6 +56,7 @@ export const Explorer = ({
           height={1000}
           indent={18}
           rowHeight={24}
+          onActivate={handleClick}
         >
           {Node}
         </ArboristTree>

--- a/packages/ui/src/components/DataStory/sidebar/explorer.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/explorer.tsx
@@ -4,7 +4,7 @@ import { ChevronDown } from '../icons/chevronDown';
 import { LogoIcon } from '../icons/logoIcon';
 import { Tree } from '../clients/Tree';
 import { Placeholder } from '../common/placeholder';
-import { Dispatch, SetStateAction } from 'react';
+import { NodeSettingsSidebarProps } from '../types';
 
 function Node({ node, style, dragHandle }: NodeRendererProps<Tree>) {
   const Icon = node.isOpen ? ChevronDown : (node.isLeaf ? LogoIcon : ChevronRight);
@@ -31,15 +31,12 @@ function Node({ node, style, dragHandle }: NodeRendererProps<Tree>) {
 
 export const Explorer = ({
   tree, setDiagramKey
-}: {
-  tree?: Tree,
-  setDiagramKey: Dispatch<SetStateAction<string | undefined>>
-}) => {
+}: Pick<NodeSettingsSidebarProps, 'tree' | 'setDiagram' | 'setDiagramKey'>
+) => {
   if (!tree || tree.type === 'file') {
     return <Placeholder content={'No data available'}/>;
   }
   const handleClick = (node:  NodeApi<Tree>) =>  {
-    console.log('handle click', node);
     setDiagramKey(node.id);
   }
 

--- a/packages/ui/src/components/DataStory/sidebar/explorer.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/explorer.tsx
@@ -3,7 +3,6 @@ import { ChevronRight } from '../icons/chevronRight';
 import { ChevronDown } from '../icons/chevronDown';
 import { LogoIcon } from '../icons/logoIcon';
 import { Tree } from '../clients/Tree';
-import { Placeholder } from '../common/placeholder';
 import { NodeSettingsSidebarProps } from '../types';
 
 function Node({ node, style, dragHandle }: NodeRendererProps<Tree>) {
@@ -30,11 +29,12 @@ function Node({ node, style, dragHandle }: NodeRendererProps<Tree>) {
 }
 
 export const Explorer = ({
-  tree, setDiagramKey
+  tree, setDiagramKey, setDiagram
 }: Pick<NodeSettingsSidebarProps, 'tree' | 'setDiagram' | 'setDiagramKey'>
 ) => {
   const handleClick = (node:  NodeApi<Tree>) =>  {
     setDiagramKey(node.id);
+    setDiagram(node?.data.content ?? null);
   }
 
   return (

--- a/packages/ui/src/components/DataStory/sidebar/explorer.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/explorer.tsx
@@ -33,23 +33,6 @@ export const Explorer = ({
 }: {
   tree?: Tree,
 }) => {
-  const data = [
-    {
-      id: 'fake-project',
-      name: 'fake-project',
-      children: [
-        {
-          id: 'nodes',
-          name: 'nodes',
-          children: [
-            { id: 'todos.get', name: 'todos.get' },
-          ],
-        },
-        { id: 'main', name: 'main' },
-      ]
-    },
-  ];
-
   return (
     <div className="h-full">
       <div className="uppercase text-xs px-8 py-2 text-gray-600">
@@ -58,7 +41,7 @@ export const Explorer = ({
       {tree
         ? <div className="px-2 py-2">
           <ArboristTree
-            initialData={data}
+            initialData={[tree]}
             openByDefault={true}
             width={600}
             height={1000}
@@ -69,7 +52,6 @@ export const Explorer = ({
           </ArboristTree>
         </div>
         :  <Placeholder content={'No data available'}/>}
-
     </div>
   );
 };

--- a/packages/ui/src/components/DataStory/sidebar/explorer.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/explorer.tsx
@@ -33,9 +33,6 @@ export const Explorer = ({
   tree, setDiagramKey
 }: Pick<NodeSettingsSidebarProps, 'tree' | 'setDiagram' | 'setDiagramKey'>
 ) => {
-  if (!tree || tree.type === 'file') {
-    return <Placeholder content={'No data available'}/>;
-  }
   const handleClick = (node:  NodeApi<Tree>) =>  {
     setDiagramKey(node.id);
   }
@@ -47,7 +44,7 @@ export const Explorer = ({
       </div>
       <div className="px-2 py-2">
         <ArboristTree
-          initialData={[tree]}
+          initialData={tree}
           openByDefault={true}
           width={600}
           height={1000}

--- a/packages/ui/src/components/DataStory/sidebar/sidebar.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/sidebar.tsx
@@ -9,7 +9,7 @@ import { AddNode } from './addNode';
 export const Sidebar = (props: NodeSettingsSidebarProps) => {
   const {
     tree, node, onClose, onUpdateNodeData, sidebarKey, setSidebarKey,
-    partialStoreRef, treeLoading
+    partialStoreRef
   } = props;
 
   const renderContent = () => {

--- a/packages/ui/src/components/DataStory/sidebar/sidebar.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/sidebar.tsx
@@ -23,7 +23,7 @@ export const Sidebar = (props: NodeSettingsSidebarProps) => {
           availableNodes={partialStoreRef.current?.availableNodes || []}
           addNodeFromDescription={(nodeDescription: NodeDescription) => partialStoreRef.current?.addNodeFromDescription?.(nodeDescription)}
           setSidebarKey={setSidebarKey}/>;
-      case 'experiment':
+      case 'explorer':
         return <Explorer tree={tree} />;
       case 'diagram':
         return <Placeholder content={'todo: show diagram configuration'}/>;

--- a/packages/ui/src/components/DataStory/sidebar/sidebar.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/sidebar.tsx
@@ -5,11 +5,12 @@ import { Placeholder } from '../common/placeholder';
 import { NodeDescription } from '@data-story/core';
 import { Run } from './run';
 import { AddNode } from './addNode';
+import React from 'react';
 
-export const Sidebar = (props: NodeSettingsSidebarProps) => {
+const SidebarComponent = (props: NodeSettingsSidebarProps) => {
   const {
     tree, node, onClose, onUpdateNodeData, sidebarKey, setSidebarKey,
-    partialStoreRef
+    partialStoreRef, setDiagramKey
   } = props;
 
   const renderContent = () => {
@@ -24,7 +25,7 @@ export const Sidebar = (props: NodeSettingsSidebarProps) => {
           addNodeFromDescription={(nodeDescription: NodeDescription) => partialStoreRef.current?.addNodeFromDescription?.(nodeDescription)}
           setSidebarKey={setSidebarKey}/>;
       case 'explorer':
-        return <Explorer tree={tree} />;
+        return <Explorer tree={tree} setDiagramKey={setDiagramKey} />;
       case 'diagram':
         return <Placeholder content={'todo: show diagram configuration'}/>;
       case 'settings':
@@ -44,3 +45,5 @@ export const Sidebar = (props: NodeSettingsSidebarProps) => {
     </div>
   );
 }
+
+export const Sidebar = React.memo(SidebarComponent)

--- a/packages/ui/src/components/DataStory/sidebar/sidebar.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/sidebar.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 const SidebarComponent = (props: NodeSettingsSidebarProps) => {
   const {
     tree, node, onClose, onUpdateNodeData, sidebarKey, setSidebarKey,
-    partialStoreRef, setDiagramKey
+    partialStoreRef, setDiagramKey, setDiagram
   } = props;
 
   const renderContent = () => {
@@ -25,7 +25,7 @@ const SidebarComponent = (props: NodeSettingsSidebarProps) => {
           addNodeFromDescription={(nodeDescription: NodeDescription) => partialStoreRef.current?.addNodeFromDescription?.(nodeDescription)}
           setSidebarKey={setSidebarKey}/>;
       case 'explorer':
-        return <Explorer tree={tree} setDiagramKey={setDiagramKey} />;
+        return <Explorer tree={tree} setDiagram={setDiagram} setDiagramKey={setDiagramKey} />;
       case 'diagram':
         return <Placeholder content={'todo: show diagram configuration'}/>;
       case 'settings':

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -48,7 +48,7 @@ export type SocketClientOptions = ClientOptions & {
 }
 
 export type DataStoryProps = {
-  clientv2?: JsClientV2,
+  client?: JsClientV2,
   server?: ServerConfig
   initDiagram?: Diagram
   hideControls?: boolean

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -50,8 +50,8 @@ export type SocketClientOptions = ClientOptions & {
 
 export type DataStoryProps = {
   client?: JsClientV2,
-  server?: ServerConfig
-  initDiagram?: Diagram
+  server?: ServerConfig;
+  initDiagram?: Diagram | null;
   hideControls?: boolean
   slotComponents?: React.ReactNode[];
   observers?: DataStoryObservers;
@@ -158,11 +158,12 @@ export type StoreSchema = {
 export type NodeSettingsSidebarProps = Omit<NodeSettingsFormProps, 'node'> & {
   tree?: Tree;
   activeBar?: string;
-  setDiagramKey: Dispatch<SetStateAction<string | undefined>> ;
+  setDiagramKey: Dispatch<SetStateAction<string | undefined>>;
   sidebarKey: string;
   node?: ReactFlowNode;
   setSidebarKey: React.Dispatch<React.SetStateAction<string>>;
   partialStoreRef: React.RefObject<Partial<StoreSchema>>;
+  setDiagram?: React.Dispatch<React.SetStateAction<Diagram | null>>
 };
 
 export type Activity = {

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -156,7 +156,7 @@ export type StoreSchema = {
   setObservers: (key: string, observers?: DataStoryObservers) => void;
 };
 export type NodeSettingsSidebarProps = Omit<NodeSettingsFormProps, 'node'> & {
-  tree?: Tree;
+  tree?: Tree[];
   activeBar?: string;
   setDiagramKey: Dispatch<SetStateAction<string | undefined>>;
   sidebarKey: string;

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -163,7 +163,7 @@ export type NodeSettingsSidebarProps = Omit<NodeSettingsFormProps, 'node'> & {
   node?: ReactFlowNode;
   setSidebarKey: React.Dispatch<React.SetStateAction<string>>;
   partialStoreRef: React.RefObject<Partial<StoreSchema>>;
-  setDiagram?: React.Dispatch<React.SetStateAction<Diagram | null>>
+  setDiagram: React.Dispatch<React.SetStateAction<Diagram | null>>
 };
 
 export type Activity = {

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -14,7 +14,7 @@ import { ReactFlowNode } from '../Node/ReactFlowNode';
 import { Edge, OnConnect, OnEdgesChange, OnNodesChange, ReactFlowInstance } from '@xyflow/react';
 import { Direction } from './getNodesWithNewSelection';
 import { ServerClient } from './clients/ServerClient';
-import { JsClientV2 } from './clients/JsClientV2';
+import { WorkspaceApiClient } from './clients/WorkspaceApiClient';
 import { Tree } from './clients/Tree';
 import React, { Dispatch, SetStateAction } from 'react';
 
@@ -49,7 +49,7 @@ export type SocketClientOptions = ClientOptions & {
 }
 
 export type DataStoryProps = {
-  client?: JsClientV2,
+  client?: WorkspaceApiClient,
   server?: ServerConfig;
   initDiagram?: Diagram | null;
   hideControls?: boolean
@@ -74,7 +74,7 @@ export type DataStoryCanvasProps = {
 export type StoreInitOptions = {
   rfInstance: ReactFlowInstance<ReactFlowNode, Edge<Record<string, unknown>, string | undefined>>,
   server?: ServerConfig,
-  initDiagram?: Diagram,
+  initDiagram?: Diagram | null,
   callback?: DataStoryCallback,
 }
 

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -16,6 +16,7 @@ import { Direction } from './getNodesWithNewSelection';
 import { ServerClient } from './clients/ServerClient';
 import { JsClientV2 } from './clients/JsClientV2';
 import { Tree } from './clients/Tree';
+import React from 'react';
 
 export type DataStoryCallback = (options: {run: () => void}) => void;
 
@@ -156,7 +157,6 @@ export type StoreSchema = {
 };
 export type NodeSettingsSidebarProps = Omit<NodeSettingsFormProps, 'node'> & {
   tree?: Tree;
-  treeLoading?: boolean;
   activeBar?: string;
   sidebarKey: string;
   node?: ReactFlowNode;
@@ -164,6 +164,9 @@ export type NodeSettingsSidebarProps = Omit<NodeSettingsFormProps, 'node'> & {
   partialStoreRef: React.RefObject<Partial<StoreSchema>>;
 };
 
-export type IconProps = {
-  isActive?: boolean;
+export type Activity = {
+  id: string;
+  name: string;
+  icon: React.FC<{}>;
+  position: 'top' | 'bottom';
 };

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -16,7 +16,7 @@ import { Direction } from './getNodesWithNewSelection';
 import { ServerClient } from './clients/ServerClient';
 import { JsClientV2 } from './clients/JsClientV2';
 import { Tree } from './clients/Tree';
-import React from 'react';
+import React, { Dispatch, SetStateAction } from 'react';
 
 export type DataStoryCallback = (options: {run: () => void}) => void;
 
@@ -158,6 +158,7 @@ export type StoreSchema = {
 export type NodeSettingsSidebarProps = Omit<NodeSettingsFormProps, 'node'> & {
   tree?: Tree;
   activeBar?: string;
+  setDiagramKey: Dispatch<SetStateAction<string | undefined>> ;
   sidebarKey: string;
   node?: ReactFlowNode;
   setSidebarKey: React.Dispatch<React.SetStateAction<string>>;

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -59,7 +59,6 @@ export type DataStoryProps = {
   onSave?: () => void;
   hideSidebar?: boolean;
   hideActivityBar?: boolean;
-  mode?: 'Workspace' | 'Single';
 }
 
 export type DataStoryCanvasProps = {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -8,5 +8,6 @@ export { DataStoryEvents, type DataStoryEventType } from './components/DataStory
 export type { DataStoryObservers } from './components/DataStory/types'
 export { Explorer } from './components/DataStory/sidebar/explorer';
 export { default as NodeComponent } from './components/Node/NodeComponent';
-export { JsClientV2 } from './components/DataStory/clients/JsClientV2';
+export { WorkspaceApiClient } from './components/DataStory/clients/WorkspaceApiClient';
 export type { WorkspacesApi } from './components/DataStory/clients/WorkspacesApi';
+export type { ServerConfig } from './components/DataStory/clients/ServerConfig';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -9,3 +9,4 @@ export type { DataStoryObservers } from './components/DataStory/types'
 export { Explorer } from './components/DataStory/sidebar/explorer';
 export { default as NodeComponent } from './components/Node/NodeComponent';
 export { JsClientV2 } from './components/DataStory/clients/JsClientV2';
+export type { WorkspacesApi } from './components/DataStory/clients/WorkspacesApi';


### PR DESCRIPTION
- feat: Implement support for multiple diagrams (workspace) in DataStory and sidebar switching


https://github.com/user-attachments/assets/d26a4bd3-16e4-43ea-87ca-1d58201b25bb


- feat: change tree structure from object to array
- feat: address PR #262  comments and feedback from discussions
