### PR TITLE
Prepare removal of server prop

### DIFF
--- a/packages/docs/components/Playground.tsx
+++ b/packages/docs/components/Playground.tsx
@@ -2,17 +2,10 @@
 
 import { Application, coreNodeProvider, Diagram } from '@data-story/core';
 import React, { useMemo } from 'react';
-import { DataStory, WorkspaceApiClient, ServerConfig } from '@data-story/ui';
+import { DataStory, WorkspaceApiClient } from '@data-story/ui';
 import { loadDiagram, LocalStorageKey, SaveComponent } from './Save';
-import { ServerRequest } from '../const';
 
 export default Playground;
-
-function getServer(mode: 'js' | 'node', app: Application): ServerConfig {
-  return mode === 'node'
-    ? { type: 'SOCKET', url: ServerRequest }
-    : { type: 'JS', app };
-}
 
 const app = new Application()
   .register(coreNodeProvider)
@@ -21,10 +14,8 @@ const app = new Application()
 function Playground({ mode }: {mode?: 'js' | 'node'}) {
   const { diagram } = loadDiagram(LocalStorageKey);
   const [initDiagram] = React.useState<Diagram>(diagram);
-  const [saveDiagram, setSaveDiagram] = React.useState<() => void>(() => {
-  });
+  const [saveDiagram, setSaveDiagram] = React.useState<() => void>(() => {});
   const client = useMemo(() => new WorkspaceApiClient(), []);
-  const server = useMemo(() => getServer(mode, app), [mode])
 
   return (
     <div className="w-full" style={{ height: 'calc(100vh - 72px)' }} data-cy="playground">
@@ -38,7 +29,7 @@ function Playground({ mode }: {mode?: 'js' | 'node'}) {
           <SaveComponent setSaveDiagram={setSaveDiagram}/>,
         ]}
         initDiagram={initDiagram}
-        server={server}
+        server={{ type: 'JS', app }}
       />
     </div>
   );

--- a/packages/docs/components/demos/ObserversDemo.tsx
+++ b/packages/docs/components/demos/ObserversDemo.tsx
@@ -25,9 +25,7 @@ export default ({ mode, observers }:
       <DataStory
         client={client}
         observers={observers}
-        server={mode === 'node'
-          ? { type: 'SOCKET', url: ServerRequest }
-          : { type: 'JS', app }}
+        server={{ type: 'JS', app }}
       />
     </div>
   );

--- a/packages/docs/pages/getting-started.mdx
+++ b/packages/docs/pages/getting-started.mdx
@@ -20,23 +20,3 @@ export default function Home() {
 
 > With this basic usage, you will get all available nodes in `@data-story/core` and an inline JS server.
 
-### Usage with NodeJS
-First, also install:
-```bash
-yarn add @data-story/nodejs
-```
-
-Then, when using the component, instruct it to listen on a websocket:
-```tsx
-<DataStory
-  server={{ type: 'SOCKET', url: 'ws://localhost:3300' }}
-/>
-```
-
-Finally, start a server:
-```bash
-npx @data-story/nodejs server
-```
-
-
-

--- a/packages/docs/pages/local.tsx
+++ b/packages/docs/pages/local.tsx
@@ -1,8 +1,0 @@
-import { DataStory } from '@data-story/ui';
-import { ServerRequest } from '../const';
-
-export default function Home() {
-  return <div className="w-full" style={{ height: '100vh' }}>
-    <DataStory server={{type: 'SOCKET', url: ServerRequest }} />
-  </div>
-}

--- a/packages/ui/src/components/DataStory/store/store.tsx
+++ b/packages/ui/src/components/DataStory/store/store.tsx
@@ -136,10 +136,7 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
 
   onInit: (options: StoreInitOptions) => {
     set({
-      serverConfig: options.server || {
-        type: 'SOCKET',
-        url: 'ws://localhost:3100'
-      }
+      serverConfig: options.server
     })
 
     set({ rfInstance: options.rfInstance })

--- a/packages/ui/src/components/DataStory/store/store.tsx
+++ b/packages/ui/src/components/DataStory/store/store.tsx
@@ -24,7 +24,7 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
   nodes: [],
   edges: [],
   params: [],
-  server: null,
+  serverClient: null,
   availableNodes: [],
   openNodeSidebarId: null,
   observerMap: new Map(),
@@ -146,7 +146,7 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
 
     if (options.callback) {
       const run = () => {
-        get().server?.run(
+        get().serverClient?.run(
           get().toDiagram(),
           // TODO this does not work?!
           createObservers(get().observerMap)
@@ -169,7 +169,7 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
   onRun: () => {
     const observers = createObservers(get().observerMap);
 
-    get().server!.run(
+    get().serverClient!.run(
       get().toDiagram(),
       observers,
     )
@@ -182,7 +182,7 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
         app: serverConfig.app,
       })
 
-      set({ server })
+      set({ serverClient: server })
       server.init()
     }
 
@@ -193,7 +193,7 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
         serverConfig: serverConfig as WebSocketServerConfig,
       })
 
-      set({ server })
+      set({ serverClient: server })
       server.init()
     }
   },

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -135,7 +135,7 @@ export type StoreSchema = {
 
   /** The Server and its config */
   serverConfig: ServerConfig;
-  server: null | ServerClient;
+  serverClient: null | ServerClient;
   initServer: StoreInitServer;
 
   /** When DataStory component initializes */


### PR DESCRIPTION
Going forward the `<DataStory />` component will be controlled using a `client`. Therefore, this PR aims to prepare removal of current `server` prop.