### PR TITLE
ActivityBar cleanup

### DIFF
--- a/packages/ui/src/components/DataStory/common/method.ts
+++ b/packages/ui/src/components/DataStory/common/method.ts
@@ -41,8 +41,6 @@ export const isSingleFile = (trees: Tree[]): boolean => {
 
 export const ActivityGroups: Activity[] = [
   { id: 'explorer', name: 'Explorer', icon: ExplorerIcon, position: 'top' },
-  { id: 'node', name: 'Node Config', icon: NodeIcon, position: 'top' },
-  { id: 'diagram', name: 'Diagram Config', icon: DiagramIcon, position: 'top' },
   { id: 'settings', name: 'Settings', icon: ConfigIcon, position: 'top' },
 ];
 

--- a/packages/ui/src/components/DataStory/common/method.ts
+++ b/packages/ui/src/components/DataStory/common/method.ts
@@ -40,10 +40,10 @@ export const isSingleFile = (trees: Tree[]): boolean => {
 }
 
 export const ActivityGroups: Activity[] = [
+  { id: 'explorer', name: 'Explorer', icon: ExplorerIcon, position: 'top' },
   { id: 'node', name: 'Node Config', icon: NodeIcon, position: 'top' },
   { id: 'diagram', name: 'Diagram Config', icon: DiagramIcon, position: 'top' },
   { id: 'settings', name: 'Settings', icon: ConfigIcon, position: 'top' },
-  { id: 'explorer', name: 'Explorer', icon: ExplorerIcon, position: 'top' },
 ];
 
 // for debugging.


### PR DESCRIPTION
* Moves Explorer activity button up top to mimic VS Code
* Removes NodeConfig as this is a concern of a single diagram, it should be accessed via the canvas (or canvas control)
* Removes DiagramConfig with same reasoning as above