### PR TITLE
feat: replace `JsClient` with `WorkspaceApiClient` in `run` function

### DIFF
--- a/packages/docs/components/Playground.tsx
+++ b/packages/docs/components/Playground.tsx
@@ -2,7 +2,7 @@
 
 import { Application, coreNodeProvider, Diagram } from '@data-story/core';
 import React, { useMemo } from 'react';
-import { DataStory, WorkspaceApiClient, WorkspaceSocketClient } from '@data-story/ui';
+import { DataStory, DataStoryEvents, eventManager, WorkspaceApiClient, WorkspaceSocketClient } from '@data-story/ui';
 import { loadDiagram, LocalStorageKey, SaveComponent } from './Save';
 
 export default Playground;

--- a/packages/docs/components/Playground.tsx
+++ b/packages/docs/components/Playground.tsx
@@ -30,7 +30,7 @@ function Playground({ mode }: {mode?: 'js' | 'node'}) {
           <SaveComponent setSaveDiagram={setSaveDiagram}/>,
         ]}
         initDiagram={initDiagram}
-        server={{ type: 'JS', app }}
+        server={{ type: 'JS', app: null }}
         initSidebarKey="explorer"
       />
     </div>

--- a/packages/docs/components/Playground.tsx
+++ b/packages/docs/components/Playground.tsx
@@ -25,7 +25,7 @@ function Playground({ mode }: {mode?: 'js' | 'node'}) {
     <div className="w-full" style={{ height: 'calc(100vh - 72px)' }} data-cy="playground">
       <DataStory
         onSave={saveDiagram}
-        client={client}
+        client={client as WorkspaceApiClient}
         slotComponents={[
           <SaveComponent setSaveDiagram={setSaveDiagram}/>,
         ]}

--- a/packages/docs/components/demos/UnfoldingDemo.tsx
+++ b/packages/docs/components/demos/UnfoldingDemo.tsx
@@ -64,9 +64,9 @@ export default ({ part }: { part: 'MAIN' | 'NESTED_NODE' | 'MAIN_UNFOLDED'}) => 
     nestedNodes
   ).unfold();
 
-  const mainClient = new MockJSClient(diagram);
-  const mainUnfoldedClient = new MockJSClient(unfolded.diagram);
-  const nestedNodeClient = new MockJSClient(nestedNode);
+  const mainClient = new MockJSClient(diagram, app);
+  const mainUnfoldedClient = new MockJSClient(unfolded.diagram, app);
+  const nestedNodeClient = new MockJSClient(nestedNode, app);
 
   // *************************************
   // Render requested part

--- a/packages/docs/components/splash/MockJSClient.tsx
+++ b/packages/docs/components/splash/MockJSClient.tsx
@@ -1,12 +1,12 @@
-import { Diagram, NodeDescription } from '@data-story/core';
+import { Application, Diagram, NodeDescription } from '@data-story/core';
 import { WorkspaceApiClient, WorkspacesApi } from '@data-story/ui';
 
 export class MockJSClient extends WorkspaceApiClient {
   private diagram: Diagram;
   private nodeDescriptions: NodeDescription[];
 
-  constructor(diagram?: Diagram, nodeDescriptions?: NodeDescription[]) {
-    super();
+  constructor(diagram?: Diagram, app?: Application, nodeDescriptions?: NodeDescription[]) {
+    super(app);
     this.diagram = diagram ?? new Diagram();
     this.nodeDescriptions = nodeDescriptions || [];
   }

--- a/packages/docs/components/splash/MockJSClient.tsx
+++ b/packages/docs/components/splash/MockJSClient.tsx
@@ -1,11 +1,12 @@
 import { Diagram, NodeDescription } from '@data-story/core';
-import { WorkspacesApi } from '@data-story/ui';
+import { WorkspaceApiClient, WorkspacesApi } from '@data-story/ui';
 
-export class MockJSClient {
+export class MockJSClient extends WorkspaceApiClient {
   private diagram: Diagram;
   private nodeDescriptions: NodeDescription[];
 
   constructor(diagram?: Diagram, nodeDescriptions?: NodeDescription[]) {
+    super();
     this.diagram = diagram ?? new Diagram();
     this.nodeDescriptions = nodeDescriptions || [];
   }

--- a/packages/ui/src/components/DataStory/DataStory.tsx
+++ b/packages/ui/src/components/DataStory/DataStory.tsx
@@ -43,6 +43,16 @@ export const DataStoryComponent = (
   }, []);
   handleRequestError(getTreeError);
 
+  const { data: nodeDescriptions, loading: nodeDescriptionsLoading, error: getNodeDescriptionsError } = useRequest(async() => {
+    return client
+      ? await client.workspacesApi.getNodeDescriptions({ path })
+      : undefined;
+  }, {
+    refreshDeps: [client], // Will re-fetch if client changes
+    manual: !client, // If client is not available initially, do not run automatically
+  });
+  handleRequestError(getNodeDescriptionsError);
+
   const handleClickExplorerNode = useCallback((node:  NodeApi<Tree>) => {
     // store the diagram in the Ref before changing the diagramKey
     if (diagramKey) {
@@ -73,16 +83,6 @@ export const DataStoryComponent = (
       setActivityGroups(ActivityGroups);
     }
   }, [tree]);
-
-  const { data: nodeDescriptions, loading: nodeDescriptionsLoading, error: getNodeDescriptionsError } = useRequest(async() => {
-    return client
-      ? await client.workspacesApi.getNodeDescriptions({ path })
-      : undefined;
-  }, {
-    refreshDeps: [client], // Will re-fetch if client changes
-    manual: !client, // If client is not available initially, do not run automatically
-  });
-  handleRequestError(getNodeDescriptionsError);
 
   useEffect(() => {
     if (sidebarKey !== 'node') {

--- a/packages/ui/src/components/DataStory/DataStory.tsx
+++ b/packages/ui/src/components/DataStory/DataStory.tsx
@@ -11,12 +11,12 @@ import { DataStoryCanvas } from './DataStoryCanvas';
 import { useRequest } from 'ahooks';
 import { LoadingMask } from './common/loadingMask';
 import { Diagram } from '@data-story/core';
-import { ActivityGroups, areEqual, findFirstFileNode, path } from './common/method';
+import { ActivityGroups, findFirstFileNode, path } from './common/method';
 import { NodeApi } from 'react-arborist';
 import { Tree } from '@data-story/core';
 
 function handleRequestError(requestError?: Error): void {
-  if (requestError) console.error(`Error fetching : ${requestError?.message}` );
+  if (requestError) console.error(`Error fetching : ${requestError?.message}`);
 }
 
 export const DataStoryComponent = (
@@ -36,14 +36,18 @@ export const DataStoryComponent = (
   const { data: tree, loading: treeLoading, error: getTreeError } = useRequest(async() => {
     return client
       ? await client.workspacesApi.getTree({ path })
-      : Promise.resolve(undefined);
+      : Promise.resolve([]);
   }, {
     refreshDeps: [client],
     manual: !client,
   }, []);
   handleRequestError(getTreeError);
 
-  const { data: nodeDescriptions, loading: nodeDescriptionsLoading, error: getNodeDescriptionsError } = useRequest(async() => {
+  const {
+    data: nodeDescriptions,
+    loading: nodeDescriptionsLoading,
+    error: getNodeDescriptionsError
+  } = useRequest(async() => {
     return client
       ? await client.workspacesApi.getNodeDescriptions({ path })
       : undefined;
@@ -53,11 +57,12 @@ export const DataStoryComponent = (
   });
   handleRequestError(getNodeDescriptionsError);
 
-  const handleClickExplorerNode = useCallback((node:  NodeApi<Tree>) => {
+  const handleClickExplorerNode = useCallback((node: NodeApi<Tree>) => {
     // store the diagram in the Ref before changing the diagramKey
     if (diagramKey) {
       diagramMapRef.current.set(diagramKey, partialStoreRef?.current?.toDiagram?.() ?? null)
-    };
+    }
+    ;
 
     if (node.isLeaf) {
       setDiagramKey(node.id);
@@ -75,7 +80,7 @@ export const DataStoryComponent = (
   }, [tree]);
 
   useEffect(() => {
-    if(!tree?.length) {
+    if (!tree?.length) {
       setActivityGroups([]);
     } else if (Array.isArray(props.hideActivityBar) && props.hideActivityBar.length) {
       setActivityGroups(ActivityGroups.filter((activity) => !(props.hideActivityBar as AcitvityBarType[])?.includes(activity.id)));
@@ -101,42 +106,42 @@ export const DataStoryComponent = (
   return (
     <DataStoryCanvasProvider>
       <div className="relative h-full w-full">
-        {treeLoading && <LoadingMask/>}
-        <Allotment className='h-full border-0.5 relative'>
-          <Allotment.Pane visible={!(props.hideActivityBar === true)} minSize={44} maxSize={44}>
-            <ActivityBar
-              activityGroups={activityGroups}
-              selectedNode={selectedNode}
-              setActiveKey={setSidebarKey}
-              activeKey={sidebarKey}
-              onClose={setIsSidebarClose}/>
-          </Allotment.Pane>
-          <Allotment.Pane visible={!isSidebarClose} snap maxSize={500}>
-            <Sidebar
-              tree={tree}
-              handleClickExplorerNode={handleClickExplorerNode}
-              diagramKey={diagramKey}
-              nodeDescriptions={nodeDescriptions} nodeDescriptionsLoading={nodeDescriptionsLoading}
-              partialStoreRef={partialStoreRef}
-              sidebarKey={sidebarKey}
-              setSidebarKey={setSidebarKey} node={selectedNode}
-              onUpdateNodeData={setUpdateSelectedNodeData} onClose={setIsSidebarClose}/>
-          </Allotment.Pane>
-          <Allotment.Pane minSize={300}>
-            {
-              !treeLoading &&
-              <DataStoryCanvas {...props}
-                key={diagramKey}
-                initDiagram={diagram}
-                ref={partialStoreRef}
-                setSidebarKey={setSidebarKey}
-                sidebarKey={sidebarKey}
-                selectedNode={selectedNode}
-                selectedNodeData={updateSelectedNodeData}
-                onNodeSelected={setSelectedNode}/>
-            }
-          </Allotment.Pane>
-        </Allotment>
+        {
+          (treeLoading && !tree)
+            ? <LoadingMask/>
+            : <Allotment className='h-full border-0.5 relative'>
+              <Allotment.Pane visible={!(props.hideActivityBar === true)} minSize={44} maxSize={44}>
+                <ActivityBar
+                  activityGroups={activityGroups}
+                  selectedNode={selectedNode}
+                  setActiveKey={setSidebarKey}
+                  activeKey={sidebarKey}
+                  onClose={setIsSidebarClose}/>
+              </Allotment.Pane>
+              <Allotment.Pane visible={!isSidebarClose} snap maxSize={500}>
+                <Sidebar
+                  tree={tree}
+                  handleClickExplorerNode={handleClickExplorerNode}
+                  diagramKey={diagramKey}
+                  nodeDescriptions={nodeDescriptions} nodeDescriptionsLoading={nodeDescriptionsLoading}
+                  partialStoreRef={partialStoreRef}
+                  sidebarKey={sidebarKey}
+                  setSidebarKey={setSidebarKey} node={selectedNode}
+                  onUpdateNodeData={setUpdateSelectedNodeData} onClose={setIsSidebarClose}/>
+              </Allotment.Pane>
+              <Allotment.Pane minSize={300}>
+                <DataStoryCanvas {...props}
+                  key={diagramKey}
+                  initDiagram={diagram}
+                  ref={partialStoreRef}
+                  setSidebarKey={setSidebarKey}
+                  sidebarKey={sidebarKey}
+                  selectedNode={selectedNode}
+                  selectedNodeData={updateSelectedNodeData}
+                  onNodeSelected={setSelectedNode}/>
+              </Allotment.Pane>
+            </Allotment>
+        }
       </div>
     </DataStoryCanvasProvider>
   )

--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -50,7 +50,8 @@ const Flow = ({
   onNodeSelected,
   selectedNodeData,
   selectedNode,
-  onSave
+  onSave,
+  client
 }: DataStoryCanvasProps) => {
   const selector = (state: StoreSchema) => ({
     nodes: state.nodes,
@@ -137,6 +138,7 @@ const Flow = ({
             server,
             initDiagram,
             callback: onInitialize,
+            clientRun: client?.run,
           });
           setIsExecutePostRenderEffect(true);
         }}

--- a/packages/ui/src/components/DataStory/clients/WorkspaceApiClient.tsx
+++ b/packages/ui/src/components/DataStory/clients/WorkspaceApiClient.tsx
@@ -32,10 +32,8 @@ export const createDiagram = (content = 'Diagram') => {
 export class WorkspaceApiClient {
   private executor: Executor | undefined
   private app: Application
-  constructor() {
-    this.app = new Application();
-    this.app.register(coreNodeProvider);
-    this.app.boot();
+  constructor(app?: Application) {
+    this.app = app || new Application().register(coreNodeProvider).boot();
   }
 
   run = (

--- a/packages/ui/src/components/DataStory/clients/WorkspaceApiClient.tsx
+++ b/packages/ui/src/components/DataStory/clients/WorkspaceApiClient.tsx
@@ -38,9 +38,9 @@ export class WorkspaceApiClient {
     this.app.boot();
   }
 
-  run(
+  run = (
     { updateEdgeCounts, diagram, observers }: ClientRunParams
-  ) {
+  ) => {
     eventManager.emit({
       type: DataStoryEvents.RUN_START
     });
@@ -110,7 +110,7 @@ export class WorkspaceApiClient {
 
     // Start the updates
     handleUpdates(execution[Symbol.asyncIterator]());
-  }
+  };
 
   workspacesApi: WorkspacesApi = {
     getNodeDescriptions: async({ path }) => {

--- a/packages/ui/src/components/DataStory/common/method.ts
+++ b/packages/ui/src/components/DataStory/common/method.ts
@@ -49,6 +49,8 @@ export const areEqual = (prevProps, nextProps) => {
   Object.entries(nextProps).forEach(([key, val]) => {
     if (prevProps[key] !== val) {
       console.log(`Prop '${key}' changed DataStory`);
+      console.log('prev:', prevProps[key]);
+      console.log('next:', val);
     }
   });
 

--- a/packages/ui/src/components/DataStory/sidebar/explorer.tsx
+++ b/packages/ui/src/components/DataStory/sidebar/explorer.tsx
@@ -4,6 +4,7 @@ import { ChevronDown } from '../icons/chevronDown';
 import { LogoIcon } from '../icons/logoIcon';
 import { Tree } from '@data-story/core';
 import { NodeSettingsSidebarProps } from '../types';
+import React from 'react';
 
 function Node({ node, style, dragHandle }: NodeRendererProps<Tree>) {
   const Icon = node.isOpen ? ChevronDown : (node.isLeaf ? LogoIcon : ChevronRight);
@@ -28,11 +29,11 @@ function Node({ node, style, dragHandle }: NodeRendererProps<Tree>) {
   );
 }
 
-export const Explorer = ({
+export const ExplorerComponent = ({
   tree, diagramKey, handleClickExplorerNode
 }: Pick<NodeSettingsSidebarProps, 'handleClickExplorerNode' | 'tree' | 'diagramKey'>
 ) => {
-  const handleClick = (node:  NodeApi<Tree>) =>  {
+  const handleClick = (node: NodeApi<Tree>) => {
     handleClickExplorerNode(node);
   }
 
@@ -58,3 +59,5 @@ export const Explorer = ({
     </div>
   );
 };
+
+export const Explorer = React.memo(ExplorerComponent);

--- a/packages/ui/src/components/DataStory/store/store.tsx
+++ b/packages/ui/src/components/DataStory/store/store.tsx
@@ -158,16 +158,13 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
   },
   onRun: () => {
     const observers = createObservers(get().observerMap);
-
     if(get().serverConfig.type === 'SOCKET') {
       get().serverClient!.run(
         get().toDiagram(),
         // @ts-ignore
         observers,
       )
-    }
-    else {
-      console.log('Running diagram: JS',  get()?.testClientRun);
+    } else {
       get()?.testClientRun?.({
         diagram: get().toDiagram(),
         updateEdgeCounts: get().updateEdgeCounts,
@@ -238,16 +235,19 @@ export const useStore: UseBoundStore<StoreApi<StoreSchema>> = (...params) => {
 // https://react.dev/reference/react/useImperativeHandle
 export const useGetStore = (ref: Ref<unknown>) => {
   const selector = (state: StoreSchema) => ({
-    onRun: state.onRun,
     addNodeFromDescription: state.addNodeFromDescription,
     toDiagram: state.toDiagram,
-    updateEdgeCounts: state.updateEdgeCounts,
+    onRun: state.onRun,
   });
-  const storeSelector = useStore(selector, shallow);
+  const {addNodeFromDescription, toDiagram, onRun} = useStore(selector, shallow);
 
   useImperativeHandle(ref, () => {
-    return (storeSelector);
-  }, [storeSelector.onRun, storeSelector.addNodeFromDescription, storeSelector.toDiagram, storeSelector.updateEdgeCounts]);
+    return ({
+      addNodeFromDescription,
+      toDiagram,
+      onRun,
+    });
+  }, [addNodeFromDescription, toDiagram, onRun]);
 }
 
 export const DataStoryCanvasProvider = ({ children }: {children: React.ReactNode}) => {

--- a/packages/ui/src/components/DataStory/store/store.tsx
+++ b/packages/ui/src/components/DataStory/store/store.tsx
@@ -24,7 +24,8 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
   serverClient: null,
   openNodeSidebarId: null,
   observerMap: new Map(),
-  testClientRun: (params: ClientRunParams) => {},
+  clientRun: (params: ClientRunParams) => {
+  },
 
   // METHODS
   toDiagram: () => {
@@ -137,13 +138,13 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
     })
 
     set({ rfInstance: options.rfInstance })
-    get().initServer(get().serverConfig, options.clientRun)
-    set({ testClientRun: options.clientRun })
+    get().initServer(get().serverConfig)
+    set({ clientRun: options.clientRun })
 
     if (options.initDiagram) get().updateDiagram(options.initDiagram)
 
     if (options.callback) {
-      options.callback({ run:  get().onRun })
+      options.callback({ run: get().onRun })
     }
   },
   updateDiagram: (diagram: Diagram) => {
@@ -158,21 +159,21 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
   },
   onRun: () => {
     const observers = createObservers(get().observerMap);
-    if(get().serverConfig.type === 'SOCKET') {
+    if (get().serverConfig.type === 'SOCKET') {
       get().serverClient!.run(
         get().toDiagram(),
         // @ts-ignore
         observers,
       )
     } else {
-      get()?.testClientRun?.({
+      get()?.clientRun?.({
         diagram: get().toDiagram(),
         updateEdgeCounts: get().updateEdgeCounts,
         observers
       })
     }
   },
-  initServer: (serverConfig: ServerConfig, clientRun: StoreInitOptions['clientRun']) => {
+  initServer: (serverConfig: ServerConfig) => {
     if (serverConfig.type === 'SOCKET') {
       const server = new SocketClient({
         updateEdgeCounts: get().updateEdgeCounts,
@@ -216,7 +217,8 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
 
   setObservers(observerId: string, observers?: DataStoryObservers) {
     get().observerMap.set(observerId, (observers || {
-      inputObservers: [], onDataChange: () => {}
+      inputObservers: [], onDataChange: () => {
+      }
     }) as DataStoryObservers);
   },
 
@@ -239,7 +241,7 @@ export const useGetStore = (ref: Ref<unknown>) => {
     toDiagram: state.toDiagram,
     onRun: state.onRun,
   });
-  const {addNodeFromDescription, toDiagram, onRun} = useStore(selector, shallow);
+  const { addNodeFromDescription, toDiagram, onRun } = useStore(selector, shallow);
 
   useImperativeHandle(ref, () => {
     return ({

--- a/packages/ui/src/components/DataStory/store/store.tsx
+++ b/packages/ui/src/components/DataStory/store/store.tsx
@@ -246,16 +246,13 @@ export const useGetStore = (ref: Ref<unknown>) => {
     onRun: state.onRun,
     addNodeFromDescription: state.addNodeFromDescription,
     toDiagram: state.toDiagram,
+    updateEdgeCounts: state.updateEdgeCounts,
   });
-  const { onRun, addNodeFromDescription, toDiagram } = useStore(selector, shallow);
+  const storeSelector = useStore(selector, shallow);
 
   useImperativeHandle(ref, () => {
-    return ({
-      onRun,
-      addNodeFromDescription,
-      toDiagram,
-    });
-  }, [onRun, addNodeFromDescription, toDiagram]);
+    return (storeSelector);
+  }, [storeSelector.onRun, storeSelector.addNodeFromDescription, storeSelector.toDiagram, storeSelector.updateEdgeCounts]);
 }
 
 export const DataStoryCanvasProvider = ({ children }: {children: React.ReactNode}) => {

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -16,7 +16,7 @@ import { Direction } from './getNodesWithNewSelection';
 import { ServerClient } from './clients/ServerClient';
 import { WorkspaceApiClient } from './clients/WorkspaceApiClient';
 import { Tree } from '@data-story/core';
-import React, { Dispatch, SetStateAction } from 'react';
+import React from 'react';
 import { NodeApi } from 'react-arborist';
 
 export type DataStoryCallback = (options: {run: () => void}) => void;
@@ -46,6 +46,12 @@ export type JSClientOptions = ClientOptions & {
 
 export type SocketClientOptions = ClientOptions & {
   serverConfig: WebSocketServerConfig,
+}
+
+export interface ClientRunParams {
+  updateEdgeCounts: JSClientOptions['updateEdgeCounts'],
+  diagram: Diagram,
+  observers?: ServerClientObservationConfig
 }
 
 export type AcitvityBarType = 'node' | 'diagram' | 'settings' | 'explorer';
@@ -85,9 +91,10 @@ export type StoreInitOptions = {
   server?: ServerConfig,
   initDiagram?: Diagram | null,
   callback?: DataStoryCallback,
+  clientRun?: (params: ClientRunParams) => void;
 }
 
-export type StoreInitServer = (serverConfig: ServerConfig, observers?: ServerClientObservationConfig) => void;
+export type StoreInitServer = (serverConfig: ServerConfig, clientRun?: StoreInitOptions['clientRun']) => void;
 
 export type FormCommonProps = {
   node: ReactFlowNode;
@@ -114,6 +121,8 @@ export type NodeSettingsFormProps = {
 }
 
 export type StoreSchema = {
+  testClientRun?: (params: ClientRunParams) => void
+
   /** The main reactflow instance */
   rfInstance: StoreInitOptions['rfInstance'] | undefined;
   toDiagram: () => Diagram;

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -18,6 +18,7 @@ import { WorkspaceApiClient } from './clients/WorkspaceApiClient';
 import { Tree } from '@data-story/core';
 import React from 'react';
 import { NodeApi } from 'react-arborist';
+import { WorkspaceSocketClient } from './clients/WorkspaceSocketClient';
 
 export type DataStoryCallback = (options: {run: () => void}) => void;
 
@@ -57,7 +58,7 @@ export interface ClientRunParams {
 export type AcitvityBarType = 'node' | 'diagram' | 'settings' | 'explorer';
 
 export type DataStoryProps = {
-  client?: WorkspaceApiClient,
+  client?: WorkspaceApiClient | WorkspaceSocketClient,
   server?: ServerConfig;
   initDiagram?: Diagram | null;
   hideControls?: boolean

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -58,7 +58,7 @@ export interface ClientRunParams {
 export type AcitvityBarType = 'node' | 'diagram' | 'settings' | 'explorer';
 
 export type DataStoryProps = {
-  client?: WorkspaceApiClient | WorkspaceSocketClient,
+  client?: WorkspaceApiClient,
   server?: ServerConfig;
   initDiagram?: Diagram | null;
   hideControls?: boolean
@@ -95,7 +95,7 @@ export type StoreInitOptions = {
   clientRun?: (params: ClientRunParams) => void;
 }
 
-export type StoreInitServer = (serverConfig: ServerConfig, clientRun?: StoreInitOptions['clientRun']) => void;
+export type StoreInitServer = (serverConfig: ServerConfig) => void;
 
 export type FormCommonProps = {
   node: ReactFlowNode;
@@ -122,7 +122,7 @@ export type NodeSettingsFormProps = {
 }
 
 export type StoreSchema = {
-  testClientRun?: (params: ClientRunParams) => void
+  clientRun?: (params: ClientRunParams) => void
 
   /** The main reactflow instance */
   rfInstance: StoreInitOptions['rfInstance'] | undefined;


### PR DESCRIPTION
- feat: replace `JsClient` with `WorkspaceApiClient` in `run` function
    - remove `new JsClient` in store
![image](https://github.com/user-attachments/assets/9c61a80f-5825-48c6-88a6-8cba2e83260a)

- fix: resolve warning about final argument size change in `useMemo` between renders
![image](https://github.com/user-attachments/assets/0b0131e5-b3bf-4683-bb63-fc4a47595fc0)

-[fix: resolve issue preventing addition of custom nodes](https://github.com/ajthinking/data-story/commit/89931aff1f083ab4f428e154db9fb50decdd9d65)