### PR TITLE
Renaming ServiceProvider.register to boot

### DIFF
--- a/packages/core/src/Application.test.ts
+++ b/packages/core/src/Application.test.ts
@@ -8,7 +8,7 @@ describe('register', () => {
     const app = new Application()
 
     const provider: ServiceProvider = {
-      register: (app) => {},
+      boot: (app) => {},
     }
 
     app.register(provider)
@@ -22,11 +22,11 @@ describe('register', () => {
     const app = new Application()
 
     const provider1: ServiceProvider = {
-      register: (app) => {},
+      boot: (app) => {},
     }
 
     const provider2: ServiceProvider = {
-      register: (app) => {},
+      boot: (app) => {},
     }
 
     app.register([provider1, provider2])
@@ -43,19 +43,19 @@ describe('boot', () => {
     const app = new Application()
 
     const provider1: ServiceProvider = {
-      register: vi.fn(),
+      boot: vi.fn(),
     }
 
     const provider2: ServiceProvider = {
-      register: vi.fn(),
+      boot: vi.fn(),
     }
 
     app.register([provider1, provider2])
 
     app.boot()
 
-    expect(provider1.register).toHaveBeenCalledWith(app)
-    expect(provider2.register).toHaveBeenCalledWith(app)
+    expect(provider1.boot).toHaveBeenCalledWith(app)
+    expect(provider2.boot).toHaveBeenCalledWith(app)
   })
 })
 

--- a/packages/core/src/Application.ts
+++ b/packages/core/src/Application.ts
@@ -29,7 +29,7 @@ export class Application {
 
   boot() {
     this.providers.forEach(provider => {
-      provider.register(this);
+      provider.boot(this);
     });
 
     return this;

--- a/packages/core/src/coreNodeProvider.ts
+++ b/packages/core/src/coreNodeProvider.ts
@@ -3,7 +3,7 @@ import { ServiceProvider } from './types/ServiceProvider';
 import * as computers from './computers'
 
 export const coreNodeProvider: ServiceProvider = {
-  register: (app: Application) => {
+  boot: (app: Application) => {
     app.addComputers(Object.values(computers));
   },
 }

--- a/packages/core/src/treeNodeProvider.ts
+++ b/packages/core/src/treeNodeProvider.ts
@@ -5,7 +5,7 @@ import { ServiceProvider } from './types/ServiceProvider';
  * Register nodes from the application tree
  */
 export const treeNodeProvider: ServiceProvider = {
-  register: (app: Application) => {
+  boot: (app: Application) => {
     const treeManager = app.getTreeManager()
     const path = treeManager.rootPath
 

--- a/packages/core/src/types/ServiceProvider.ts
+++ b/packages/core/src/types/ServiceProvider.ts
@@ -1,5 +1,5 @@
 import { Application } from '../Application';
 
 export type ServiceProvider = {
-  register: (app: Application) => void;
+  boot: (app: Application) => void;
 }

--- a/packages/hubspot/src/hubspotProvider.ts
+++ b/packages/hubspot/src/hubspotProvider.ts
@@ -2,7 +2,7 @@ import { Application, Computer, ComputerFactory, ServiceProvider } from '@data-s
 import * as computers from './computers'
 
 export const hubspotProvider: ServiceProvider = {
-  register: (app: Application) => {
+  boot: (app: Application) => {
     const configs = Object.values(computers as {[key: string]: Computer})
     app.addComputers(configs);
   },

--- a/packages/nodejs/src/nodeJsProvider.ts
+++ b/packages/nodejs/src/nodeJsProvider.ts
@@ -2,7 +2,7 @@ import { Application, ServiceProvider } from '@data-story/core';
 import * as computers from './computers'
 
 export const nodeJsProvider: ServiceProvider = {
-  register: (app: Application) => {
+  boot: (app: Application) => {
     app.addComputers(Object.values(computers));
   },
 }

--- a/packages/openai/src/openAiProvider.ts
+++ b/packages/openai/src/openAiProvider.ts
@@ -2,7 +2,7 @@ import { Application, ComputerFactory, ServiceProvider } from '@data-story/core'
 import * as computers from './computers'
 
 export const openAiProvider: ServiceProvider = {
-  register: (app: Application) => {
+  boot: (app: Application) => {
     app.addComputers(Object.values(computers));
   },
 }


### PR DESCRIPTION
Since it makes more sense to call `ServiceProvider.boot()` will run when we run `app.boot()`
`app.register()` can be considered a preparation step. Note how ServiceProvider no longer has a register method of its own.