### PR TITLE
Separate boot & bootSync

### DIFF
--- a/packages/core/src/Application.test.ts
+++ b/packages/core/src/Application.test.ts
@@ -38,8 +38,8 @@ describe('register', () => {
   })
 })
 
-describe('boot', () => {
-  it('runs register and boot on all providers', () => {
+describe('bootAsync', () => {
+  it('runs register and boot on all providers', async () => {
     const app = new Application()
 
     const provider1: ServiceProvider = {
@@ -52,7 +52,7 @@ describe('boot', () => {
 
     app.register([provider1, provider2])
 
-    app.boot()
+    await app.boot()
 
     expect(provider1.boot).toHaveBeenCalledWith(app)
     expect(provider2.boot).toHaveBeenCalledWith(app)

--- a/packages/core/src/Application.ts
+++ b/packages/core/src/Application.ts
@@ -12,6 +12,8 @@ import { ServiceProvider } from './types/ServiceProvider';
 import { Storage } from './types/Storage';
 
 export class Application {
+  hasBooted = false;
+
   constructor(private treeManager: TreeManager = new NullTreeManager()
   ) {}
 
@@ -27,10 +29,26 @@ export class Application {
     return this;
   }
 
-  boot() {
+  /**
+   *
+   * @deprecated Use boot instead
+   */
+  bootSync() {
     this.providers.forEach(provider => {
       provider.boot(this);
     });
+
+    this.hasBooted = true;
+
+    return this;
+  }
+
+  async boot() {
+    this.providers.forEach(provider => {
+      provider.boot(this);
+    });
+
+    this.hasBooted = true;
 
     return this;
   }
@@ -90,4 +108,8 @@ export class Application {
   getTreeManager() {
     return this.treeManager
   }
+}
+
+export type BootedApplication = Application & {
+  hasBooted: true;
 }

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -8,6 +8,6 @@ core.register([
   coreNodeProvider,
 ]);
 
-core.boot();
+core.bootSync();
 
 export { core };

--- a/packages/core/src/support/benchmark.ts
+++ b/packages/core/src/support/benchmark.ts
@@ -20,7 +20,7 @@ import { coreNodeProvider } from '../coreNodeProvider';
     coreNodeProvider,
   ]);
 
-  app.boot();
+  await app.boot();
 
   const diagram = core.getDiagramBuilder()
     .add(Create, {json: JSON.stringify(data)})

--- a/packages/docs/components/Playground.tsx
+++ b/packages/docs/components/Playground.tsx
@@ -9,7 +9,7 @@ export default Playground;
 
 const app = new Application()
   .register(coreNodeProvider)
-  .boot();
+  .bootSync();
 
 function Playground({ mode }: {mode?: 'js' | 'node'}) {
   const client = useMemo(() => {

--- a/packages/docs/components/demos/ObserversDemo.tsx
+++ b/packages/docs/components/demos/ObserversDemo.tsx
@@ -11,7 +11,7 @@ export default ({ mode, observers }:
 }) => {
   const app = new Application()
     .register(coreNodeProvider)
-    .boot();
+    .bootSync();
   const { Signal, Table } = nodes;
 
   const diagram = core.getDiagramBuilder()

--- a/packages/docs/components/demos/VisualizeDemo.tsx
+++ b/packages/docs/components/demos/VisualizeDemo.tsx
@@ -46,7 +46,7 @@ export default () => {
   const app = useMemo(() => {
     return new Application()
       .register(coreNodeProvider)
-      .boot();
+      .bootSync();
   }, [Application]);
   const { Signal, Table, Map, Create, Request, ConsoleLog } = nodes;
 

--- a/packages/ui/src/components/DataStory/clients/WorkspaceApiJSClient.tsx
+++ b/packages/ui/src/components/DataStory/clients/WorkspaceApiJSClient.tsx
@@ -79,7 +79,7 @@ export class WorkspaceApiJSClient implements WorkspaceApiClient {
   private app: Application
 
   constructor(app?: Application) {
-    this.app = app || new Application().register(coreNodeProvider).boot();
+    this.app = app || new Application().register(coreNodeProvider).bootSync();
   }
 
   run = (


### PR DESCRIPTION
In preparation of enabling async `ServiceProviders.boot` methods, the `app.boot()` needs to be async as well. This PR prepares that by the following:
* Old `app.boot()` renamed to `app.bootSync()` and deprecated
* A new async boot method is added, and implemented in a few places
Furthermore:
* A property hasBooted is added to the Application

Follow ups:
* Eliminate all usage of bootSync