### PR TITLE
Performance: Avoid spread, prefer batching pushTo

### DIFF
--- a/packages/core/src/InputDevice.ts
+++ b/packages/core/src/InputDevice.ts
@@ -38,7 +38,12 @@ export class InputDevice {
     for(const link of links) {
       const batch = this.memory.pullLinkItems(link.id, remaining)
 
-      pulled.push(...batch)
+      if(batch.length < 1000) {
+        pulled.push.apply(pulled, batch)
+      } else {
+        for(const item of batch) pulled.push(item)
+      }
+
       remaining -= batch.length
       if(remaining === 0) break
     }

--- a/packages/core/src/computers/Clone.ts
+++ b/packages/core/src/computers/Clone.ts
@@ -30,20 +30,43 @@ export const Clone: Computer = {
   ],
 
   async *run({ input, output, params }) {
-    while(true) {
-      const incoming = input.pull()
-      output.pushTo('original', incoming)
+    while (true) {
+      const startTime = Date.now();
 
-      const count = Number(params.count)
+      const incoming = input.pull();
+      output.pushTo('original', incoming);
+
+      const count = Number(params.count);
+      const clones = [];
+      const BATCH_SIZE = 10000; // Adjust based on your memory constraints
 
       for (let i = 0; i < count; i++) {
-        output.pushTo('clones', incoming.map(item => ({
-          ...item.value,
-          _clone_id: i,
-        })))
+        for (const item of incoming) {
+          // Efficient object cloning without spread operator
+          const clonedItem = Object.assign({}, item.value, { _clone_id: i });
+          clones.push(clonedItem);
+
+          // Push in batches to manage memory
+          if (clones.length >= BATCH_SIZE) {
+            await output.pushTo('clones', clones.splice(0, BATCH_SIZE));
+          }
+        }
       }
+
+      // Push any remaining clones
+      if (clones.length > 0) {
+        await output.pushTo('clones', clones);
+      }
+
+      // Clear large arrays to free memory
+      incoming.length = 0;
+      clones.length = 0;
+
+      const endTime = Date.now();
+      console.log('Clone time:', endTime - startTime, 'ms');
 
       yield;
     }
   },
+
 };

--- a/packages/core/src/computers/Clone.ts
+++ b/packages/core/src/computers/Clone.ts
@@ -13,11 +13,11 @@ export const Clone: Computer = {
   ],
   outputs: [
     {
-      name: 'original',
+      name: 'clones',
       schema: {}
     },
     {
-      name: 'clones',
+      name: 'original',
       schema: {}
     },
   ],


### PR DESCRIPTION
Optimize Clone.run
Spread operator gave max call stack error in `pullFrom` when receiving 200K items.
