### PR TITLE
VS Code: demo command

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-story/core",
-  "version": "0.0.104",
+  "version": "0.0.105",
   "main": "dist/main/index.js",
   "type": "commonjs",
   "types": "dist/main/index.d.ts",

--- a/packages/ds-ext/package.json
+++ b/packages/ds-ext/package.json
@@ -2,7 +2,7 @@
   "name": "ds-ext",
   "displayName": "ds-ext",
   "description": "",
-  "version": "0.0.104",
+  "version": "0.0.105",
   "publisher": "ajthinking",
   "engines": {
     "vscode": "^1.80.0"
@@ -18,12 +18,8 @@
   "contributes": {
     "commands": [
       {
-        "command": "ds-ext.showReactApp",
-        "title": "Show React App"
-      },
-      {
-        "command": "ds-ext.openAsJson",
-        "title": "Open raw, diagram JSON"
+        "command": "ds-ext.createDemos",
+        "title": "DataStory: Create Demo Diagrams"
       }
     ],
     "languages": [

--- a/packages/ds-ext/src/commands/createDemosDirectory.ts
+++ b/packages/ds-ext/src/commands/createDemosDirectory.ts
@@ -1,0 +1,45 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as demos from './demos';
+
+export function createDemosDirectory() {
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders) {
+    vscode.window.showErrorMessage('No workspace folder is open.');
+    return;
+  }
+
+  const workspaceRoot = workspaceFolders[0].uri.fsPath;
+  const demosDir = path.join(workspaceRoot, 'demos');
+
+  try {
+    // Nuke directory if it already exists
+    if (fs.existsSync(demosDir)) {
+      fs.rmSync(demosDir, { recursive: true });
+    }
+
+    // Create the directory
+    fs.mkdirSync(demosDir);
+
+    // Create a demo data directory
+    fs.mkdirSync(path.join(demosDir, 'data'));
+
+    // Add a todos.json in the data directory
+    fs.writeFileSync(path.join(demosDir, 'data', 'todos.json'), JSON.stringify([
+      { id: 1, title: 'Learn DataStory', completed: true },
+      { id: 2, title: 'Build a DataStory extension', completed: false },
+      { id: 3, title: 'Profit', completed: false },
+    ], null, 2));
+
+    // Loop through each demo imported from the `demos` index file
+    Object.entries(demos).forEach(([moduleName, demoContent]) => {
+      const filePath = path.join(demosDir, `${moduleName}.diagram.json`);
+      fs.writeFileSync(filePath, JSON.stringify(demoContent, null, 2));
+    });
+
+    vscode.window.showInformationMessage('Created DataStory demos directory.');
+  } catch (error: any) {
+    vscode.window.showErrorMessage(`Error creating demo files: ${error.message}`);
+  }
+}

--- a/packages/ds-ext/src/commands/demos/create_to_json_file_write.ts
+++ b/packages/ds-ext/src/commands/demos/create_to_json_file_write.ts
@@ -1,0 +1,10 @@
+import { DiagramBuilder } from '@data-story/core';
+import { nodes as coreNodes } from '@data-story/core';
+import { nodes as nodeJsNodes } from '@data-story/nodejs';
+
+export const create_to_json_file_write = new DiagramBuilder()
+  .add(coreNodes.Create)
+  .add(nodeJsNodes.JsonFileWrite, {
+    file_path: 'demos/output/items.json'
+  })
+  .get();

--- a/packages/ds-ext/src/commands/demos/empty.ts
+++ b/packages/ds-ext/src/commands/demos/empty.ts
@@ -1,0 +1,3 @@
+import { DiagramBuilder } from '@data-story/core';
+
+export const empty = new DiagramBuilder().get();

--- a/packages/ds-ext/src/commands/demos/index.ts
+++ b/packages/ds-ext/src/commands/demos/index.ts
@@ -1,0 +1,5 @@
+export { create_to_json_file_write } from './create_to_json_file_write';
+export { empty } from './empty';
+export { json_file_read_to_table } from './json_file_read_to_table';
+export { signal_to_table } from './signal_to_table';
+export { signal_to_table_1m_instant_items } from './signal_to_table_1m_instant_items';

--- a/packages/ds-ext/src/commands/demos/json_file_read_to_table.ts
+++ b/packages/ds-ext/src/commands/demos/json_file_read_to_table.ts
@@ -1,0 +1,10 @@
+import { DiagramBuilder } from '@data-story/core';
+import { nodes as coreNodes } from '@data-story/core';
+import { nodes as nodeJsNodes } from '@data-story/nodejs';
+
+export const json_file_read_to_table = new DiagramBuilder()
+  .add(nodeJsNodes.JsonFileRead, {
+    file_path: 'demos/demo_data/todos.json'
+  })
+  .add(coreNodes.Table)
+  .get();

--- a/packages/ds-ext/src/commands/demos/signal_to_table.ts
+++ b/packages/ds-ext/src/commands/demos/signal_to_table.ts
@@ -1,0 +1,7 @@
+import { DiagramBuilder } from '@data-story/core';
+import { nodes } from '@data-story/core';
+
+export const signal_to_table = new DiagramBuilder()
+  .add(nodes.Signal)
+  .add(nodes.Table)
+  .get();

--- a/packages/ds-ext/src/commands/demos/signal_to_table_1m_instant_items.ts
+++ b/packages/ds-ext/src/commands/demos/signal_to_table_1m_instant_items.ts
@@ -1,0 +1,7 @@
+import { DiagramBuilder } from '@data-story/core';
+import { nodes } from '@data-story/core';
+
+export const signal_to_table_1m_instant_items = new DiagramBuilder()
+  .add(nodes.Signal, { period: 0, count: 1_000_000 })
+  .add(nodes.Table)
+  .get();

--- a/packages/ds-ext/src/extension.ts
+++ b/packages/ds-ext/src/extension.ts
@@ -1,7 +1,14 @@
 import * as vscode from 'vscode';
 import { DiagramEditorProvider } from './DiagramEditorProvider';
+import * as fs from 'fs';
+import * as path from 'path';
+import { createDemosDirectory } from './commands/createDemosDirectory';
 
 export function activate(context: vscode.ExtensionContext) {
+  let disposable = vscode.commands.registerCommand('ds-ext.createDemos', async () => {
+    createDemosDirectory();
+  });
+
   context.subscriptions.push(
     vscode.window.registerCustomEditorProvider(
       'ds-ext.diagramEditor',

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-story/nodejs",
-  "version": "0.0.104",
+  "version": "0.0.105",
   "main": "dist/index.js",
   "type": "commonjs",
   "types": "dist/index.d.ts",

--- a/packages/nodejs/src/computers/JsonFileRead/JsonFileRead.ts
+++ b/packages/nodejs/src/computers/JsonFileRead/JsonFileRead.ts
@@ -42,8 +42,6 @@ export const JsonFileRead: Computer = {
         absolute: true,
       });
 
-      console.log('files:', files)
-
       for (const file of files) {
         try {
           const content = fs.readFileSync(file, 'utf-8');

--- a/packages/nodejs/src/computers/JsonFileWrite/JsonFileWrite.ts
+++ b/packages/nodejs/src/computers/JsonFileWrite/JsonFileWrite.ts
@@ -1,6 +1,6 @@
-import glob from 'glob';
 import { promises as fs } from 'fs';
 import { Computer, str } from '@data-story/core';
+import * as path from 'path';
 
 export const JsonFileWrite: Computer = {
   name: 'JsonFile.write',
@@ -13,8 +13,8 @@ export const JsonFileWrite: Computer = {
   outputs: [],
   params: [
     str({
-      name: 'path',
-      label: 'Path',
+      name: 'file_path',
+      label: 'File Path',
       help: 'File path',
     }),
   ],
@@ -26,9 +26,14 @@ export const JsonFileWrite: Computer = {
   async *run({ input, params }) {
     const incoming = input.pull()
 
-    const path = params.path as string
+    const filePath = params.file_path as string
     const content = JSON.stringify(incoming.map(i => i.value), null, 2)
 
-    await fs.writeFile(path, content, 'utf-8')
+    const root = process.env.WORKSPACE_FOLDER_PATH;
+    if(!root) throw new Error('WORKSPACE_FOLDER_PATH not set')
+
+    const fullPath = path.join(root, filePath)
+    await fs.mkdir(path.dirname(fullPath), { recursive: true })
+    await fs.writeFile(fullPath, content, 'utf-8')
   },
 };

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-story/ui",
-  "version": "0.0.104",
+  "version": "0.0.105",
   "main": "./dist/bundle.js",
   "types": "./dist/src/index.d.ts",
   "module": "./dist/bundle.mjs",


### PR DESCRIPTION
Contributes command: `createDemos`.
Upon running, it will populate a directory `./demos` and `./demos/data`. Any old content will be nuked.

<img width="1288" alt="image" src="https://github.com/user-attachments/assets/82b3fb9a-f309-4ff9-a656-737682318f0a">

Purpose:
* reproducable debugging
* performance trials
* educational content

Relases v0.0.105 🎈 