### PR TITLE
Support absolute/relative json files + drag and drop

### DIFF
--- a/packages/ds-ext/src/app/onDrop.ts
+++ b/packages/ds-ext/src/app/onDrop.ts
@@ -3,16 +3,69 @@ import { NodeDescription, str } from '@data-story/core';
 export const onDrop = (event: any, addNodeFromDescription: any) => {
   event.preventDefault();
 
+  if(isDropFromOs(event)) return onDropFromOs(
+    event,
+    addNodeFromDescription
+  );
+
+  if(isDropFromExplorer(event)) return onDropFromExplorer(
+    event,
+    addNodeFromDescription
+  );
+};
+
+export const isDropFromOs = (event: any) => {
+  return event.dataTransfer.files.length;
+};
+
+export const isDropFromExplorer = (event: any) => {
+  return event.dataTransfer.getData('text/plain');
+};
+
+export const onDropFromOs = (event: any, addNodeFromDescription: any) => {
+  const file = event.dataTransfer.files[0];
+  const path = file.path;
+  const filename = path.split('/').pop();
+  const extention = filename.split('.').pop();
+
+  if (extention !== 'json') {
+    console.warn({
+      message: 'Currently, only JSON files are supported.',
+      path,
+      filename,
+      extention,
+    });
+
+    return;
+  }
+
+  const description = createJsonFileReadDescription(filename, path);
+  addNodeFromDescription(description);
+};
+
+export const onDropFromExplorer = (event: any, addNodeFromDescription: any) => {
+  // DROP FROM EXPLORER
   const path = event.dataTransfer.getData('text/plain');
   const filename = path.split('/').pop();
   const extention = filename.split('.').pop();
 
   if (extention !== 'json') {
-    console.warn('Currently, only JSON files are supported.');
+    console.warn({
+      message: 'Currently, only JSON files are supported.',
+      path,
+      filename,
+      extention,
+    });
+
     return;
   }
 
-  const description: NodeDescription = {
+  const description = createJsonFileReadDescription(filename, path);
+  addNodeFromDescription(description);
+};
+
+export const createJsonFileReadDescription = (filename: string, path: string): NodeDescription => {
+  return {
     name: 'JsonFile.read',
     label: filename,
     inputs: [],
@@ -40,6 +93,4 @@ export const onDrop = (event: any, addNodeFromDescription: any) => {
       }),
     ],
   };
-
-  addNodeFromDescription(description);
 };


### PR DESCRIPTION
1. In JsonFileRead and JsonFileWrite - adds support for paths with this rule:
* a/relative/path/to/file -> will be joined with WORKSPACE_PATH.
* /a/complete/path -> will not be joined.

2. Reimplements dropping files from finder in ds-ext (another version exists in nodejs package)