### PR TITLE
fix: resolve issue with Ctrl + V not working for pasting in CodeMirror within the Datastory VSCode extension mode.

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -408,13 +408,13 @@ __metadata:
   linkType: hard
 
 "@codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.17.0, @codemirror/view@npm:^6.23.0, @codemirror/view@npm:^6.27.0":
-  version: 6.34.1
-  resolution: "@codemirror/view@npm:6.34.1"
+  version: 6.27.0
+  resolution: "@codemirror/view@npm:6.27.0"
   dependencies:
     "@codemirror/state": "npm:^6.4.0"
     style-mod: "npm:^4.1.0"
     w3c-keyname: "npm:^2.2.4"
-  checksum: 10/012f195d7c9da2f9693b2192e0e52c7d3f94d9c887c46e218ddb36ee1a050978ee6a13c7d0207dd3fb970b4454198962112b9afe17e1f23d2b89a274b7d186a0
+  checksum: 10/dc57315690cd575897a69e3d64fc84d7268a5181fd9e7770d3cfda1c287352f818c667e44c88b2a7368c222d27f5ad0ee60c544dd3a35078217188a7bb10990d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I'm not quite sure what specifically caused this issue, I suspect that the upgrade of @codemirror/view introduced [EditContext](https://developer.mozilla.org/en-US/docs/Web/API/EditContext).

before:

https://github.com/user-attachments/assets/7896c633-9f22-4e93-84b7-57674bcb47df


after: 

https://github.com/user-attachments/assets/1cc70eb6-bdcc-4a53-bf29-7c86f7a3af69


Relevant links
- https://github.com/ajthinking/data-story/commit/b63742830d08a7dece91166842222df76b0ec23d#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de
- https://github.com/codemirror/view/blob/main/CHANGELOG.md   (6.34.1 ~ 6.27.0)