### PR TITLE
feat: Replace `initExecutionUpdates` method with `useObserverConsole` for data requests.

### DIFF
--- a/packages/core/src/computers/ConsoleLog.test.ts
+++ b/packages/core/src/computers/ConsoleLog.test.ts
@@ -1,21 +1,11 @@
 import { when } from '../support/computerTester/ComputerTester';
 import { ConsoleLog } from './ConsoleLog';
 
-it('register one console log hook per item', async () => {
+it('register one console log per item', async () => {
   await when(ConsoleLog)
     .hasDefaultParams()
     .getsInput([{ id: 1 }, { id: 2 }])
     .doRun()
-    .expectHooks([
-      {
-        type: 'CONSOLE_LOG',
-        args: [{ id: 1 }]
-      },
-      {
-        type: 'CONSOLE_LOG',
-        args: [{ id: 2 }]
-      },
-    ])
     .ok()
 })
 
@@ -26,11 +16,5 @@ it('can register an interpolated console log message', async () => {
     })
     .getsInput([{ id: 1, name: 'ajthinking' }])
     .doRun()
-    .expectHooks([
-      {
-        type: 'CONSOLE_LOG',
-        args: ['Hello ajthinking!']
-      },
-    ])
     .ok()
 })

--- a/packages/core/src/computers/ConsoleLog.ts
+++ b/packages/core/src/computers/ConsoleLog.ts
@@ -38,24 +38,5 @@ export const ConsoleLog: Computer = {
     })
   ],
 
-  async *run({ input, hooks, params: rawParams }) {
-    console.log('ConsoleLog running')
-    while(true) {
-      const incoming = input.pull() as ItemWithParams[]
-
-      for(const item of incoming) {
-        hooks.register({
-          type: 'CONSOLE_LOG',
-          args: [
-            // If nothing passed log the whole item
-            !rawParams.message
-              ? item.value
-              : item.params.message
-          ]
-        })
-      }
-
-      yield;
-    }
-  },
+  async *run({ input, hooks, params: rawParams }) {},
 };

--- a/packages/ds-ext/src/messageHandlers/onRun.ts
+++ b/packages/ds-ext/src/messageHandlers/onRun.ts
@@ -47,12 +47,7 @@ export const onRun: MessageHandler = async ({ event, webviewPanel, inputObserver
   const execution = executor.execute();
 
   try {
-    for await(const update of execution) {
-      webviewPanel.webview.postMessage({
-        msgId,
-        ...update
-      });
-    }
+    for await(const update of execution) {}
 
     const endTime = Date.now();
     webviewPanel.webview.postMessage({

--- a/packages/nodejs/src/server/messageHandlers/run.ts
+++ b/packages/nodejs/src/server/messageHandlers/run.ts
@@ -33,12 +33,7 @@ export const run: MessageHandler<RunMessage> = async({
   const execution = executor.execute()
 
   try {
-    for await(const update of execution) {
-      ws.send(JSON.stringify({
-        ...update,
-        msgId: data.msgId,
-      }))
-    }
+    for await(const update of execution) {}
 
     ws.send(
       JSON.stringify({

--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -17,6 +17,7 @@ import InputNodeComponent from '../Node/InputNodeComponent';
 import TableNodeComponent from '../Node/TableNodeComponent';
 import { DataStoryCanvasProps, StoreInitOptions, StoreSchema } from './types';
 import OutputNodeComponent from '../Node/OutputNodeComponent';
+import ConsoleNodeComponent from '../Node/ConsoleNodeComponent';
 import { onDropDefault } from './onDropDefault';
 import type { NodeTypes } from '@xyflow/react/dist/esm/types';
 import { HotkeyManager, useHotkeys } from './useHotkeys';
@@ -31,6 +32,7 @@ const nodeTypes = {
   inputNodeComponent: InputNodeComponent,
   outputNodeComponent: OutputNodeComponent,
   tableNodeComponent: TableNodeComponent,
+  consoleNodeComponent: ConsoleNodeComponent,
 };
 
 const DataStoryCanvasComponent = forwardRef((props: DataStoryCanvasProps, ref) => {

--- a/packages/ui/src/components/DataStory/clients/WorkspaceApiClientBase.ts
+++ b/packages/ui/src/components/DataStory/clients/WorkspaceApiClientBase.ts
@@ -1,5 +1,5 @@
 import { WorkspaceApiClient } from './WorkspaceApiClient';
-import { ClientRunParams, ServerClientObservationConfig } from '../types';
+import { ClientRunParams } from '../types';
 import { filter, Observable, Subject, Subscription } from 'rxjs';
 import {
   Diagram,
@@ -31,13 +31,11 @@ export class WorkspaceApiClientBase implements WorkspaceApiClient {
   private receivedMsg$ = new Subject();
 
   constructor(private transport: Transport) {
-    this.initExecutionUpdates();
     this.initExecutionResult();
     this.initExecutionFailure();
     this.initUpdateStorage();
     this.run = this.run.bind(this);
     this.updateDiagram = this.updateDiagram.bind(this);
-    // this.initReceiveMsg();
   }
 
   async getNodeDescriptions({ path }: {path?: string}): Promise<NodeDescription[]> {
@@ -113,24 +111,6 @@ export class WorkspaceApiClientBase implements WorkspaceApiClient {
     return this.receivedMsg$.subscribe((data: any) => {
       console.log('Received message:', data);
     });
-  }
-
-  private initExecutionUpdates() {
-    return this.receivedMsg$.pipe(filter(matchMsgType('ExecutionUpdate')))
-      .subscribe((data: any) => {
-        for(const hook of data.hooks as Hook[]) {
-          if (hook.type === 'CONSOLE_LOG') {
-            console.log(...hook.args)
-          } else if (hook.type === 'UPDATES') {
-            const providedCallback = (...data: any) => {
-              console.log('THIS IS THE UPDATE HOOK!')
-              console.log('DataPassed', data)
-            }
-
-            providedCallback(...hook.args)
-          }
-        }
-      })
   }
 
   private initExecutionResult() {

--- a/packages/ui/src/components/DataStory/mockJSServer/messageHandlers.ts
+++ b/packages/ui/src/components/DataStory/mockJSServer/messageHandlers.ts
@@ -43,9 +43,7 @@ export const getDefaultMsgHandlers = (app: Application, inputObserverController:
     try {
       const execution = executor?.execute();
 
-      for await(const executionUpdate of execution) {
-        sendEvent(executionUpdate);
-      }
+      for await(const executionUpdate of execution) {}
 
       const executionResult = {
         type: 'ExecutionResult',

--- a/packages/ui/src/components/Node/ConsoleNodeComponent.cy.tsx
+++ b/packages/ui/src/components/Node/ConsoleNodeComponent.cy.tsx
@@ -1,0 +1,62 @@
+import ConsoleNodeComponent from './ConsoleNodeComponent';
+import { ReactFlowProvider } from '@xyflow/react';
+import { ItemsObserver } from '@data-story/core';
+import { DataStoryContext } from '../DataStory/store/store';
+
+const data = {
+  'params': [],
+  'computer': 'ConsoleLog',
+  'label': 'ConsoleLog',
+  'inputs': [
+    {
+      'id': 'ConsoleLog.1.input',
+      'name': 'input',
+      'schema': {}
+    }
+  ],
+  'outputs': []
+};
+const id = 'ConsoleLog.1';
+
+const mountConsoleNodeComponent = (items: unknown[], client?: () => void) => {
+  cy.mount(
+    // @ts-ignore
+    <DataStoryContext.Provider value={() => {
+      return ({
+        toDiagram: () => ({
+          getLinkIdFromNodeId: (id: string, port: string) => {
+            return `${id}.${port}`;
+          }
+        }),
+        client: client?.() || {
+          itemsObserver: (observer: ItemsObserver) => {
+            console.log('itemsObserver:', observer)
+            // @ts-ignore
+            observer.onReceive(items);
+          }
+        }
+      })
+    }}>
+      <ReactFlowProvider>
+        <ConsoleNodeComponent id={id} data={data} selected={false}/>
+      </ReactFlowProvider>
+    </DataStoryContext.Provider>
+  );
+}
+
+describe('ConsoleNodeComponent', () => {
+  it('should render', () => {
+    mountConsoleNodeComponent([]);
+    cy.get('[data-cy="data-story-node-component"]').should('exist');
+    cy.get('[data-cy="data-story-node-component"]').contains('ConsoleLog');
+  });
+
+  it('should render a console log', () => {
+    const customLog = cy.stub().callsFake((e) => e);
+    cy.stub(console, 'log').callsFake(customLog);
+    mountConsoleNodeComponent(['Hello, World!']);
+    cy.get('[data-cy="data-story-node-component"]').should('exist');
+    cy.wrap(customLog).should('be.called');
+    cy.wrap(customLog).should('be.calledWith', 'Hello, World!');
+  });
+});

--- a/packages/ui/src/components/Node/ConsoleNodeComponent.tsx
+++ b/packages/ui/src/components/Node/ConsoleNodeComponent.tsx
@@ -1,14 +1,47 @@
 import React, { memo } from 'react';
 import { DataStoryNodeData } from './ReactFlowNode';
 import { NodeComponent } from '../../index';
+import { useStore } from '../DataStory/store/store';
+import { shallow } from 'zustand/shallow';
+import { Subscription } from 'rxjs';
+import { useMount, useUnmount } from 'ahooks';
+import { ItemsObserver, RequestObserverType } from '@data-story/core';
+import { StoreSchema } from '../DataStory/types';
 
 const ConsoleNodeComponent = ({ id, data, selected }: {
   id: string,
   data: DataStoryNodeData
   selected: boolean
 }) => {
-  console.log('ConsoleNodeComponent', id, data, selected)
+  useObserverConsole({ id });
   return <NodeComponent id={id} data={data} selected={selected}/>
 }
 
+const useObserverConsole = ({ id }: {id: string}) => {
+  const selector = (state: StoreSchema) => ({
+    toDiagram: state.toDiagram,
+    client: state.client,
+  });
+  const { toDiagram, client } = useStore(selector, shallow);
+
+  let consoleSubscription: Subscription;
+  // Add the node to the inputObservers when the node is mounted
+  useMount(() => {
+    const linkId = toDiagram()?.getLinkIdFromNodeId?.(id, 'input');
+    if (!client?.itemsObserver || !linkId) return;
+    const consoleObserver: ItemsObserver = {
+      linkIds: [linkId],
+      type: RequestObserverType.itemsObserver,
+      onReceive: (batchedItems) => {
+        console.log(...batchedItems ?? []);
+      }
+    }
+
+    consoleSubscription = client?.itemsObserver?.(consoleObserver);
+  });
+
+  useUnmount(() => {
+    consoleSubscription?.unsubscribe();
+  });
+}
 export default memo(ConsoleNodeComponent);

--- a/packages/ui/src/components/Node/ConsoleNodeComponent.tsx
+++ b/packages/ui/src/components/Node/ConsoleNodeComponent.tsx
@@ -1,0 +1,14 @@
+import React, { memo } from 'react';
+import { DataStoryNodeData } from './ReactFlowNode';
+import { NodeComponent } from '../../index';
+
+const ConsoleNodeComponent = ({ id, data, selected }: {
+  id: string,
+  data: DataStoryNodeData
+  selected: boolean
+}) => {
+  console.log('ConsoleNodeComponent', id, data, selected)
+  return <NodeComponent id={id} data={data} selected={selected}/>
+}
+
+export default memo(ConsoleNodeComponent);

--- a/packages/ui/src/components/Node/ConsoleNodeComponent.tsx
+++ b/packages/ui/src/components/Node/ConsoleNodeComponent.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
 import { DataStoryNodeData } from './ReactFlowNode';
-import { NodeComponent } from '../../index';
+import NodeComponent from './NodeComponent';
 import { useStore } from '../DataStory/store/store';
 import { shallow } from 'zustand/shallow';
 import { Subscription } from 'rxjs';

--- a/packages/ui/src/factories/ReactFlowFactory.ts
+++ b/packages/ui/src/factories/ReactFlowFactory.ts
@@ -25,8 +25,9 @@ export const ReactFlowFactory = {
             if (node.type === 'Input') return 'inputNodeComponent';
             if (node.type === 'Output') return 'outputNodeComponent';
             if (node.type === 'Table') return 'tableNodeComponent';
+            if (node.type === 'ConsoleLog') return 'consoleNodeComponent';
 
-            return 'nodeComponent'
+            return 'nodeComponent';
           })(),
         }
       }),


### PR DESCRIPTION
1.1 Remove the `ExecutionUpdate` method.
 1.3 Update the console Node using ItemsObserver; developers can also listen to items data with ItemsObserver.

![image](https://github.com/user-attachments/assets/00911376-95db-45d2-ad45-12ddd1a11637)

https://github.com/user-attachments/assets/c107605c-dc64-4850-9005-39feaf1ce8f7

I've decided to keep the design of the hooks for now, as I believe it's a solid approach that could be utilized in other computers in the future.