### PR TITLE
feat: Add a `throttleMs` parameter to implement throttling for data observations.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,8 @@
   "dependencies": {
     "axios": "^1.3.4",
     "dotenv": "^16.0.3",
-    "nanoid": "3"
+    "nanoid": "3",
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@types/node": "18.14.2",

--- a/packages/core/src/InputObserverController.ts
+++ b/packages/core/src/InputObserverController.ts
@@ -16,6 +16,8 @@ type MemoryLinksCountObserver = {
   count: number;
 }
 
+const ThrottleMS: number = 100;
+
 export class InputObserverController {
 
   public executionObservers: ExecutionObserver[] = [];
@@ -48,7 +50,7 @@ export class InputObserverController {
         filter(payload =>  observer.linkIds.includes(payload.linkId)),
         map(payload => payload.items),
         // todo: could implement a timer that doesn't rely on bufferTime.
-        bufferTime(observer.throttleMs ?? 100),
+        bufferTime(observer.throttleMs ?? ThrottleMS),
         filter(it=>it.length > 0),
         map(bufferedItems => bufferedItems.flat(1)),
         tap(items => {
@@ -59,7 +61,7 @@ export class InputObserverController {
       subscription = this.links$.pipe(
         filter(payload => observer.linkIds.includes(payload.linkId)),
         map(payload => payload),
-        bufferTime(observer.throttleMs ?? 100),
+        bufferTime(observer.throttleMs ?? ThrottleMS),
         filter(it=>it.length > 0),
         map(bufferedCounts => bufferedCounts.flat(1)),
         tap(counts => {

--- a/packages/core/src/InputObserverController.ts
+++ b/packages/core/src/InputObserverController.ts
@@ -1,9 +1,7 @@
 import { ItemValue } from './types/ItemValue';
 import { RequestObserverType } from './types/InputObserveConfig';
-import { InputObserver } from './types/InputObserver';
-import { ExecutionObserver, ItemsObserver, LinkCountsObserver } from './types/ExecutionObserver';
-import { bufferTime, fromEvent, Subject, Subscription, takeUntil } from 'rxjs';
-import { itemsObserver } from '@data-story/nodejs/dist/server/messageHandlers';
+import { ExecutionObserver, LinkCountsObserver } from './types/ExecutionObserver';
+import { bufferTime, Subject, Subscription, takeUntil } from 'rxjs';
 import { filter, map, tap } from 'rxjs/operators';
 
 type MemoryItemObserver = {
@@ -85,6 +83,7 @@ export class InputObserverController {
     if (observer?.observerId) {
       const subscription = this.observerMap.get(observer.observerId);
       if (subscription) {
+        console.log('真正需要被取消订阅的 cancel Unsubscribe observer', observer.observerId);
         subscription.unsubscribe();
         this.observerMap.delete(observer.observerId);
       }

--- a/packages/core/src/InputObserverController.ts
+++ b/packages/core/src/InputObserverController.ts
@@ -2,6 +2,9 @@ import { ItemValue } from './types/ItemValue';
 import { RequestObserverType } from './types/InputObserveConfig';
 import { InputObserver } from './types/InputObserver';
 import { ExecutionObserver, ItemsObserver, LinkCountsObserver } from './types/ExecutionObserver';
+import { bufferTime, fromEvent, Subject, Subscription, takeUntil } from 'rxjs';
+import { itemsObserver } from '@data-story/nodejs/dist/server/messageHandlers';
+import { filter, map, tap } from 'rxjs/operators';
 
 type MemoryItemObserver = {
   type: RequestObserverType.itemsObserver;
@@ -19,17 +22,21 @@ export class InputObserverController {
 
   public executionObservers: ExecutionObserver[] = [];
 
+  private items$ = new Subject<MemoryItemObserver>();
+  private observerMap: Map<string, Subscription> = new Map();
+
   /**
    * Constructs an instance of InputObserverController
    */
-  constructor() {}
+  constructor() {
+  }
 
   /**
    * Determines if a report should be sent for a given inputObserver ( nodeId and portId )
    */
-  private isReport (inputObserver: MemoryItemObserver | MemoryLinksCountObserver, type: RequestObserverType): ExecutionObserver[] {
+  private findObservers(inputObserver: MemoryItemObserver | MemoryLinksCountObserver, type: RequestObserverType): ExecutionObserver[] {
     return this.executionObservers.filter((executionObserver) => {
-      return executionObserver.linkIds.includes(inputObserver.linkId) && executionObserver.type === type;
+      // return executionObserver.linkIds.includes(inputObserver.linkId) && executionObserver.type === type;
     });
   }
 
@@ -37,14 +44,11 @@ export class InputObserverController {
    * When we invoke `reportItems`, it triggers the `notifyObservers` callback and forwards the `items` and `inputObserver` parameters
    */
   reportItems(memoryObserver: MemoryItemObserver): void {
-    const inputObservers = this.isReport(memoryObserver, RequestObserverType.itemsObserver) as ItemsObserver[];
-    inputObservers.map((inputObserver) => {
-      inputObserver.onReceive(memoryObserver.items, inputObserver as unknown as InputObserver);
-    })
+    this.items$.next(memoryObserver);
   }
 
   reportLinksCount(memoryObserver: MemoryLinksCountObserver): void {
-    const inputObservers = this.isReport(memoryObserver, RequestObserverType.linkCountsObserver) as LinkCountsObserver[];
+    const inputObservers = this.findObservers(memoryObserver, RequestObserverType.linkCountsObserver) as LinkCountsObserver[];
     inputObservers.map((inputObserver) => {
       inputObserver.onReceive({
         links: [{
@@ -56,7 +60,34 @@ export class InputObserverController {
     })
   }
 
+  // todo: 添加一个取消订阅的方法
+  /**
+   * 1. 如果想要取消订阅，需要为每个请求的 observer 添加一个 ObserverId
+   * 1.1 后端需要存储一个 Map<ObserverId, Observer>
+   * 2. 取消订阅时，需要重新发送一个请求，将对应的 ObserverId 请求传递给后端，
+   * 2.1 后端根据 ObserverId 找到对应的 Observer，然后取消订阅
+   */
+
   pushExecutionObserver(observer: ExecutionObserver): void {
-    this.executionObservers.push(observer);
+    if(observer.type === 'itemsObserver') {
+      const subscription = this.items$.pipe(
+        filter(payload => observer.linkIds.includes(payload.linkId)),
+        map(payload => payload.items),
+        bufferTime(observer.throttleMs ?? 0),
+        map(bufferedItems => bufferedItems.flat(1)),
+        tap(items => observer.onReceive(items))
+      ).subscribe();
+      if (observer?.observerId) this.observerMap.set(observer.observerId, subscription);
+    }
+  }
+
+  pullExecutionObserver(observer: ExecutionObserver): void {
+    if (observer?.observerId) {
+      const subscription = this.observerMap.get(observer.observerId);
+      if (subscription) {
+        subscription.unsubscribe();
+        this.observerMap.delete(observer.observerId);
+      }
+    }
   }
 }

--- a/packages/core/src/OutputDevice.ts
+++ b/packages/core/src/OutputDevice.ts
@@ -1,14 +1,9 @@
 import { LinkId } from './types/Link'
 import { ItemValue } from './types/ItemValue'
-import { PortId } from './types/PortId'
 import { ExecutionMemory } from './ExecutionMemory'
 import { ItemWithParams, isItemWithParams } from './ItemWithParams'
 import { PortName } from './types/Port'
 import { Node } from './types/Node';
-
-type LinkItems = Record<LinkId, ItemValue[]>
-
-export type OutputTree = Record<PortId, LinkItems>
 
 export type PortLinkMap = Record<PortName, LinkId[]>
 
@@ -56,7 +51,6 @@ export class OutputDevice {
         // Clone items to ensure induvidual mutation per branch
         formattedItems
       )
-      // console.log('OutputDevice pushTo linkId:', linkId, 'formattedItems', formattedItems);
       // Update link counts
       const count = this.memory.getLinkCount(linkId)!
       this.memory.setLinkCount(linkId, count + items.length);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,7 +43,7 @@ export { jsExpressionEvaluation } from './Param/evaluations/jsExpressionEvaluati
 export { numberCast } from './Param/casts/numberCast'
 export { stringCast } from './Param/casts/stringCast'
 export { core } from './core'
-export type { LinkCountInfo, LinkCountsObserver, ExecutionObserver, ItemsObserver, NodeObserver } from './types/ExecutionObserver'
+export type { LinkCountInfo, LinkCountsObserver, ExecutionObserver, ItemsObserver, NodeObserver, CancelObserver } from './types/ExecutionObserver'
 export * as nodes from './computers'
 export * from './Param'
 export { Registry } from './Registry'

--- a/packages/core/src/types/ExecutionObserver.ts
+++ b/packages/core/src/types/ExecutionObserver.ts
@@ -29,12 +29,19 @@ export type LinkCountsObserver = {
     links: LinkCountInfo[],
   }) => void,
 }
+
 export type NodeObserver = {
-  type: 'NodeObserver',
+  type: RequestObserverType.notifyDataUpdate,
   nodeId: string,
   onlyStatuses: string[],
   onlyOncePerStatus?: boolean,
   throttleMs?: number,
   onReceive: (data: any) => void,
 }
-export type ExecutionObserver = ItemsObserver | LinkCountsObserver;
+
+export type CancelObserver = {
+  type: RequestObserverType.cancelObserver,
+  observerId: string,
+}
+
+export type ExecutionObserver = ItemsObserver | LinkCountsObserver | CancelObserver;

--- a/packages/core/src/types/ExecutionObserver.ts
+++ b/packages/core/src/types/ExecutionObserver.ts
@@ -5,7 +5,7 @@ export type ItemsObserver = {
   type: RequestObserverType.itemsObserver,
   linkIds: string[],
   onReceive: NotifyObserversCallback,
-  observerId?: string,
+  observerId: string,
   direction?: 'pull' | 'push',
   onlyFirstNItems?: number,
   throttleMs?: number,
@@ -21,8 +21,8 @@ export interface LinkCountInfo {
 export type LinkCountsObserver = {
   type: RequestObserverType.linkCountsObserver,
   linkIds: string[],
+  observerId: string,
   state?: 'running' | 'complete',
-  observerId?: string,
   throttleMs?: number,
   msgId?: string,
   onReceive: (params:{

--- a/packages/core/src/types/InputObserveConfig.ts
+++ b/packages/core/src/types/InputObserveConfig.ts
@@ -2,6 +2,7 @@ export enum RequestObserverType {
   linkCountsObserver = 'linkCountsObserver',
   itemsObserver = 'itemsObserver',
   notifyDataUpdate = 'notifyDataUpdate',
+  cancelObserver = 'cancelObserver',
 }
 export type InputObserveConfig = {nodeId: string, portId?: string, type: RequestObserverType}
 | {linkId: string, type: RequestObserverType};

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -33,6 +33,7 @@
     "global.d.ts"
   ],
   "exclude": [
-    "./node_modules"
+    "./node_modules",
+    "./dist"
   ]
 }

--- a/packages/docs/components/demos/ObserversDemo.tsx
+++ b/packages/docs/components/demos/ObserversDemo.tsx
@@ -1,4 +1,4 @@
-import { core, nodes, RequestObserverType } from '@data-story/core';
+import { core, createDataStoryId, nodes, RequestObserverType } from '@data-story/core';
 import React from 'react';
 import { DataStory } from '@data-story/ui';
 import { CustomizeJSClient } from '../splash/CustomizeJSClient';
@@ -9,13 +9,16 @@ const diagram = core.getDiagramBuilder()
   .add(Signal, { period: 5, count: 10 })
   .add(Table)
   .get();
+const observerId = createDataStoryId();
 const linksCountObserver = {
   type: RequestObserverType.linkCountsObserver as const,
   linkIds: [diagram.links[0]?.id],
   onReceive: (count) => {
     console.log('Link count', count);
-  }
+  },
+  observerId: createDataStoryId(),
 }
+
 export default () => {
   const { app, loading } = useRequestApp();
   const client = new CustomizeJSClient({ diagram: diagram, app });
@@ -26,6 +29,7 @@ export default () => {
       <DataStory
         client={client}
         itemsObserver={{
+          observerId,
           type: RequestObserverType.itemsObserver,
           // set the linkIds that you want to observe
           linkIds: [diagram.links[0]?.id],

--- a/packages/docs/components/demos/VisualizeDemo.tsx
+++ b/packages/docs/components/demos/VisualizeDemo.tsx
@@ -1,4 +1,4 @@
-import { core, nodes, RequestObserverType } from '@data-story/core';
+import { core, createDataStoryId, nodes, RequestObserverType } from '@data-story/core';
 import React, { useMemo } from 'react';
 import { DataStory } from '@data-story/ui';
 import {
@@ -53,12 +53,14 @@ const diagram = core.getDiagramBuilder()
   .add(Table)
   .get();
 
+const observerId = createDataStoryId();
 const linksCountObserver = {
   type: RequestObserverType.linkCountsObserver as const,
   linkIds: [diagram.links[1].id],
   onReceive: (count) => {
     console.log('Link count', count);
-  }
+  },
+  observerId: createDataStoryId(),
 }
 
 export default () => {
@@ -112,7 +114,8 @@ export default () => {
                 ...points,
                 ...items,
               ].slice(-100));
-            }
+            },
+            observerId
           }}
           linksCountObserver={linksCountObserver}
         />

--- a/packages/ui/src/components/DataStory/DataStory.tsx
+++ b/packages/ui/src/components/DataStory/DataStory.tsx
@@ -9,6 +9,7 @@ import { DataStoryCanvasProvider } from './store/store';
 import { DataStoryCanvas } from './DataStoryCanvas';
 import { useRequest } from 'ahooks';
 import { LoadingMask } from './common/loadingMask';
+import { ItemsObserver } from '@data-story/core';
 
 function handleRequestError(requestError?: Error): void {
   if (requestError) console.error(`Error fetching : ${requestError?.message}`);
@@ -17,7 +18,7 @@ function handleRequestError(requestError?: Error): void {
 export const DataStoryComponent = (
   props: DataStoryProps
 ) => {
-  const { client, initSidebarKey, children, initDiagram, onChange } = props;
+  const { client, initSidebarKey, children, initDiagram, onChange, linksCountObserver, itemsObserver} = props;
   const [selectedNode, setSelectedNode] = useState<ReactFlowNode>();
   const [isSidebarClose, setIsSidebarClose] = useState(!!props.hideSidebar);
   const partialStoreRef = useRef<Partial<StoreSchema>>(null);
@@ -46,6 +47,18 @@ export const DataStoryComponent = (
     refreshDeps: [client], // Will re-fetch if client changes
   });
   handleRequestError(diagramDataError);
+
+  useEffect(() => {
+    if (client?.itemsObserver && itemsObserver) {
+      client?.itemsObserver?.(itemsObserver as ItemsObserver)
+    }
+  }, [itemsObserver, client.itemsObserver]);
+
+  useEffect(() => {
+    if (client?.linksCountObserver && linksCountObserver) {
+      client?.linksCountObserver?.(linksCountObserver);
+    }
+  }, [client?.linksCountObserver, linksCountObserver]);
 
   useEffect(() => {
     if (sidebarKey !== 'node') {

--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -93,18 +93,6 @@ const Flow = ({
   const { addSelectedNodes, setNodes } = reactFlowStore.getState();
 
   useEffect(() => {
-    if (client?.itemsObserver && itemsObserver) {
-      client?.itemsObserver?.(itemsObserver as ItemsObserver)
-    }
-  }, [itemsObserver, client.itemsObserver]);
-
-  useEffect(() => {
-    if (client?.linksCountObserver && linksCountObserver) {
-      client?.linksCountObserver?.(linksCountObserver);
-    }
-  }, [client?.linksCountObserver, linksCountObserver]);
-
-  useEffect(() => {
     if (onInitialize && onRun && isExecutePostRenderEffect) {
       onInitialize({ run: onRun });
       setIsExecutePostRenderEffect(false);

--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -128,24 +128,25 @@ const Flow = ({
       observerId,
       linkIds: allLinkIds,
       type: RequestObserverType.linkCountsObserver,
-      throttleMs: 50,
       onReceive: ({ links }) => {
         if (!links || links.length === 0) return;
+
         const edgeCounts = links.reduce((acc, link) => {
           acc[link.linkId] = link.count;
           return acc;
         }, {});
+
         updateEdgeCounts({
           edgeCounts: edgeCounts,
           state: links[0].state || 'complete',
         })
       }
     })
-
     return () => {
       client?.cancelObserver?.({ observerId, type: RequestObserverType.cancelObserver });
     }
-  }, [client, edges, updateEdgeCounts]);
+  // listen to edges.length because changes in the count on edges trigger this useEffect, leading to frequent subscriptions and unsubscriptions, which can impact performance.
+  }, [client, edges.length, updateEdgeCounts]);
 
   const hotkeyManager = useMemo(() => new HotkeyManager(flowRef), []);
   const setShowRun = useCallback((show: boolean) => setSidebarKey!(show ? 'run' : ''), [setSidebarKey]);

--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -124,15 +124,19 @@ const Flow = ({
   useEffect(() => {
     const observerId = createDataStoryId();
     const allLinkIds = edges.map(edge => edge.id);
-    console.log('allLinkIds linksCountObserver observer', observerId);
     client?.linksCountObserver?.({
       observerId,
       linkIds: allLinkIds,
       type: RequestObserverType.linkCountsObserver,
+      throttleMs: 50,
       onReceive: ({ links }) => {
         if (!links || links.length === 0) return;
+        const edgeCounts = links.reduce((acc, link) => {
+          acc[link.linkId] = link.count;
+          return acc;
+        }, {});
         updateEdgeCounts({
-          edgeCounts: { [links[0].linkId]: links[0].count },
+          edgeCounts: edgeCounts,
           state: links[0].state || 'complete',
         })
       }
@@ -140,7 +144,6 @@ const Flow = ({
 
     return () => {
       client?.cancelObserver?.({ observerId, type: RequestObserverType.cancelObserver });
-      console.log('allLinkIds linksCountObserver cancel observer', observerId);
     }
   }, [client, edges, updateEdgeCounts]);
 

--- a/packages/ui/src/components/DataStory/clients/WorkspaceApiClient.ts
+++ b/packages/ui/src/components/DataStory/clients/WorkspaceApiClient.ts
@@ -1,5 +1,5 @@
 import { ClientRunParams } from '../types';
-import { Diagram, ItemsObserver, LinkCountsObserver, NodeDescription } from '@data-story/core';
+import { CancelObserver, Diagram, ItemsObserver, LinkCountsObserver, NodeDescription } from '@data-story/core';
 import { Subscription } from 'rxjs';
 
 export interface WorkspaceApiClient {
@@ -9,4 +9,5 @@ export interface WorkspaceApiClient {
   getDiagram?: ({ path }: {path?: string}) => Promise<Diagram>;
   linksCountObserver?:(params: LinkCountsObserver) => void;
   itemsObserver?: (params: ItemsObserver) => Subscription;
+  cancelObserver?:(params: CancelObserver) => Promise<void>
 }

--- a/packages/ui/src/components/DataStory/clients/WorkspaceApiClientBase.ts
+++ b/packages/ui/src/components/DataStory/clients/WorkspaceApiClientBase.ts
@@ -100,7 +100,6 @@ export class WorkspaceApiClientBase implements WorkspaceApiClient {
     const data = await this.transport.sendAndReceive({
       ...params,
     });
-    console.log('Cancel observer', data);
   }
 
   run({ diagram }: ClientRunParams): void {

--- a/packages/ui/src/components/DataStory/clients/WorkspaceApiClientBase.ts
+++ b/packages/ui/src/components/DataStory/clients/WorkspaceApiClientBase.ts
@@ -12,6 +12,7 @@ import {
 } from '@data-story/core';
 import { eventManager } from '../events/eventManager';
 import { DataStoryEvents } from '../events/dataStoryEventType';
+import { CancelObserver } from '@data-story/core/src';
 
 export interface Transport {
   sendAndReceive<T>(params: Record<string, any>): Promise<T>;
@@ -20,7 +21,7 @@ export interface Transport {
 }
 
 const matchMsgType = (type: string) => it => it.type === type;
-function removeUnserializable(params: ExecutionObserver): Partial<ExecutionObserver> {
+function removeUnserializable(params: Exclude<ExecutionObserver, CancelObserver>): Partial<ExecutionObserver> {
   const { onReceive, ...serializableParams } = params;
 
   return JSON.parse(JSON.stringify(serializableParams));
@@ -93,6 +94,13 @@ export class WorkspaceApiClientBase implements WorkspaceApiClient {
       const { links } = data as { links: LinkCountInfo[] };
       params.onReceive({ links });
     });
+  }
+
+  async cancelObserver(params: ExecutionObserver): Promise<void> {
+    const data = this.transport.sendAndReceive({
+      ...params,
+    });
+    console.log('Cancel observer', data);
   }
 
   run({ diagram }: ClientRunParams): void {

--- a/packages/ui/src/components/DataStory/clients/WorkspaceApiClientBase.ts
+++ b/packages/ui/src/components/DataStory/clients/WorkspaceApiClientBase.ts
@@ -8,11 +8,11 @@ import {
   ItemValue, LinkCountsObserver,
   NodeDescription,
   LinkCountInfo,
-  ExecutionObserver
+  ExecutionObserver,
+  CancelObserver
 } from '@data-story/core';
 import { eventManager } from '../events/eventManager';
 import { DataStoryEvents } from '../events/dataStoryEventType';
-import { CancelObserver } from '@data-story/core/src';
 
 export interface Transport {
   sendAndReceive<T>(params: Record<string, any>): Promise<T>;
@@ -96,8 +96,8 @@ export class WorkspaceApiClientBase implements WorkspaceApiClient {
     });
   }
 
-  async cancelObserver(params: ExecutionObserver): Promise<void> {
-    const data = this.transport.sendAndReceive({
+  async cancelObserver(params: CancelObserver): Promise<void> {
+    const data = await this.transport.sendAndReceive({
       ...params,
     });
     console.log('Cancel observer', data);

--- a/packages/ui/src/components/DataStory/mockJSServer/messageHandlers.ts
+++ b/packages/ui/src/components/DataStory/mockJSServer/messageHandlers.ts
@@ -88,6 +88,10 @@ export const getDefaultMsgHandlers = (app: Application, inputObserverController:
 
   const cancelObserver = ({ data, sendEvent }: HandlerParam) => {
     inputObserverController.pullExecutionObserver(data as ExecutionObserver);
+    sendEvent({
+      ...data as Record<string, unknown>,
+      cancelObserver: true
+    });
   }
 
   const notifyDataUpdate = ({ data, sendEvent }: HandlerParam) => {
@@ -123,6 +127,7 @@ export const getDefaultMsgHandlers = (app: Application, inputObserverController:
     getDiagram,
     linkCountsObserver,
     itemsObserver,
-    notifyDataUpdate
+    notifyDataUpdate,
+    cancelObserver
   }
 }

--- a/packages/ui/src/components/DataStory/mockJSServer/messageHandlers.ts
+++ b/packages/ui/src/components/DataStory/mockJSServer/messageHandlers.ts
@@ -9,6 +9,7 @@ import {
   type ItemsObserver, LinkCountsObserver
 } from '@data-story/core';
 import { loadDiagram, saveDiagram } from './storeDiagram';
+import { ExecutionObserver } from '@data-story/core/src';
 
 type RunMessage = {
   msgId: string,
@@ -83,6 +84,10 @@ export const getDefaultMsgHandlers = (app: Application, inputObserverController:
         })
       }
     } as ItemsObserver);
+  }
+
+  const cancelObserver = ({ data, sendEvent }: HandlerParam) => {
+    inputObserverController.pullExecutionObserver(data as ExecutionObserver);
   }
 
   const notifyDataUpdate = ({ data, sendEvent }: HandlerParam) => {

--- a/packages/ui/src/components/DataStory/store/store.tsx
+++ b/packages/ui/src/components/DataStory/store/store.tsx
@@ -155,30 +155,10 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
     get()?.client?.run({
       diagram: get().toDiagram(),
     });
-    // update the diagram edges with the link counts
-    if (get().client?.linksCountObserver) {
-      get().linkCountsObserver();
-    }
   },
 
   setParams: (params: Param[]) => {
     set({ params })
-  },
-
-  // Since linkCountsObserver is working with real-time data, it receive one data point at a time. Once throttling is implemented, we will switch to batch transmission.
-  linkCountsObserver: () => {
-    const allLinkIds = get().edges.map(edge => edge.id);
-    get().client?.linksCountObserver?.({
-      linkIds: allLinkIds,
-      type: RequestObserverType.linkCountsObserver,
-      onReceive: ({ links }) => {
-        if (!links || links.length === 0) return;
-        get().updateEdgeCounts({
-          edgeCounts: { [links[0].linkId]: links[0].count },
-          state: links[0].state || 'complete',
-        })
-      }
-    })
   },
 
   updateEdgeCounts: ({ edgeCounts, state }) => {

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -92,7 +92,6 @@ export type NodeSettingsFormProps = {
 
 export type StoreSchema = {
   client?: WorkspaceApiClient;
-  linkCountsObserver: () => void;
 
   /** The main reactflow instance */
   rfInstance: StoreInitOptions['rfInstance'] | undefined;

--- a/packages/ui/src/components/Node/ConsoleNodeComponent.tsx
+++ b/packages/ui/src/components/Node/ConsoleNodeComponent.tsx
@@ -5,7 +5,7 @@ import { useStore } from '../DataStory/store/store';
 import { shallow } from 'zustand/shallow';
 import { Subscription } from 'rxjs';
 import { useMount, useUnmount } from 'ahooks';
-import { ItemsObserver, RequestObserverType } from '@data-story/core';
+import { createDataStoryId, ItemsObserver, RequestObserverType } from '@data-story/core';
 import { StoreSchema } from '../DataStory/types';
 
 const ConsoleNodeComponent = ({ id, data, selected }: {
@@ -17,14 +17,15 @@ const ConsoleNodeComponent = ({ id, data, selected }: {
   return <NodeComponent id={id} data={data} selected={selected}/>
 }
 
+let consoleSubscription: Subscription;
+const observerId = createDataStoryId();
+
 const useObserverConsole = ({ id }: {id: string}) => {
   const selector = (state: StoreSchema) => ({
     toDiagram: state.toDiagram,
     client: state.client,
   });
   const { toDiagram, client } = useStore(selector, shallow);
-
-  let consoleSubscription: Subscription;
   // Add the node to the inputObservers when the node is mounted
   useMount(() => {
     const linkId = toDiagram()?.getLinkIdFromNodeId?.(id, 'input');
@@ -32,6 +33,7 @@ const useObserverConsole = ({ id }: {id: string}) => {
     const consoleObserver: ItemsObserver = {
       linkIds: [linkId],
       type: RequestObserverType.itemsObserver,
+      observerId,
       onReceive: (batchedItems) => {
         console.log(...batchedItems ?? []);
       }
@@ -41,7 +43,9 @@ const useObserverConsole = ({ id }: {id: string}) => {
   });
 
   useUnmount(() => {
+    // todo: unsubscribe also moves to workspace
     consoleSubscription?.unsubscribe();
+    client?.cancelObserver?.({ observerId, type: RequestObserverType.cancelObserver });
   });
 }
 export default memo(ConsoleNodeComponent);

--- a/packages/ui/src/components/Node/ConsoleNodeComponent.tsx
+++ b/packages/ui/src/components/Node/ConsoleNodeComponent.tsx
@@ -17,7 +17,6 @@ const ConsoleNodeComponent = ({ id, data, selected }: {
   return <NodeComponent id={id} data={data} selected={selected}/>
 }
 
-let consoleSubscription: Subscription;
 const observerId = createDataStoryId();
 
 const useObserverConsole = ({ id }: {id: string}) => {
@@ -39,12 +38,10 @@ const useObserverConsole = ({ id }: {id: string}) => {
       }
     }
 
-    consoleSubscription = client?.itemsObserver?.(consoleObserver);
+    client?.itemsObserver?.(consoleObserver);
   });
 
   useUnmount(() => {
-    // todo: unsubscribe also moves to workspace
-    consoleSubscription?.unsubscribe();
     client?.cancelObserver?.({ observerId, type: RequestObserverType.cancelObserver });
   });
 }

--- a/packages/ui/src/components/Node/UseObserverTable.tsx
+++ b/packages/ui/src/components/Node/UseObserverTable.tsx
@@ -5,7 +5,6 @@ import { useMount, useUnmount } from 'ahooks';
 import { shallow } from 'zustand/shallow';
 import { Subscription } from 'rxjs';
 
-let tableSubscription: Subscription;
 const observerId = createDataStoryId();
 export function useObserverTable({ id, isDataFetched, setIsDataFetched, setItems }: {
   id: string,
@@ -28,22 +27,19 @@ export function useObserverTable({ id, isDataFetched, setIsDataFetched, setItems
       observerId,
       linkIds: [linkId],
       type: RequestObserverType.itemsObserver,
-      throttleMs: 300,
+      throttleMs: 2000,
       onReceive: (batchedItems) => {
         if (!isDataFetched) {
           setIsDataFetched(true);
         }
-        console.log('batchedItems', batchedItems);
-
         setItems(prevItems => [...prevItems, ...batchedItems.flat()]);
       }
     }
 
-    tableSubscription = client?.itemsObserver?.(tableObserver);
+    client?.itemsObserver?.(tableObserver);
   });
 
   useUnmount(() => {
-    tableSubscription?.unsubscribe();
     client?.cancelObserver?.({ observerId, type: RequestObserverType.cancelObserver });
   });
 }

--- a/packages/ui/src/components/Node/UseObserverTable.tsx
+++ b/packages/ui/src/components/Node/UseObserverTable.tsx
@@ -1,10 +1,12 @@
 import { useStore } from '../DataStory/store/store';
 import { StoreSchema } from '../DataStory/types';
-import { ItemsObserver, RequestObserverType } from '@data-story/core';
+import { createDataStoryId, ItemsObserver, RequestObserverType } from '@data-story/core';
 import { useMount, useUnmount } from 'ahooks';
 import { shallow } from 'zustand/shallow';
 import { Subscription } from 'rxjs';
 
+let tableSubscription: Subscription;
+const observerId = createDataStoryId();
 export function useObserverTable({ id, isDataFetched, setIsDataFetched, setItems }: {
   id: string,
   isDataFetched: boolean,
@@ -18,18 +20,19 @@ export function useObserverTable({ id, isDataFetched, setIsDataFetched, setItems
 
   const { toDiagram, client } = useStore(selector, shallow);
 
-  let tableSubscription: Subscription;
   // Add the node to the inputObservers when the node is mounted
   useMount(() => {
     const linkId = toDiagram()?.getLinkIdFromNodeId?.(id, 'input');
     if (!client?.itemsObserver || !linkId) return;
     const tableObserver: ItemsObserver = {
+      observerId,
       linkIds: [linkId],
       type: RequestObserverType.itemsObserver,
       onReceive: (batchedItems) => {
         if (!isDataFetched) {
           setIsDataFetched(true);
         }
+        console.log('batchedItems', batchedItems);
 
         setItems(prevItems => [...prevItems, ...batchedItems.flat()]);
       }
@@ -40,5 +43,6 @@ export function useObserverTable({ id, isDataFetched, setIsDataFetched, setItems
 
   useUnmount(() => {
     tableSubscription?.unsubscribe();
+    client?.cancelObserver?.({ observerId, type: RequestObserverType.cancelObserver });
   });
 }

--- a/packages/ui/src/components/Node/UseObserverTable.tsx
+++ b/packages/ui/src/components/Node/UseObserverTable.tsx
@@ -3,7 +3,6 @@ import { StoreSchema } from '../DataStory/types';
 import { createDataStoryId, ItemsObserver, RequestObserverType } from '@data-story/core';
 import { useMount, useUnmount } from 'ahooks';
 import { shallow } from 'zustand/shallow';
-import { Subscription } from 'rxjs';
 
 const observerId = createDataStoryId();
 export function useObserverTable({ id, isDataFetched, setIsDataFetched, setItems }: {
@@ -27,7 +26,7 @@ export function useObserverTable({ id, isDataFetched, setIsDataFetched, setItems
       observerId,
       linkIds: [linkId],
       type: RequestObserverType.itemsObserver,
-      throttleMs: 2000,
+      throttleMs: 3000,
       onReceive: (batchedItems) => {
         if (!isDataFetched) {
           setIsDataFetched(true);

--- a/packages/ui/src/components/Node/UseObserverTable.tsx
+++ b/packages/ui/src/components/Node/UseObserverTable.tsx
@@ -28,6 +28,7 @@ export function useObserverTable({ id, isDataFetched, setIsDataFetched, setItems
       observerId,
       linkIds: [linkId],
       type: RequestObserverType.itemsObserver,
+      throttleMs: 300,
       onReceive: (batchedItems) => {
         if (!isDataFetched) {
           setIsDataFetched(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -478,6 +478,7 @@ __metadata:
     axios: "npm:^1.3.4"
     dotenv: "npm:^16.0.3"
     nanoid: "npm:3"
+    rxjs: "npm:^7.8.1"
     ts-node: "npm:^10.9.1"
     typescript: "npm:4.9.5"
     vite: "npm:^5.0.10"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0ba07381-f1c2-4bb2-ad78-788f2611375a)


In the video below, I've set the throttleMs for the table's itemsObserver to 3000 milliseconds, while the throttleMs for the linksCountObserver and itemsObserver remains at the default of 100 milliseconds.

https://github.com/user-attachments/assets/4430d4f3-6591-4cf7-81e2-768a1418ee8a

