### PR TITLE
Use less aggressive max zoom when adding new nodes

### DIFF
--- a/packages/ui/src/components/DataStory/store/store.tsx
+++ b/packages/ui/src/components/DataStory/store/store.tsx
@@ -94,7 +94,9 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
     get().selectNode(node.id)
 
     setTimeout(() => {
-      get().rfInstance?.fitView();
+      get().rfInstance?.fitView({
+        maxZoom: 3,
+      });
       get().focusOnFlow();
     }, 1);
   },


### PR DESCRIPTION
Sets maxZoom in `fitView` when adding new node

### Before (exessive zoom in)
<img width="1053" alt="image" src="https://github.com/user-attachments/assets/38b8ac6a-4419-41a1-ae95-09b027591b98">


### After
<img width="1031" alt="image" src="https://github.com/user-attachments/assets/0c2e8ac1-4364-435f-9d16-67e31f9ca3c1">
