### PR TITLE
Enable requesting HTML

### DIFF
--- a/packages/core/src/computers/Request.ts
+++ b/packages/core/src/computers/Request.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { json_, str } from '../Param';
 import { get } from '../utils/get';
 import { Computer } from '../types/Computer';
+import { asArray } from '../utils/asArray';
 
 export const Request: Computer = {
   name: 'Request',
@@ -63,13 +64,15 @@ export const Request: Computer = {
 
       if(method === 'GET') {
         const response = await axios.get(url, config)
-        const items = get(response.data, item_path)
+        const itemables = get(response.data, item_path)
+        const items = asArray(itemables)
         output.pushTo('items', items)
       }
 
       if(method === 'POST') {
         const response = await axios.post(url, body, config)
-        const items = get(response.data, item_path)
+        const itemables = get(response.data, item_path)
+        const items = asArray(itemables)
         output.pushTo('items', items)
       }
 

--- a/packages/ui/src/components/DataStory/clients/WorkspaceApiClient.ts
+++ b/packages/ui/src/components/DataStory/clients/WorkspaceApiClient.ts
@@ -187,9 +187,7 @@ export class WorkspaceApiClient implements WorkspaceApiClientImplement {
   private initExecutionFailure() {
     return this.receivedMsg$.pipe(filter(matchMsgType('ExecutionFailure')))
       .subscribe((data: any) => {
-        console.error('Execution failed: ', {
-          history: data.history,
-        })
+        console.error('Execution failed')
 
         eventManager.emit({
           type: DataStoryEvents.RUN_ERROR,


### PR DESCRIPTION
This PR enables fetching HTML with Request node.
The HTML will be outputted as a single item.

<img width="689" alt="image" src="https://github.com/user-attachments/assets/78680c71-3c5b-4704-a048-3b16bc31f1c7" />

### Follow ups
* In this case, Request will output ['<!DOCTYPE html>....</html>'] ie [s: string]. However, that does not conform to the type of ItemValue:

`export type ItemValue = Record<string, any>`