### PR TITLE
feat: Implement DiagramObserverStorage as a fallback for DuckDBStorage and improve the types

### DIFF
--- a/packages/core/src/InputDevice.test.ts
+++ b/packages/core/src/InputDevice.test.ts
@@ -226,7 +226,7 @@ describe('params', () => {
         name: 'greeting',
         label: 'Greeting',
         help: 'The greeting to use',
-        value: 'Hello ${name}',
+        value: 'Hello ${{name}}',
         multiline: false,
         canInterpolate: true,
         interpolate: true,

--- a/packages/core/src/InputObserverController.ts
+++ b/packages/core/src/InputObserverController.ts
@@ -11,7 +11,7 @@ import {
 import { bufferTime, Subject, Subscription } from 'rxjs';
 import { filter, map, tap } from 'rxjs/operators';
 import { LinkId } from './types/Link';
-import { GetDataFromStorage } from './types/GetDataFromStorage';
+import { GetDataFromStorage, LinkItems } from './types/GetDataFromStorage';
 import { NodeStatus } from './Executor';
 import { NodeId } from './types/Node';
 import { ObserverStorage } from './types/ObserverStorage';
@@ -57,8 +57,8 @@ export class InputObserverController {
 
   // The current requirement only needs to retain 'BUSY' and 'COMPLETE' in NodeStatus.
   async reportNodeStatus(nodeId: NodeId, status: NodeStatus): Promise<void> {
-    const currentStatus = await this.storage.getNodeStatus(nodeId);
-    if (status === 'AVAILABLE' || currentStatus === status) {
+    const preStatus = await this.storage.getNodeStatus(nodeId);
+    if (status === 'AVAILABLE' || preStatus === status) {
       return;
     }
     this.nodeStatus$.next({nodeId, status});
@@ -69,8 +69,8 @@ export class InputObserverController {
     linkId,
     limit = 100,
     offset = 0
-  }: GetDataFromStorage): Promise<Record<LinkId, ItemValue[]>> {
-    const items: Record<LinkId, ItemValue[]> = {};
+  }: GetDataFromStorage): Promise<LinkItems> {
+    const items: LinkItems = {};
     const currentItems = await this.storage.getLinkItems({linkId, offset, limit}) ?? [];
     items[linkId] = currentItems;
     return items;

--- a/packages/core/src/ItemWithParams/ItemWithParams.test.ts
+++ b/packages/core/src/ItemWithParams/ItemWithParams.test.ts
@@ -13,7 +13,7 @@ describe('value', () => {
       [
         str({
           name: 'greeting',
-          value: 'Hello ${name}!',
+          value: 'Hello ${{name}}!',
         })
       ],
       []
@@ -30,7 +30,7 @@ describe('params', () => {
       [
         str({
           name: 'greeting',
-          value: 'Hello ${name}!',
+          value: 'Hello ${{name}}!',
         })
       ],
       []

--- a/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
+++ b/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
@@ -47,7 +47,7 @@ export class StringableParamEvaluator implements ParamsValueEvaluator<Stringable
        * When the item value is { name: "Bob" }
        */
       transformedValue = transformedValue.replace(
-        /\${([\w\.]+)}/g,
+        /\${{([\w\.]+)}}/g,
         (_: string, name: string) => get(itemValue, name)
       );
     }

--- a/packages/core/src/V2/convertJSONToDiagram.test.ts
+++ b/packages/core/src/V2/convertJSONToDiagram.test.ts
@@ -21,7 +21,7 @@ describe('convertParams', () => {
     expect(signalParams).toEqual({
       period: 50,
       count: 300,
-      expression: '{\n  id: ${i}\n}'
+      expression: '{\n  id: ${{i}}\n}'
     });
   });
 

--- a/packages/core/src/computers/ConsoleLog.test.ts
+++ b/packages/core/src/computers/ConsoleLog.test.ts
@@ -12,7 +12,7 @@ it('register one console log per item', async () => {
 it('can register an interpolated console log message', async () => {
   await when(ConsoleLog)
     .hasParams({
-      message: 'Hello ${name}!'
+      message: 'Hello ${{name}}!'
     })
     .getsInput([{ id: 1, name: 'ajthinking' }])
     .doRun()

--- a/packages/core/src/computers/Request.ts
+++ b/packages/core/src/computers/Request.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { json_, str } from '../Param';
 import { get } from '../utils/get';
 import { Computer } from '../types/Computer';
+import { asArray } from '../utils/asArray';
 
 export const Request: Computer = {
   name: 'Request',
@@ -63,13 +64,15 @@ export const Request: Computer = {
 
       if(method === 'GET') {
         const response = await axios.get(url, config)
-        const items = get(response.data, item_path)
+        const itemables = get(response.data, item_path)
+        const items = asArray(itemables)
         output.pushTo('items', items)
       }
 
       if(method === 'POST') {
         const response = await axios.post(url, body, config)
-        const items = get(response.data, item_path)
+        const itemables = get(response.data, item_path)
+        const items = asArray(itemables)
         output.pushTo('items', items)
       }
 

--- a/packages/core/src/computers/Signal.test.ts
+++ b/packages/core/src/computers/Signal.test.ts
@@ -17,7 +17,7 @@ it('outputs items with the template provided', async () => {
     .hasParams({
       period: 1,
       count: 3,
-      expression: '{ identifier: ${i}}'
+      expression: '{ identifier: ${{i}} }'
     })
     .doRun()
     .expectOutput([{identifier: 1}])

--- a/packages/core/src/computers/Signal.ts
+++ b/packages/core/src/computers/Signal.ts
@@ -31,11 +31,11 @@ export const Signal: Computer = {
     hjson({
       name: 'expression',
       label: 'Template expression',
-      help: 'Use this field to customize the signal. ${i} is available as a variable.',
+      help: 'Use this field to customize the signal. ${{i}} is available as a variable.',
       // Avoid Hjson bug
       value: [
         '{',
-        '  id: ${i}',
+        '  id: ${{i}}',
         '}',
       ].join('\n'),
       evaluations: [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export { get } from './utils/get'
+export { asArray } from './utils/asArray'
 export { debounce } from './utils/debounce'
 export { sleep } from './utils/sleep'
 export { stringifyError } from './utils/stringifyError'

--- a/packages/core/src/storage/diagramObserverStorage.ts
+++ b/packages/core/src/storage/diagramObserverStorage.ts
@@ -48,4 +48,10 @@ export class DiagramObserverStorage implements ObserverStorage {
     this.nodeStatusStorage.set(nodeId, status);
   }
 
+  async close(): Promise<void> {
+    this.linkCountsStorage.clear();
+    this.linkItemsStorage.clear();
+    this.nodeStatusStorage.clear();
+  }
+
 }

--- a/packages/core/src/types/GetDataFromStorage.ts
+++ b/packages/core/src/types/GetDataFromStorage.ts
@@ -1,3 +1,4 @@
+import { ItemValue } from './ItemValue';
 import { LinkId } from './Link';
 
 export type GetDataFromStorage = {
@@ -7,3 +8,5 @@ export type GetDataFromStorage = {
   offset?: number,
   limit?: number,
 }
+
+export type LinkItems = Record<LinkId, ItemValue[]>

--- a/packages/core/src/types/ObserverStorage.ts
+++ b/packages/core/src/types/ObserverStorage.ts
@@ -25,4 +25,6 @@ export interface ObserverStorage {
   // Node Status
   getNodeStatus(nodeId: NodeId): Promise<NodeStatus | undefined>;
   setNodeStatus(nodeId: NodeId, status: NodeStatus): Promise<void>;
+
+  close(): Promise<void>;
 }

--- a/packages/core/src/utils/asArray.test.ts
+++ b/packages/core/src/utils/asArray.test.ts
@@ -1,0 +1,11 @@
+import { asArray } from './asArray';
+
+it('returns the input if it is an array', () => {
+  expect(asArray([1, 2, 3])).toEqual([1, 2, 3]);
+})
+
+it('returns an array with the input as the only element if it is not an array', () => {
+  expect(asArray(1)).toEqual([1]);
+  expect(asArray('hello')).toEqual(['hello']);
+  expect(asArray({ a: 1 })).toEqual([{ a: 1 }]);
+})

--- a/packages/core/src/utils/asArray.ts
+++ b/packages/core/src/utils/asArray.ts
@@ -1,0 +1,7 @@
+export const asArray = <T>(value: T | T[]): T[] => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  return [value];
+}

--- a/packages/ds-ext/src/DiagramEditorProvider.ts
+++ b/packages/ds-ext/src/DiagramEditorProvider.ts
@@ -15,7 +15,7 @@ import { observeLinkUpdate } from './messageHandlers/observeLinkUpdate';
 import { getDataFromStorage } from './messageHandlers/getDataFromStorage';
 import { cancelObservation } from './messageHandlers/cancelObservation';
 import { DuckDBStorage } from './duckDBStorage';
-import { createDataStoryDB } from './commands/createDataStoryDB';
+import { createDataStoryDBPath } from './commands/createDataStoryDBPath';
 
 export class DiagramEditorProvider implements vscode.CustomEditorProvider<DiagramDocument> {
   private readonly _onDidChangeCustomDocument = new vscode.EventEmitter<vscode.CustomDocumentEditEvent<DiagramDocument>>();
@@ -43,7 +43,7 @@ export class DiagramEditorProvider implements vscode.CustomEditorProvider<Diagra
   }
 
   constructor(private readonly context: vscode.ExtensionContext) {
-    const dbPath = createDataStoryDB();
+    const dbPath = createDataStoryDBPath();
     this.duckDBStorage = new DuckDBStorage(dbPath);
     this.inputObserverController = new InputObserverController(this.duckDBStorage);
   }

--- a/packages/ds-ext/src/DiagramEditorProvider.ts
+++ b/packages/ds-ext/src/DiagramEditorProvider.ts
@@ -15,6 +15,7 @@ import { observeLinkUpdate } from './messageHandlers/observeLinkUpdate';
 import { getDataFromStorage } from './messageHandlers/getDataFromStorage';
 import { cancelObservation } from './messageHandlers/cancelObservation';
 import { DuckDBStorage } from './duckDBStorage';
+import { createDataStoryDB } from './commands/createDataStoryDB';
 
 export class DiagramEditorProvider implements vscode.CustomEditorProvider<DiagramDocument> {
   private readonly _onDidChangeCustomDocument = new vscode.EventEmitter<vscode.CustomDocumentEditEvent<DiagramDocument>>();
@@ -42,7 +43,7 @@ export class DiagramEditorProvider implements vscode.CustomEditorProvider<Diagra
   }
 
   constructor(private readonly context: vscode.ExtensionContext) {
-    const dbPath = path.join(vscode.workspace.workspaceFolders![0].uri.fsPath, 'diagram.db');
+    const dbPath = createDataStoryDB();
     this.duckDBStorage = new DuckDBStorage(dbPath);
     this.inputObserverController = new InputObserverController(this.duckDBStorage);
   }

--- a/packages/ds-ext/src/commands/createDataStoryDB.ts
+++ b/packages/ds-ext/src/commands/createDataStoryDB.ts
@@ -1,0 +1,28 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+export function createDataStoryDB(): string {
+  const workspacePath = vscode.workspace.workspaceFolders![0].uri.fsPath;
+
+  // Construct the datastory directory path
+  const datastoryDir = path.join(workspacePath, 'datastory');
+
+  // Check if the datastory directory exists, create if it doesn't
+  if (!fs.existsSync(datastoryDir)) {
+    fs.mkdirSync(datastoryDir);
+  }
+
+  const dbPath = path.join(datastoryDir, 'execution.db');
+
+  // Create the execution.db file
+  fs.writeFile(dbPath, '', (err) => {
+    if (err) {
+      console.error('Error creating execution.db:', err);
+    } else {
+      console.log('execution.db created successfully in datastory directory.');
+    }
+  });
+
+  return dbPath;
+}

--- a/packages/ds-ext/src/commands/createDataStoryDBPath.ts
+++ b/packages/ds-ext/src/commands/createDataStoryDBPath.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-export function createDataStoryDB(): string {
+export function createDataStoryDBPath(): string {
   const workspacePath = vscode.workspace.workspaceFolders![0].uri.fsPath;
 
   // Construct the datastory directory path
@@ -14,15 +14,6 @@ export function createDataStoryDB(): string {
   }
 
   const dbPath = path.join(datastoryDir, 'execution.db');
-
-  // Create the execution.db file
-  fs.writeFile(dbPath, '', (err) => {
-    if (err) {
-      console.error('Error creating execution.db:', err);
-    } else {
-      console.log('execution.db created successfully in datastory directory.');
-    }
-  });
 
   return dbPath;
 }

--- a/packages/ds-ext/src/commands/createDataStoryDBPath.ts
+++ b/packages/ds-ext/src/commands/createDataStoryDBPath.ts
@@ -6,7 +6,7 @@ export function createDataStoryDBPath(): string {
   const workspacePath = vscode.workspace.workspaceFolders![0].uri.fsPath;
 
   // Construct the datastory directory path
-  const datastoryDir = path.join(workspacePath, 'datastory');
+  const datastoryDir = path.join(workspacePath, '.datastory');
 
   // Check if the datastory directory exists, create if it doesn't
   if (!fs.existsSync(datastoryDir)) {

--- a/packages/ds-ext/src/duckDBStorage.ts
+++ b/packages/ds-ext/src/duckDBStorage.ts
@@ -1,17 +1,17 @@
 import { GetLinkItemsParams, ItemValue, ObserverStorage } from '@data-story/core';
 import type { Database as DatabaseType} from 'duckdb-async';
+import { createDataStoryDBPath } from './commands/createDataStoryDBPath';
 export class DuckDBStorage implements ObserverStorage {
   private db: DatabaseType | null = null;
-  private dbPath: string;
 
-  constructor(dbPath: string) {
-    this.dbPath = dbPath;
+  constructor() {
     this.initDatabase();
   }
 
   async initDatabase() {
     const { Database } = await import('duckdb-async');
-    this.db = await Database.create(this.dbPath);
+    const dbPath = createDataStoryDBPath();
+    this.db = await Database.create(dbPath);
     await this.db.all(`
       CREATE TABLE IF NOT EXISTS linkCounts (
         linkId TEXT PRIMARY KEY,
@@ -71,11 +71,11 @@ export class DuckDBStorage implements ObserverStorage {
 
   async appendLinkItems(linkId: string, items: ItemValue[]): Promise<void> {
     const currentTime = new Date().toISOString();
-    items.forEach(async(item) => {
+    for(const item of items) {
       const data = JSON.stringify(item);
       await this.db?.all('INSERT INTO linkItems (linkId, item, createTime, updateTime) VALUES (?, ?, ?, ?)',
         linkId, data, currentTime, currentTime);
-    });
+    }
   }
 
   async getNodeStatus(nodeId: string): Promise<'BUSY' | 'COMPLETE' | undefined> {

--- a/packages/ds-ext/src/extension.ts
+++ b/packages/ds-ext/src/extension.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import { DiagramEditorProvider } from './DiagramEditorProvider';
 import { createDemosDirectory } from './commands/createDemosDirectory';
+import path from 'path';
+import * as fs from 'fs';
 
 let diagramEditorProvider: DiagramEditorProvider;
 
@@ -8,8 +10,11 @@ export function activate(context: vscode.ExtensionContext) {
   let disposable = vscode.commands.registerCommand('ds-ext.createDemos', async () => {
     createDemosDirectory();
   });
+
   const outputChannel = vscode.window.createOutputChannel('DS-Ext');
   outputChannel.appendLine('Congratulations, your extension "ds-ext" is now active!');
+  outputChannel.appendLine(`ds-ext is installed at ${context.extensionPath}`);
+  outputChannel.show();
 
   diagramEditorProvider = new DiagramEditorProvider(context);
   context.subscriptions.push(
@@ -19,26 +24,26 @@ export function activate(context: vscode.ExtensionContext) {
     )
   );
 
-  const installScriptsPath = `${context.extensionPath}/install-scripts`;
+  const installScriptsPath = path.join(context.extensionPath, 'install-scripts');
+  const duckdbAsyncPath = path.join(installScriptsPath, 'node_modules', 'duckdb-async');
 
-  outputChannel.appendLine(`ds-ext is installed at ${context.extensionPath}`);
-  outputChannel.show();
-
-  vscode.window.showInformationMessage(
-    'The "ds-ext" extension requires "duckdb-async". Would you like to install it now?',
-    'Yes',
-    'No'
-  ).then(selection => {
-    if (selection === 'Yes') {
-      // Create a new terminal
-      const terminal = vscode.window.createTerminal('DuckDB Setup');
-      terminal.show();
-      // Change directory to the extension path
-      terminal.sendText(`cd "${installScriptsPath}"`);
-      // run the install command
-      terminal.sendText('npm install duckdb-async');
-    }
-  });
+  // Check if duckdb-async is installed to prevent the user from needing to reload the window for installation.
+  if (!fs.existsSync(duckdbAsyncPath)) {
+    vscode.window.showInformationMessage(
+      'The "ds-ext" extension requires "duckdb-async". Would you like to install it now?',
+      'Yes',
+      'No'
+    ).then(selection => {
+      if (selection === 'Yes') {
+        // Create a new terminal
+        const terminal = vscode.window.createTerminal('DuckDB Setup');
+        terminal.show();
+        // change the directory to the install-scripts folder and run npm install duckdb-async
+        terminal.sendText(`cd "${installScriptsPath}"`);
+        terminal.sendText('npm install duckdb-async');
+      }
+    });
+  }
 }
 
 export function deactivate(context: any) {

--- a/packages/ds-ext/src/extension.ts
+++ b/packages/ds-ext/src/extension.ts
@@ -14,7 +14,7 @@ export function activate(context: vscode.ExtensionContext) {
   const outputChannel = vscode.window.createOutputChannel('DS-Ext');
   outputChannel.appendLine('Congratulations, your extension "ds-ext" is now active!');
   outputChannel.appendLine(`ds-ext is installed at ${context.extensionPath}`);
-  outputChannel.show();
+  // outputChannel.show();
 
   diagramEditorProvider = new DiagramEditorProvider(context);
   context.subscriptions.push(

--- a/packages/ds-ext/src/extension.ts
+++ b/packages/ds-ext/src/extension.ts
@@ -28,6 +28,8 @@ export function activate(context: vscode.ExtensionContext) {
   const duckdbAsyncPath = path.join(installScriptsPath, 'node_modules', 'duckdb-async');
 
   // Check if duckdb-async is installed to prevent the user from needing to reload the window for installation.
+  outputChannel.appendLine(`duckdbAsyncPath: ${duckdbAsyncPath}`);
+  outputChannel.appendLine(`fs.existsSync(duckdbAsyncPath): ${fs.existsSync(duckdbAsyncPath)}`);
   if (!fs.existsSync(duckdbAsyncPath)) {
     vscode.window.showInformationMessage(
       'The "ds-ext" extension requires "duckdb-async". Would you like to install it now?',
@@ -41,6 +43,8 @@ export function activate(context: vscode.ExtensionContext) {
         // change the directory to the install-scripts folder and run npm install duckdb-async
         terminal.sendText(`cd "${installScriptsPath}"`);
         terminal.sendText('npm install duckdb-async');
+      } else if (selection === 'No') {
+        vscode.window.showInformationMessage('Your data will be stored in memory and will not be persisted to a file.');
       }
     });
   }

--- a/packages/nodejs/src/computers/JsonFileRead/JsonFileRead.ts
+++ b/packages/nodejs/src/computers/JsonFileRead/JsonFileRead.ts
@@ -1,7 +1,7 @@
 import * as glob from 'glob';
 import fs from 'fs';
 import path from 'path'; // Import path module
-import { Computer, get, ItemValue, serializeError, str } from '@data-story/core';
+import { Computer, get, asArray, ItemValue, serializeError, str } from '@data-story/core';
 
 export const JsonFileRead: Computer = {
   name: 'JsonFile.read',
@@ -67,17 +67,17 @@ export const JsonFileRead: Computer = {
         try {
           const content = fs.readFileSync(file, 'utf-8');
           const data = JSON.parse(content);
-          const items = get(data, itemsPath).map((i: ItemValue) => ({
+          const itemable = get(data, itemsPath);
+          const items = asArray(itemable).map((i: ItemValue) => ({
             ...i,
             _filePath: file,
           }));
           output.push(items);
+          yield;
         } catch (fileError: any) {
           output.pushTo('errors', [serializeError(fileError)]);
         }
       }
-
-      yield;
     } catch (error: any) {
       output.pushTo('errors', [serializeError(error)]);
       yield;

--- a/packages/ui/src/components/DataStory/Form/nodeSettingsForm.tsx
+++ b/packages/ui/src/components/DataStory/Form/nodeSettingsForm.tsx
@@ -4,6 +4,7 @@ import { Param, ParamValue, pascalToSentenceCase } from '@data-story/core';
 import { FormProvider, useForm } from 'react-hook-form';
 import { NodeSettingsFormProps, StoreSchema } from '../types';
 import { useStore } from '../store/store';
+import { CloseIcon } from '../icons/closeIcon';
 
 type TabKey = 'Params' | 'InputSchemas' | 'OutputSchemas';
 const TAB_COMPONENTS: Record<TabKey, React.ComponentType<any>> = {
@@ -75,7 +76,7 @@ export const NodeSettingsForm: React.FC<NodeSettingsFormProps> = ({ node, onClos
       <div
         className="shadow-lg relative flex flex-col justify-between w-full bg-white outline-none focus:outline-none h-full">
         {/* ***** HEADER ***** */}
-        <div className="flex items-start px-8 py-2">
+        <div className="flex justify-between px-8 py-2">
           <input
             {...form.register('label')}
             className="pr-4 mt-4 bg-white flex flex-col align-center justify-center text-lg text-gray-400 font-bold tracking widest"
@@ -85,6 +86,9 @@ export const NodeSettingsForm: React.FC<NodeSettingsFormProps> = ({ node, onClos
               className="flex flex-col pr-4 my-2 mt-3 italic align-center justify-center text-sm text-gray-400 font-base tracking widest">
               renamed from {node.data?.computer}
             </div>}
+          </div>
+          <div className="flex items-center mt-4 text-gray-400" onClick={() => onClose(true)}>
+            <CloseIcon />
           </div>
         </div>
         {/* ***** TABS ***** */}

--- a/packages/ui/src/components/DataStory/clients/WorkspaceApiClient.ts
+++ b/packages/ui/src/components/DataStory/clients/WorkspaceApiClient.ts
@@ -187,9 +187,7 @@ export class WorkspaceApiClient implements WorkspaceApiClientImplement {
   private initExecutionFailure() {
     return this.receivedMsg$.pipe(filter(matchMsgType('ExecutionFailure')))
       .subscribe((data: any) => {
-        console.error('Execution failed: ', {
-          history: data.history,
-        })
+        console.error('Execution failed')
 
         eventManager.emit({
           type: DataStoryEvents.RUN_ERROR,


### PR DESCRIPTION
- feat: Implement DiagramObserverStorage as a fallback for DuckDBStorage 

![image](https://github.com/user-attachments/assets/c1be4859-29db-4e70-8318-77a627b0512a)

- chore: rebase the main branch
- feat: Replace diagram.db with ./datastory/executions.db and implement createDataStoryDB method
- feat: Check if duckdb-async is installed to prevent the user from needing to reload the window for installation.
- refactor: Improve type definitions for better clarity and usability.


https://github.com/user-attachments/assets/90e5f882-e891-4592-8955-1de107ade004

