### PR TITLE
Register nested node on app level only

### DIFF
--- a/packages/docs/components/demos/UnfoldingDemo.tsx
+++ b/packages/docs/components/demos/UnfoldingDemo.tsx
@@ -58,7 +58,7 @@ export default ({ part }: { part: 'MAIN' | 'NESTED_NODE' | 'MAIN_UNFOLDED' }) =>
             { name: 'Charlie', age: 45 },
           ]),
         })
-        .addNestedNode('FooBarStamper', nestedNode)
+        .add('FooBarStamper')
         .add('Table')
         .connect()
         .place()


### PR DESCRIPTION
For the demo, register the custom nested node directly on the `Application`.

### Follow ups
Consider ability to register and store nested nodes in the *Diagram* itself?