### PR TITLE
Make Density demo datasets

### DIFF
--- a/packages/ds-ext/src/commands/createDemosDirectory.ts
+++ b/packages/ds-ext/src/commands/createDemosDirectory.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as demos from './demos';
+import { makeDensityDatasets } from './makeDensityDatasets';
 
 export async function createDemosDirectory() {
   const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -31,6 +32,9 @@ export async function createDemosDirectory() {
       { id: 2, title: 'Build a DataStory extension', completed: false },
       { id: 3, title: 'Profit', completed: false },
     ], null, 2));
+
+    // Create density datasets
+    makeDensityDatasets(path.join(demosDir, 'data', 'densities'));
 
     for (const [moduleName, demoFactory] of Object.entries(demos)) {
       const filePath = path.join(demosDir, `${moduleName}.diagram.json`);

--- a/packages/ds-ext/src/commands/makeDensityDatasets.ts
+++ b/packages/ds-ext/src/commands/makeDensityDatasets.ts
@@ -1,0 +1,52 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const makeDensityDatasets = (directory: string) => {
+  const datasetsDir = path.join(directory);
+  if (!fs.existsSync(datasetsDir)) fs.mkdirSync(datasetsDir);
+
+  // Utility function to generate an item with schemaDensity
+  const generateItem = (schemaDensity: any) => {
+    const item = {} as any;
+    for (let i = 0; i < schemaDensity; i++) {
+      item[`field_${i}`] = `value_${i}`;
+    }
+    return item;
+  };
+
+  // Utility function to generate files with items
+  const generateFileContent = (itemsDensity: any, schemaDensity: any) => {
+    const items = [];
+    for (let i = 0; i < itemsDensity; i++) {
+      items.push(generateItem(schemaDensity));
+    }
+    return items;
+  };
+
+  // Generate datasets based on density vectors
+  const createDatasets = (fileDensity: any, itemsDensity: any, schemaDensity: any) => {
+    const datasetDir = path.join(datasetsDir, `${fileDensity}:${itemsDensity}:${schemaDensity}`);
+    if (!fs.existsSync(datasetDir)) fs.mkdirSync(datasetDir);
+
+    for (let i = 0; i < fileDensity; i++) {
+      const filePath = path.join(datasetDir, `${i}.json`);
+      const content = generateFileContent(itemsDensity, schemaDensity);
+      fs.writeFileSync(filePath, JSON.stringify(content, null, 2));
+    }
+  };
+
+  // Define your density vectors
+  const fileDensities = [1, 10, 100]; // Low, medium, high file density
+  const itemsDensities = [10, 100, 1000]; // Low, medium, high items density
+  const schemaDensities = [5, 50, 500]; // Low, medium, high schema density
+
+  // Generate all combinations of datasets
+  fileDensities.forEach(fileDensity => {
+    itemsDensities.forEach(itemsDensity => {
+      schemaDensities.forEach(schemaDensity => {
+        createDatasets(fileDensity, itemsDensity, schemaDensity);
+      });
+    });
+  });
+};


### PR DESCRIPTION
Adds JSON datasets with various characteristics in the Demo command.

### Vectors:
* filesDensity: the number of files in a folder
* itemsDensity: the number of items in a file
* schemaDensity: the size of an individual item

The files created have path 
```ts
`.datastory/demos/data/densities/${filesDensity}:${itemsDensity}:${schemaDensity}:${n}.json`
```

<img width="663" alt="image" src="https://github.com/user-attachments/assets/f89f2427-5bcc-4fac-b694-0341f1c7ea72" />

### Testing
Datasets can be read in bulk using JsonFile.read node

<img width="1110" alt="image" src="https://github.com/user-attachments/assets/add2585b-5074-434b-b1ee-008ca4bd89ab" />
