### PR TITLE
datastory.config.json

### DIFF
--- a/packages/ds-ext/src/DataStoryConfig.ts
+++ b/packages/ds-ext/src/DataStoryConfig.ts
@@ -1,0 +1,3 @@
+export interface DataStoryConfig {
+  storage: 'DUCK_DB' | 'FILE' | 'IN_MEMORY';
+}

--- a/packages/ds-ext/src/loadConfig.ts
+++ b/packages/ds-ext/src/loadConfig.ts
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import path from 'path';
+import vscode from 'vscode';
+import { DataStoryConfig } from './DataStoryConfig';
+
+export function loadConfig(extensionContext: vscode.ExtensionContext): DataStoryConfig {
+  const defaultConfig: DataStoryConfig = {
+    storage: 'DUCK_DB',
+  };
+
+  const workspacePath = vscode.workspace.workspaceFolders![0].uri.fsPath;
+  const configPath = path.join(workspacePath, 'datastory.config.json');
+
+  if (!fs.existsSync(configPath)) {
+    console.log('No datastory.config.json found, using default configuration.');
+    return defaultConfig;
+  }
+
+  try {
+    const configContent = fs.readFileSync(configPath, 'utf8');
+    return JSON.parse(configContent) as DataStoryConfig;
+  } catch (error) {
+    console.log(error);
+    console.error('Failed to parse datastory.config.json. Using default configuration.');
+    return defaultConfig;
+  }
+}


### PR DESCRIPTION
When DiagramEditor is created, it will check for a `datastory.config.json` where we can optionally specify which storage we prefer.