### PR TITLE
Add controller dispose

### DIFF
--- a/packages/core/src/InputObserverController.ts
+++ b/packages/core/src/InputObserverController.ts
@@ -16,6 +16,7 @@ import { NodeId } from './types/Node';
 import { ObserverStorage } from './types/ObserverStorage';
 import { LinkItemsParam } from './types/LinkItemsParam';
 import { LinksCountParam } from './types/LinksCountParam';
+import { sleep } from './utils/sleep';
 
 const ThrottleMS: number = 300;
 
@@ -152,5 +153,19 @@ export class InputObserverController {
         this.observerMap.delete(observer.observerId);
       }
     }
+  }
+
+  async dispose() {
+    // Await any throttled events to complete
+    await sleep(ThrottleMS)
+
+    // Remove all subscriptions
+    this.observerMap.forEach((subscription) => subscription.unsubscribe());
+    this.observerMap.clear();
+
+    // Complete all subjects
+    this.items$.complete();
+    this.links$.complete();
+    this.nodeStatus$.complete();
   }
 }


### PR DESCRIPTION
Adds `InputObserverController.dispose()`. 
Useful to experiment with observers in headless code, like this example:

```ts
import { Application } from './Application'
import { coreNodeProvider } from './coreNodeProvider'
import { InMemoryStorage } from './InMemoryStorage'
import { InputObserverController } from './InputObserverController'
import { DiagramObserverStorage } from './storage/diagramObserverStorage'
import { ObserveLinkItems } from './types/ExecutionObserver'
import { RequestObserverType } from './types/InputObserveConfig'

(async () => {
  const app = new Application().register([coreNodeProvider])
  await app.boot()

  const diagram = app.getDiagramBuilder()
    .add('Signal', { count: 10})
    .add('Ignore')
    .connect()
    .get()

  const [ link ] = diagram.links

  const controller = new InputObserverController(
    new DiagramObserverStorage()
  )

  const linkObserver: ObserveLinkItems = {
    type: RequestObserverType.observeLinkItems,
    linkIds: [ link.id ],
    onReceive: (linksData) => {
      console.log('In onReceive!')
      console.log(linksData.map(l => `${l.linkId}: ${JSON.stringify(l.items)}`))
    },
    observerId: 'my-id',
  }

  controller.addLinkItemsObserver(linkObserver)

  const executor = app.getExecutor({
    diagram,
    storage: new InMemoryStorage(),
    inputObserverController: controller,
  })

  const execution = executor.execute()

  for await(const update of execution) {}
  console.log('Execution completed!')

  // without this line the script would never complete
  await controller.dispose()
  console.log('Controller disposed!')
})();
```