### PR TITLE
Rename node.type -> node.name

### DIFF
--- a/packages/core/src/Diagram.test.ts
+++ b/packages/core/src/Diagram.test.ts
@@ -8,7 +8,7 @@ describe('add', () => {
     const diagram = new Diagram()
     const node: Node = {
       id: 'node-id',
-      type: 'MyNode',
+      name: 'MyNode',
       inputs: [],
       outputs: [],
       params: []
@@ -30,7 +30,7 @@ describe('nodeWithOutputPortId', () => {
 
     const node: Node = {
       id: 'node-id',
-      type: 'MyNode',
+      name: 'MyNode',
       inputs: [],
       outputs: [output],
       params: []
@@ -70,7 +70,7 @@ describe('clone', () => {
   it('creates a deep clone of the diagram', () => {
     const node: Node = {
       id: 'node-id',
-      type: 'MyNode',
+      name: 'MyNode',
       inputs: [],
       outputs: [],
       params: []

--- a/packages/core/src/Diagram.ts
+++ b/packages/core/src/Diagram.ts
@@ -128,10 +128,10 @@ export class Diagram {
   }
 
   inputNodes(): Node[] {
-    return this.nodes.filter(node => node.type === 'Input')
+    return this.nodes.filter(node => node.name === 'Input')
   }
 
   outputNodes(): Node[] {
-    return this.nodes.filter(node => node.type === 'Output')
+    return this.nodes.filter(node => node.name === 'Output')
   }
 }

--- a/packages/core/src/DiagramBuilder.test.ts
+++ b/packages/core/src/DiagramBuilder.test.ts
@@ -35,8 +35,8 @@ describe('add', () => {
       .get()
 
     expect(diagram.nodes).toMatchObject([
-      { id: 'Create.1', type: 'Create' },
-      { id: 'Ignore.1', type: 'Ignore' },
+      { id: 'Create.1', name: 'Create' },
+      { id: 'Ignore.1', name: 'Ignore' },
     ])
   })
 

--- a/packages/core/src/DiagramBuilder.ts
+++ b/packages/core/src/DiagramBuilder.ts
@@ -40,7 +40,7 @@ export class DiagramBuilder {
     const node: Node = {
       id: nodeId,
       label: name,
-      type: name,
+      name: name,
       // The inputs have not yet been assigned ids, to it here
       inputs: diagram.inputNodes().map(inputNode => {
         const param = inputNode.params.find(param => param.name === 'port_name');
@@ -227,7 +227,7 @@ export class DiagramBuilder {
 
     return structuredClone({
       id,
-      type: nodeDescription.name,
+      name: nodeDescription.name,
       label: nodeDescription.label,
       inputs: nodeDescription.inputs.map(input => {
         return {
@@ -296,7 +296,7 @@ export class DiagramBuilder {
 
   protected getScopedId(nodeName: string) {
     const max = this.diagram.nodes
-      .filter(node => node.type === nodeName)
+      .filter(node => node.name === nodeName)
       .map(node => node.id)
       .map(id => id.split('.')[1])
       .map(id => parseInt(id))

--- a/packages/core/src/DiagramQuery.ts
+++ b/packages/core/src/DiagramQuery.ts
@@ -23,7 +23,7 @@ export class DiagramQuery {
   protected getPortId(portDescriptor: PortDescriptor): PortId {
     const [nodeType, portName] = portDescriptor.split('.')
 
-    const node = this.diagram.nodes.find(node => node.type === nodeType)
+    const node = this.diagram.nodes.find(node => node.name === nodeType)
     if(!node) throw new Error(`Node with type ${nodeType} not found in diagram`);
 
     const port = [

--- a/packages/core/src/ExecutionMemoryFactory.ts
+++ b/packages/core/src/ExecutionMemoryFactory.ts
@@ -59,8 +59,8 @@ export class ExecutionMemoryFactory {
       memory.outputDevices.set(node.id, outputDevice)
 
       // Initialize runner generators
-      const computer = this.registry.computers[node.type]
-      if (!computer) throw new Error(`Computer "${node.type}" not found`)
+      const computer = this.registry.computers[node.name]
+      if (!computer) throw new Error(`Computer "${node.name}" not found`)
 
       memory.setNodeRunner(
         node.id,

--- a/packages/core/src/Executor.test.ts
+++ b/packages/core/src/Executor.test.ts
@@ -33,7 +33,7 @@ describe('execute', () => {
   it('can execute a diagram with a single no-input no-output node', async () => {
     const node: Node = {
       id: 'node-id',
-      type: 'Dummy',
+      name: 'Dummy',
       inputs: [],
       outputs: [],
       params: []
@@ -73,7 +73,7 @@ describe('execute', () => {
   it('can execute a diagram with non connected input node', async () => {
     const node: Node = {
       id: 'node-id',
-      type: 'Accepter',
+      name: 'Accepter',
       inputs: [{
         id: 'input-id',
         name: 'input',
@@ -110,7 +110,7 @@ describe('execute', () => {
   it('can execute a diagram with a node outputting items', async () => {
     const node: Node = {
       id: 'zergling-spawner-id',
-      type: 'Spawner',
+      name: 'Spawner',
       inputs: [],
       outputs: [
         {
@@ -153,7 +153,7 @@ describe('execute', () => {
   it('can execute a diagram with item flowing between two nodes', async () => {
     const create: Node = {
       id: 'create-id',
-      type: 'Create',
+      name: 'Create',
       inputs: [],
       outputs: [{
         id: 'Create.1.output',
@@ -165,7 +165,7 @@ describe('execute', () => {
 
     const log: Node = {
       id: 'log-id',
-      type: 'Log',
+      name: 'Log',
       inputs: [{
         id: 'Log.1.input',
         name: 'input',

--- a/packages/core/src/Executor.ts
+++ b/packages/core/src/Executor.ts
@@ -128,7 +128,7 @@ export class Executor {
   protected getRunnableNodes(): Node[] {
     return this.diagram.nodes.filter(node => {
       // If the computer implements a custom hook
-      const computer = this.registry.computers[node.type]
+      const computer = this.registry.computers[node.name]
       const hook = computer.canRun
       if(hook) return hook({
         isAvailable: () => this.memory.getNodeStatus(node.id) === 'AVAILABLE',

--- a/packages/core/src/InputDevice.test.ts
+++ b/packages/core/src/InputDevice.test.ts
@@ -9,7 +9,7 @@ describe('pull', () => {
   it('returns items at port named "input" wrapped as ItemWithParams', () => {
     const node: Node = {
       id: 'target',
-      type: 'node-type',
+      name: 'node-type',
       inputs: [{id: 'target-input-id', name: 'input', schema: {}}],
       outputs: [],
       params: []
@@ -49,7 +49,7 @@ describe('pull', () => {
     expect(() => {
       const node: Node = {
         id: 'target',
-        type: 'node-type',
+        name: 'node-type',
         inputs: [{id: 'target-input-id', name: 'some-other-name', schema: {}}],
         outputs: [],
         params: []
@@ -70,7 +70,7 @@ describe('pull', () => {
   it('removes the items pulled from the links', () => {
     const node: Node = {
       id: 'target',
-      type: 'node-type',
+      name: 'node-type',
       inputs: [{id: 'target-input-id', name: 'input', schema: {}}],
       outputs: [],
       params: []
@@ -107,7 +107,7 @@ describe('pull', () => {
   it('may pull a specified number of items', () => {
     const node: Node = {
       id: 'target',
-      type: 'node-type',
+      name: 'node-type',
       inputs: [{id: 'target-input-id', name: 'input', schema: {}}],
       outputs: [],
       params: []
@@ -143,7 +143,7 @@ describe('pullFrom', () => {
   it('returns items at named port', () => {
     const node: Node = {
       id: 'target',
-      type: 'node-type',
+      name: 'node-type',
       inputs: [{id: 'target-input-id', name: 'numbers', schema: {}}],
       outputs: [],
       params: []
@@ -180,7 +180,7 @@ describe('pullFrom', () => {
   it('removes the items pulled from the links', () => {
     const node: Node = {
       id: 'target',
-      type: 'node-type',
+      name: 'node-type',
       inputs: [{id: 'target-input-id', name: 'numbers', schema: {}}],
       outputs: [],
       params: []
@@ -219,7 +219,7 @@ describe('params', () => {
   it('has getters for params returning interpolated values', () => {
     const node: Node = {
       id: 'target',
-      type: 'node-type',
+      name: 'node-type',
       inputs: [{id: 'target-input-id', name: 'input', schema: {}}],
       outputs: [],
       params: [createDefaultStringable({

--- a/packages/core/src/NodeDescriptionFactory.ts
+++ b/packages/core/src/NodeDescriptionFactory.ts
@@ -21,7 +21,7 @@ export const NodeDescriptionFactory = {
       label: name,
       category: undefined,
       inputs: diagram.nodes
-        .filter(node => node.type === 'Input')
+        .filter(node => node.name === 'Input')
         .map(node => {
           const portParam = node.params
             .find(param => param.name === 'port_name')! as StringableInputValue
@@ -34,7 +34,7 @@ export const NodeDescriptionFactory = {
           }
         }),
       outputs: diagram.nodes
-        .filter(node => node.type === 'Output')
+        .filter(node => node.name === 'Output')
         .map(node => {
           const portParam = node.params
             .find(param => param.name === 'port_name')! as StringableInputValue

--- a/packages/core/src/PositionGuesser.ts
+++ b/packages/core/src/PositionGuesser.ts
@@ -22,8 +22,8 @@ export class PositionGuesser {
     const maxY = this.diagram.nodes.map((node) => node.position!.y).reduce((max, y) => Math.max(max, y), 0)
 
     const isStarterNode = node.inputs.length === 0;
-    const type = (node as Node).name ?? (node as NodeDescription).name;
-    const isInputNode = type === 'Input';
+    const name = (node as Node).name ?? (node as NodeDescription).name;
+    const isInputNode = name === 'Input';
 
     if(isStarterNode || isInputNode) {
       return { x: startX, y: maxY === 0 ? startY : maxY + spaceY }

--- a/packages/core/src/PositionGuesser.ts
+++ b/packages/core/src/PositionGuesser.ts
@@ -22,7 +22,7 @@ export class PositionGuesser {
     const maxY = this.diagram.nodes.map((node) => node.position!.y).reduce((max, y) => Math.max(max, y), 0)
 
     const isStarterNode = node.inputs.length === 0;
-    const type = (node as Node).type ?? (node as NodeDescription).name;
+    const type = (node as Node).name ?? (node as NodeDescription).name;
     const isInputNode = type === 'Input';
 
     if(isStarterNode || isInputNode) {

--- a/packages/core/src/UnfoldedDiagramFactory.ts
+++ b/packages/core/src/UnfoldedDiagramFactory.ts
@@ -26,11 +26,11 @@ export class UnfoldedDiagramFactory {
   }
 
   unfold(): UnfoldedDiagram {
-    const replacables = this.diagram.nodes.filter(node => node.type in this.nestedNodes)
+    const replacables = this.diagram.nodes.filter(node => node.name in this.nestedNodes)
 
     for(const node of replacables) {
-      const nestedDiagram = this.nestedNodes[node.type]
-      if(!nestedDiagram) throw new Error(`No nesteddiagram found for node type "${node.type}"`)
+      const nestedDiagram = this.nestedNodes[node.name]
+      if(!nestedDiagram) throw new Error(`No nesteddiagram found for node type "${node.name}"`)
 
       this.diagram.nodes.push(...nestedDiagram.nodes)
       this.diagram.links.push(...nestedDiagram.links)
@@ -54,8 +54,8 @@ export class UnfoldedDiagramFactory {
     if(index === -1) throw new Error('Node not found in diagram')
     this.diagram.nodes.splice(index, 1)
 
-    const nestedDiagram = this.nestedNodes[node.type]
-    if(!nestedDiagram) throw new Error(`No nesteddiagram found for node type "${node.type}"`)
+    const nestedDiagram = this.nestedNodes[node.name]
+    if(!nestedDiagram) throw new Error(`No nesteddiagram found for node type "${node.name}"`)
 
     // Rewire incoming links
     for(const inputPort of node.inputs) {
@@ -64,7 +64,7 @@ export class UnfoldedDiagramFactory {
       for(const link of links) {
         const newTargetNode = nestedDiagram.nodes
           .find(node => {
-            const isInputNode = node.type === 'Input'
+            const isInputNode = node.name === 'Input'
             if(!isInputNode) return false;
 
             const param = node.params[0];
@@ -76,10 +76,10 @@ export class UnfoldedDiagramFactory {
             return matchesPortName
           })
 
-        if(!newTargetNode) throw new Error(`No input node found for input port "${inputPort.name}" on the nesteddiagram of "${node.type}"`)
+        if(!newTargetNode) throw new Error(`No input node found for input port "${inputPort.name}" on the nesteddiagram of "${node.name}"`)
 
         const newInputPort = newTargetNode.inputs[0]
-        if(!newInputPort) throw new Error(`No input port found for input port "${inputPort.name}" on the nesteddiagram of "${node.type}". The node was ${JSON.stringify(node)}`)
+        if(!newInputPort) throw new Error(`No input port found for input port "${inputPort.name}" on the nesteddiagram of "${node.name}". The node was ${JSON.stringify(node)}`)
 
         link.targetPortId = newInputPort.id
       }
@@ -91,7 +91,7 @@ export class UnfoldedDiagramFactory {
       for(const link of links) {
         const newSourceNode = nestedDiagram.nodes
           .find(node => {
-            const isOutputNode = node.type === 'Output'
+            const isOutputNode = node.name === 'Output'
             if(!isOutputNode) return false;
 
             const param = node.params[0];
@@ -103,10 +103,10 @@ export class UnfoldedDiagramFactory {
             return matchesPortName
           })
 
-        if(!newSourceNode) throw new Error(`No output node found for output port "${outputPort.name}" on the nesteddiagram of "${node.type}"`)
+        if(!newSourceNode) throw new Error(`No output node found for output port "${outputPort.name}" on the nesteddiagram of "${node.name}"`)
 
         const newOutputPort = newSourceNode.outputs[0]
-        if(!newOutputPort) throw new Error(`No output port found for output port "${outputPort.name}" on the nesteddiagram of "${node.type}"`)
+        if(!newOutputPort) throw new Error(`No output port found for output port "${outputPort.name}" on the nesteddiagram of "${node.name}"`)
 
         link.sourcePortId = newOutputPort.id
       }

--- a/packages/core/src/support/computerTester/ComputerTester.ts
+++ b/packages/core/src/support/computerTester/ComputerTester.ts
@@ -194,7 +194,7 @@ export class ComputerTester {
     // Create a new Node from the computer + params (TODO: this is a general need)
     const node: Node = {
       id: nodeId,
-      type: this.computer.name,
+      name: this.computer.name,
       inputs: (this.computer.inputs || []).map(input => ({
         id: `${nodeId}.${input.name}`,
         name: input.name,

--- a/packages/core/src/syncPortSchemas.test.ts
+++ b/packages/core/src/syncPortSchemas.test.ts
@@ -13,7 +13,7 @@ it('forwards schema to linked ports', () => {
 
   const node1: Node = {
     id: 'node1',
-    type: 'MyNode',
+    name: 'MyNode',
     inputs: [],
     outputs: [outputPort],
     params: []
@@ -27,7 +27,7 @@ it('forwards schema to linked ports', () => {
 
   const node2: Node = {
     id: 'node2',
-    type: 'MyNode',
+    name: 'MyNode',
     inputs: [inputPort],
     outputs: [],
     params: []

--- a/packages/core/src/types/Node.ts
+++ b/packages/core/src/types/Node.ts
@@ -5,7 +5,7 @@ export type NodeId = string
 
 export type Node = {
   id: NodeId
-  type: string
+  name: string
   label?: string
   inputs: Port[]
   outputs: Port[]

--- a/packages/docs/components/demos/VisualizeDemo.tsx
+++ b/packages/docs/components/demos/VisualizeDemo.tsx
@@ -57,7 +57,7 @@ export default () => {
   const { app, loading } = useRequestApp();
   const client = useMemo(() => new CustomizeJSClient({ diagram, app }), [diagram, app]);
 
-  const mapNode = diagram.nodes.find(n => n.type === 'Map');
+  const mapNode = diagram.nodes.find(n => n.name === 'Map');
   const mapperParam = mapNode.params.find(p => p.name === 'mapper') as any;
   mapperParam.value = {
     ...mapperParam.value,

--- a/packages/ui/src/factories/NodeFactory.ts
+++ b/packages/ui/src/factories/NodeFactory.ts
@@ -6,7 +6,7 @@ export const NodeFactory = {
   fromReactFlowNode: (flowNode: ReactFlowNode): Node => {
     return {
       id: flowNode.id,
-      type: flowNode.data.computer,
+      name: flowNode.data.computer,
       label: flowNode.data.label,
       inputs: flowNode.data.inputs.map(input => {
         return {
@@ -34,7 +34,7 @@ export const NodeFactory = {
 
     return structuredClone({
       id,
-      type: nodeDescription.name,
+      name: nodeDescription.name,
       label: nodeDescription.label,
       inputs: nodeDescription.inputs.map(input => {
         return {

--- a/packages/ui/src/factories/ReactFlowFactory.ts
+++ b/packages/ui/src/factories/ReactFlowFactory.ts
@@ -15,17 +15,17 @@ export const ReactFlowFactory = {
           },
           data: {
             params: node.params,
-            computer: node.type,
-            label: (node?.label || node.type) as string,
+            computer: node.name,
+            label: (node?.label || node.name) as string,
             inputs: node.inputs,
             outputs: node.outputs,
           },
           type: (() => {
-            if (node.type === 'Comment') return 'commentNodeComponent';
-            if (node.type === 'Input') return 'inputNodeComponent';
-            if (node.type === 'Output') return 'outputNodeComponent';
-            if (node.type === 'Table') return 'tableNodeComponent';
-            if (node.type === 'ConsoleLog') return 'consoleNodeComponent';
+            if (node.name === 'Comment') return 'commentNodeComponent';
+            if (node.name === 'Input') return 'inputNodeComponent';
+            if (node.name === 'Output') return 'outputNodeComponent';
+            if (node.name === 'Table') return 'tableNodeComponent';
+            if (node.name === 'ConsoleLog') return 'consoleNodeComponent';
 
             return 'nodeComponent';
           })(),

--- a/packages/ui/src/reactFlowToDiagram.ts
+++ b/packages/ui/src/reactFlowToDiagram.ts
@@ -4,7 +4,7 @@ import { SerializedReactFlow, SerializedReactFlowNode } from './SerializedReactF
 export const reactFlowNodeToDiagramNode = (flowNode: SerializedReactFlowNode): Node => {
   return {
     id: flowNode.id,
-    type: flowNode.data.computer,
+    name: flowNode.data.computer,
     inputs: flowNode.data.inputs.map(input => {
       return {
         id: input.id,
@@ -25,10 +25,10 @@ export const reactFlowNodeToDiagramNode = (flowNode: SerializedReactFlowNode): N
 }
 
 export const reactFlowToDiagram = (flow: SerializedReactFlow): Diagram => {
-  const nodes = flow.nodes.map(flowNode => {
+  const nodes: Node[] = flow.nodes.map(flowNode => {
     return {
       id: flowNode.id,
-      type: flowNode.data.computer,
+      name: flowNode.data.computer,
       inputs: flowNode.data.inputs.map(input => {
         return {
           id: input.id,


### PR DESCRIPTION
This PR moves `Node.type` to `Node.name`
This makes sense since `NodeDescription` and `Computer` both use `name` as entity identifier.

⚠️  will likely break serialized diagrams