### PR TITLE
Allow shorthand .ds

### DIFF
--- a/packages/ds-ext/package.json
+++ b/packages/ds-ext/package.json
@@ -27,10 +27,12 @@
       {
         "id": "diagramJson",
         "aliases": [
-          "Diagram JSON"
+          "Diagram JSON",
+          "Data Story"
         ],
         "extensions": [
-          ".diagram.json"
+          ".diagram.json",
+          ".ds"
         ],
         "configuration": "./language-configuration.json"
       }
@@ -42,6 +44,9 @@
         "selector": [
           {
             "filenamePattern": "*.diagram.json"
+          },
+          {
+            "filenamePattern": "*.ds"
           }
         ]
       }

--- a/packages/ds-ext/themes/file-icon-theme.json
+++ b/packages/ds-ext/themes/file-icon-theme.json
@@ -5,8 +5,11 @@
     }
   },
   "fileExtensions": {
-    "diagram.json": "diagramIcon"
+    "diagram.json": "diagramIcon",
+    "ds": "diagramIcon"
   },
   "fileNames": {},
-  "languageIds": {}
+  "languageIds": {
+    "diagramJson": "diagramIcon"
+  }
 }


### PR DESCRIPTION
Allows both `*.diagram.json` and shorthand `*.ds`
<img width="195" alt="image" src="https://github.com/user-attachments/assets/7d4b8fd0-55cc-4c0b-b399-2ce4ffcf5630" />
