### PR TITLE
feat: remove footer from Playground page and fix missing output issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ yarn.lock
 *.orig
 *.swp
 *.swo
+.aider*

--- a/packages/docs/pages/_meta.ts
+++ b/packages/docs/pages/_meta.ts
@@ -29,15 +29,16 @@ export default {
     'type': 'page',
     'theme': {
       'layout': 'raw',
+      'footer': false,
     },
   },
   'playground-node': {
     'title': 'Playground NodeJS',
     'display': 'hidden',
-    'footer': false,
     'type': 'page',
     'theme': {
       'layout': 'raw',
+      'footer': false,
     },
   },
   // 'Visualize': 'Visualize',

--- a/packages/ui/src/components/Node/table/TableNodeComponent.tsx
+++ b/packages/ui/src/components/Node/table/TableNodeComponent.tsx
@@ -149,8 +149,9 @@ const TableNodeComponent = ({ id, data }: {
       return '40px';
     }
     if (rows.length <= 9) {
-      return (rows.length + 1) * FIXED_HEIGHT + 14 + 'px';
+      return (rows.length + 1) * FIXED_HEIGHT + 'px';
     }
+    // The 14px extra height is determined through testing to ensure that the table scrollbar does not obscure the height of the table body when it appears.
     return 11 * FIXED_HEIGHT + 14 + 'px';
   }, [showNoData, rows.length]);
 


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| ❌      | ✅    |
| feat: remove extra height when the table is not scrollable | feat: remove extra height when the table is not scrollable |
|![image](https://github.com/user-attachments/assets/5ccfddb9-425f-441e-a38b-a1168c732956)|![image](https://github.com/user-attachments/assets/a4fb3d32-47cf-483b-938d-8d4e45428fac)|
| feat: remove the footer from the Playground page  | feat: remove the footer from the Playground page |
|![image](https://github.com/user-attachments/assets/b9b912d4-0f36-4b08-82e4-b986655693f6) | ![image](https://github.com/user-attachments/assets/549b9dab-94a7-4dc8-bf03-264b3aed7c2f) |
| fix: resolve the issue of missing output when adding a node to the edge between two nodes. | fix: resolve the issue of missing output when adding a node to the edge between two nodes.|
|![image](https://github.com/user-attachments/assets/b3e29d81-587b-433c-8938-3fc660cd1269) | ![image](https://github.com/user-attachments/assets/9650b0ad-284a-4d20-8394-1cc45a5afcca)|

