### PR TITLE
feat: implement copy, paste, cut, and select all functionality for node/edge management

### DIFF
--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -28,6 +28,7 @@ import { createDataStoryId, LinkCount, LinkId, NodeStatus, RequestObserverType }
 import { useDragNode } from './useDragNode';
 import { ReactFlowNode } from '../Node/ReactFlowNode';
 import { useCopyPaste } from './controls/useCopyPaste';
+import '../../styles/dataStoryCanvasStyle.css';
 
 const nodeTypes = {
   commentNodeComponent: CommentNodeComponent,
@@ -215,23 +216,12 @@ const Flow = ({
     focusOnFlow();
   }, [connect, focusOnFlow, reactFlowStore]);
 
-  const { cut, copy, paste, bufferedNodes } = useCopyPaste();
-
-  const canCopy = nodes.some(({ selected }) => selected);
-  const canPaste = bufferedNodes.length > 0;
+  useCopyPaste();
 
   return (
     <>
       <style>
         {`
-          @keyframes dash {
-            to {
-              stroke-dashoffset: -10;
-            }
-          }
-          .react-flow__edge:hover {
-            cursor: crosshair;
-          }
           ${draggedNode ? `
           .react-flow__edge {
             opacity: 0.5;
@@ -311,27 +301,7 @@ const Flow = ({
       >
         <DataStoryControls
           onSave={onSave}
-          controls={[
-            ...controls,
-            <button
-              onClick={() => cut()}
-              disabled={!canCopy}
-            >
-              cut
-            </button>,
-            <button
-              onClick={() => copy()}
-              disabled={!canCopy}
-            >
-              copy
-            </button>,
-            <button
-              onClick={() => paste({ x: 0, y: 0 })}
-              disabled={!canPaste}
-            >
-              paste
-            </button>,
-          ]}
+          controls={controls}
           setShowAddNode={setShowAddNode}
         />
         <Background color='#E7E7E7' variant={BackgroundVariant.Lines}/>

--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -27,7 +27,7 @@ import { getNodesWithNewSelection } from './getNodesWithNewSelection';
 import { createDataStoryId, LinkCount, LinkId, NodeStatus, RequestObserverType } from '@data-story/core';
 import { useDragNode } from './useDragNode';
 import { ReactFlowNode } from '../Node/ReactFlowNode';
-import useCopyPaste from './controls/useCopyPaste';
+import { useCopyPaste } from './controls/useCopyPaste';
 
 const nodeTypes = {
   commentNodeComponent: CommentNodeComponent,

--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -27,6 +27,7 @@ import { getNodesWithNewSelection } from './getNodesWithNewSelection';
 import { createDataStoryId, LinkCount, LinkId, NodeStatus, RequestObserverType } from '@data-story/core';
 import { useDragNode } from './useDragNode';
 import { ReactFlowNode } from '../Node/ReactFlowNode';
+import useCopyPaste from './controls/useCopyPaste';
 
 const nodeTypes = {
   commentNodeComponent: CommentNodeComponent,
@@ -53,7 +54,7 @@ export const DataStoryCanvas = React.memo(DataStoryCanvasComponent);
 
 const Flow = ({
   initDiagram,
-  controls,
+  controls = [],
   onInitialize,
   setSidebarKey,
   onSave,
@@ -187,7 +188,7 @@ const Flow = ({
     edges,
   });
 
-  const getOnNodesDelete =  useCallback((nodesToDelete: ReactFlowNode[]) => {
+  const getOnNodesDelete = useCallback((nodesToDelete: ReactFlowNode[]) => {
     nodesToDelete.forEach(node => {
       const store = reactFlowStore.getState();
       const { edges } = store;
@@ -213,6 +214,11 @@ const Flow = ({
     // focus on the diagram after node deletion to enhance hotkey usage
     focusOnFlow();
   }, [connect, focusOnFlow, reactFlowStore]);
+
+  const { cut, copy, paste, bufferedNodes } = useCopyPaste();
+
+  const canCopy = nodes.some(({ selected }) => selected);
+  const canPaste = bufferedNodes.length > 0;
 
   return (
     <>
@@ -258,7 +264,7 @@ const Flow = ({
         }}
         onEdgeDoubleClick={(event, edge) => {
           if (!client) return;
-          if(client.onEdgeDoubleClick) client.onEdgeDoubleClick(edge.id);
+          if (client.onEdgeDoubleClick) client.onEdgeDoubleClick(edge.id);
         }}
         onEdgesChange={(changes: EdgeChange[]) => {
           onEdgesChange(changes);
@@ -305,7 +311,27 @@ const Flow = ({
       >
         <DataStoryControls
           onSave={onSave}
-          controls={controls}
+          controls={[
+            ...controls,
+            <button
+              onClick={() => cut()}
+              disabled={!canCopy}
+            >
+              cut
+            </button>,
+            <button
+              onClick={() => copy()}
+              disabled={!canCopy}
+            >
+              copy
+            </button>,
+            <button
+              onClick={() => paste({ x: 0, y: 0 })}
+              disabled={!canPaste}
+            >
+              paste
+            </button>,
+          ]}
           setShowAddNode={setShowAddNode}
         />
         <Background color='#E7E7E7' variant={BackgroundVariant.Lines}/>

--- a/packages/ui/src/components/DataStory/controls/useCopyPaste.ts
+++ b/packages/ui/src/components/DataStory/controls/useCopyPaste.ts
@@ -74,8 +74,8 @@ export function useCopyPaste<
     setBufferedNodes(nodes);
     setBufferedEdges(edges as SerializedReactFlowEdge[]);
 
-    setNodes(nodes => nodes.filter(node => !node.selected));
-    setEdges(edges => edges.filter(edge => !(edges as SerializedReactFlowEdge[]).includes(edge as SerializedReactFlowEdge)));
+    setNodes(allNodes => allNodes.filter(node => !node.selected));
+    setEdges(allEdges => allEdges.filter(edge => !(edges as SerializedReactFlowEdge[]).includes(edge as SerializedReactFlowEdge)));
   }, [getSelectedNodesAndEdges, setNodes, setEdges]);
 
   const paste = useCallback((position = screenToFlowPosition(mousePosRef.current)) => {

--- a/packages/ui/src/components/DataStory/controls/useCopyPaste.ts
+++ b/packages/ui/src/components/DataStory/controls/useCopyPaste.ts
@@ -10,6 +10,7 @@ import {
   type KeyCode,
 } from '@xyflow/react';
 
+// Could you help me refactor the useCopyPaste hook? Please keep the logic intact while making the code clearer and more concise. AI!
 export function useCopyPaste<
   NodeType extends Node = Node,
   EdgeType extends Edge = Edge
@@ -26,9 +27,6 @@ export function useCopyPaste<
 
   console.log('bufferedNodes', bufferedNodes);
 
-  // initialize the copy/paste hook
-  // 1. remove native copy/paste/cut handlers
-  // 2. add mouse move handler to keep track of the current mouse position
   useEffect(() => {
     const events = ['cut', 'copy', 'paste'];
 

--- a/packages/ui/src/components/DataStory/controls/useCopyPaste.ts
+++ b/packages/ui/src/components/DataStory/controls/useCopyPaste.ts
@@ -24,6 +24,7 @@ export function useCopyPaste<
   useEffect(() => {
     if (!rfDomNode) return;
 
+    // Listen for mouse move events on the DOM node and disable the default actions for cut, copy, and paste
     const handleMouseMove = (event: MouseEvent) => {
       mousePosRef.current = { x: event.clientX, y: event.clientY };
     };
@@ -34,9 +35,18 @@ export function useCopyPaste<
     events.forEach(event => rfDomNode.addEventListener(event, preventDefault));
     rfDomNode.addEventListener('mousemove', handleMouseMove);
 
+    // Listen for keydown events on the DOM node and disable the default action for select all
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'a') {
+        e.preventDefault();
+      }
+    };
+
+    rfDomNode.addEventListener('keydown', handleKeyDown);
     return () => {
       events.forEach(event => rfDomNode.removeEventListener(event, preventDefault));
       rfDomNode.removeEventListener('mousemove', handleMouseMove);
+      rfDomNode.removeEventListener('keydown', handleKeyDown);
     };
   }, [rfDomNode]);
 
@@ -95,9 +105,15 @@ export function useCopyPaste<
     setEdges(edges => [...edges.map(e => ({ ...e, selected: false })), ...newEdges]);
   }, [bufferedNodes, bufferedEdges, screenToFlowPosition, setNodes, setEdges]);
 
+  const selectAll = useCallback(() => {
+    setNodes(nodes => nodes.map(node => ({ ...node, selected: true })));
+    setEdges(edges => edges.map(edge => ({ ...edge, selected: true })));
+  }, [setNodes, setEdges]);
+
   useKeyboardShortcut(['Meta+x', 'Control+x'], cut);
   useKeyboardShortcut(['Meta+c', 'Control+c'], copy);
   useKeyboardShortcut(['Meta+v', 'Control+v'], paste);
+  useKeyboardShortcut(['Meta+a', 'Control+a'], selectAll);
 
   return { cut, copy, paste, bufferedNodes, bufferedEdges };
 }

--- a/packages/ui/src/components/DataStory/controls/useCopyPaste.ts
+++ b/packages/ui/src/components/DataStory/controls/useCopyPaste.ts
@@ -1,0 +1,164 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import {
+  Node,
+  useKeyPress,
+  useReactFlow,
+  getConnectedEdges,
+  Edge,
+  XYPosition,
+  useStore,
+  type KeyCode,
+} from '@xyflow/react';
+
+export function useCopyPaste<
+  NodeType extends Node = Node,
+  EdgeType extends Edge = Edge
+>() {
+  const mousePosRef = useRef<XYPosition>({ x: 0, y: 0 });
+  const rfDomNode = useStore((state) => state.domNode);
+
+  const { getNodes, setNodes, getEdges, setEdges, screenToFlowPosition } =
+    useReactFlow<NodeType, EdgeType>();
+
+  // Set up the paste buffers to store the copied nodes and edges.
+  const [bufferedNodes, setBufferedNodes] = useState([] as NodeType[]);
+  const [bufferedEdges, setBufferedEdges] = useState([] as EdgeType[]);
+
+  console.log('bufferedNodes', bufferedNodes);
+
+  // initialize the copy/paste hook
+  // 1. remove native copy/paste/cut handlers
+  // 2. add mouse move handler to keep track of the current mouse position
+  useEffect(() => {
+    const events = ['cut', 'copy', 'paste'];
+
+    if (rfDomNode) {
+      const preventDefault = (e: Event) => e.preventDefault();
+
+      const onMouseMove = (event: MouseEvent) => {
+        mousePosRef.current = {
+          x: event.clientX,
+          y: event.clientY,
+        };
+      };
+
+      for(const event of events) {
+        rfDomNode.addEventListener(event, preventDefault);
+      }
+
+      rfDomNode.addEventListener('mousemove', onMouseMove);
+
+      return () => {
+        for(const event of events) {
+          rfDomNode.removeEventListener(event, preventDefault);
+        }
+
+        rfDomNode.removeEventListener('mousemove', onMouseMove);
+      };
+    }
+  }, [rfDomNode]);
+
+  const copy = useCallback(() => {
+    const selectedNodes = getNodes().filter((node) => node.selected);
+    const selectedEdges = getConnectedEdges(selectedNodes, getEdges()).filter(
+      (edge) => {
+        const isExternalSource = selectedNodes.every(
+          (n) => n.id !== edge.source,
+        );
+        const isExternalTarget = selectedNodes.every(
+          (n) => n.id !== edge.target,
+        );
+
+        return !(isExternalSource || isExternalTarget);
+      },
+    );
+
+    setBufferedNodes(selectedNodes);
+    setBufferedEdges(selectedEdges);
+  }, [getNodes, getEdges]);
+
+  const cut = useCallback(() => {
+    const selectedNodes = getNodes().filter((node) => node.selected);
+    const selectedEdges = getConnectedEdges(selectedNodes, getEdges()).filter(
+      (edge) => {
+        const isExternalSource = selectedNodes.every(
+          (n) => n.id !== edge.source,
+        );
+        const isExternalTarget = selectedNodes.every(
+          (n) => n.id !== edge.target,
+        );
+
+        return !(isExternalSource || isExternalTarget);
+      },
+    );
+
+    setBufferedNodes(selectedNodes);
+    setBufferedEdges(selectedEdges);
+
+    // A cut action needs to remove the copied nodes and edges from the graph.
+    setNodes((nodes) => nodes.filter((node) => !node.selected));
+    setEdges((edges) => edges.filter((edge) => !selectedEdges.includes(edge)));
+  }, [getNodes, setNodes, getEdges, setEdges]);
+
+  const paste = useCallback(
+    (
+      { x: pasteX, y: pasteY } = screenToFlowPosition({
+        x: mousePosRef.current.x,
+        y: mousePosRef.current.y,
+      }),
+    ) => {
+      const minX = Math.min(...bufferedNodes.map((s) => s.position.x));
+      const minY = Math.min(...bufferedNodes.map((s) => s.position.y));
+
+      const now = Date.now();
+
+      const newNodes: NodeType[] = bufferedNodes.map((node) => {
+        const id = `${node.id}-${now}`;
+        const x = pasteX + (node.position.x - minX);
+        const y = pasteY + (node.position.y - minY);
+
+        return { ...node, id, position: { x, y } };
+      });
+
+      const newEdges: EdgeType[] = bufferedEdges.map((edge) => {
+        const id = `${edge.id}-${now}`;
+        const source = `${edge.source}-${now}`;
+        const target = `${edge.target}-${now}`;
+
+        return { ...edge, id, source, target };
+      });
+
+      setNodes((nodes) => [
+        ...nodes.map((node) => ({ ...node, selected: false })),
+        ...newNodes,
+      ]);
+      setEdges((edges) => [
+        ...edges.map((edge) => ({ ...edge, selected: false })),
+        ...newEdges,
+      ]);
+    },
+    [bufferedNodes, bufferedEdges, screenToFlowPosition, setNodes, setEdges],
+  );
+
+  useShortcut(['Meta+x', 'Control+x'], cut);
+  useShortcut(['Meta+c', 'Control+c'], copy);
+  useShortcut(['Meta+v', 'Control+v'], paste);
+
+  return { cut, copy, paste, bufferedNodes, bufferedEdges };
+}
+
+function useShortcut(keyCode: KeyCode, callback: Function): void {
+  const [didRun, setDidRun] = useState(false);
+  const shouldRun = useKeyPress(keyCode);
+
+  useEffect(() => {
+    if (shouldRun && !didRun) {
+      callback();
+      setDidRun(true);
+    } else {
+      setDidRun(shouldRun);
+    }
+  }, [shouldRun, didRun, callback]);
+}
+
+export default useCopyPaste;

--- a/packages/ui/src/components/DataStory/controls/useCopyPaste.ts
+++ b/packages/ui/src/components/DataStory/controls/useCopyPaste.ts
@@ -88,12 +88,12 @@ export function useCopyPaste<
     });
 
     const newNodes = bufferedNodes.map(node => ({
-      ...node,
+      ...structuredClone(node),
       id: generateCopiedId(node.id),
       position: calculateNewPosition(node.position),
       selected: true,
       data: {
-        ...node.data,
+        ...structuredClone(node.data),
         inputs: (node.data.inputs as Record<string, unknown>[] || [])?.map(input => ({
           ...input,
           id: `${generateCopiedId(node.id)}.${(input.id as string).split('.').pop()}`,
@@ -106,7 +106,7 @@ export function useCopyPaste<
     }));
 
     const newEdges = bufferedEdges.map(edge  => ({
-      ...edge,
+      ...structuredClone(edge),
       id: generateCopiedId(edge.id),
       source: generateCopiedId(edge.source),
       sourceHandle: `${generateCopiedId(edge.source)}.${edge.sourceHandle!.split('.').pop()}`,
@@ -115,8 +115,8 @@ export function useCopyPaste<
       selected: true,
     }));
 
-    setNodes(nodes => [...nodes.map(n => ({ ...n, selected: false })), ...newNodes]);
-    setEdges(edges => [...edges.map(e => ({ ...e, selected: false })), ...newEdges]);
+    setNodes(nodes => [...nodes.map(node => ({ ...node, selected: false })), ...newNodes]);
+    setEdges(edges => [...edges.map(edge => ({ ...edge, selected: false })), ...newEdges]);
   }, [bufferedNodes, bufferedEdges, screenToFlowPosition, setNodes, setEdges]);
 
   const selectAll = useCallback(() => {

--- a/packages/ui/src/components/DataStory/getNodesWithNewSelection.ts
+++ b/packages/ui/src/components/DataStory/getNodesWithNewSelection.ts
@@ -2,6 +2,12 @@ import { ReactFlowNode } from '../Node/ReactFlowNode'
 
 export type Direction = 'up' | 'down' | 'left' | 'right'
 
+/**
+ * using the direction, find the closest node to the current selected node
+ * @param {Direction} direction
+ * @param {ReactFlowNode[]} nodes
+ * @returns {ReactFlowNode | undefined}
+ */
 export const getNodesWithNewSelection = (
   direction: Direction,
   nodes: ReactFlowNode[],

--- a/packages/ui/src/components/Node/NodeComponent.tsx
+++ b/packages/ui/src/components/Node/NodeComponent.tsx
@@ -19,7 +19,7 @@ const NodeComponent = ({ id, data, selected }: {
   return (
     (
       <div
-        className={'text-xs' + (selected ? ' shadow-xl' : '')}
+        className={`text-xs ${selected ? 'shadow-xl shadow-blue-100 ring-1 ring-blue-200' : ''}`}
         data-cy="data-story-node-component"
         onDoubleClick={() => {
           setOpenNodeSidebarId(id)

--- a/packages/ui/src/components/Node/table/TableNodeComponent.tsx
+++ b/packages/ui/src/components/Node/table/TableNodeComponent.tsx
@@ -15,7 +15,7 @@ import { MemoizedTableHeader } from './MemoizedTableHeader';
 import { CELL_MAX_WIDTH, CELL_MIN_WIDTH, CELL_WIDTH, CellsMatrix, ColumnWidthOptions } from './CellsMatrix';
 import { getFormatterOnlyAndDropParam } from './GetFormatterOnlyAndDropParam';
 
-const TableNodeComponent = ({ id, data }: {
+const TableNodeComponent = ({ id, data, selected }: {
   id: string,
   data: DataStoryNodeData,
   selected: boolean
@@ -158,7 +158,7 @@ const TableNodeComponent = ({ id, data }: {
   return (
     <div
       ref={tableRef}
-      className="shadow-xl bg-gray-50 border rounded border-gray-300 text-xs"
+      className={`text-xs border rounded border-gray-300 ${selected ? 'shadow-xl shadow-blue-100 ring-1 ring-blue-200' : ''} `}
     >
       <CustomHandle id={input.id} isConnectable={true} isInput={true} />
       <div data-cy={'data-story-table'} className="text-gray-600 max-w-[750px] bg-gray-100 rounded font-mono -mt-3">

--- a/packages/ui/src/styles/dataStoryCanvasStyle.css
+++ b/packages/ui/src/styles/dataStoryCanvasStyle.css
@@ -1,0 +1,9 @@
+@keyframes dash {
+    to {
+        stroke-dashoffset: -10;
+    }
+}
+
+.react-flow__edge:hover {
+    cursor: crosshair;
+}


### PR DESCRIPTION
- [x] **Keyboard Shortcut Support**: We've successfully implemented support for `Ctrl+C`, `Ctrl+V`, and `Ctrl+X`, allowing users to easily copy, paste, and cut nodes.
- [x] **Multi-selection Copy**: Users can select multiple `nodes` by holding down the `Ctrl` key, and when copying, both the selected `nodes` and their corresponding `edges` will be copied together.
 - [x] **Duplicate `Component id` Issue**: The copied `Component id` is currently not unique, leading to repetition that needs to be addressed. 
- [x] **Inadequate `node` Selection Feedback**: Especially for `table` type `nodes`, the selection feedback is not clearly visible, which could be improved for a better user experience.
- [x] **Select All Functionality**: Currently, there's no capability to select all content on the page at once.

https://github.com/user-attachments/assets/dabc4a2a-4513-4b1f-90e0-07b2bd1e5b81

### Todo: 
- [ ] **System Clipboard Support**: The copied content does not appear in the system clipboard, preventing cross-panel copying and sharing of `diagram` information.
- [ ] **Text Content Copy**: We cannot copy text content beyond `nodes`, which interferes with copying text in the Sidebar and `Resource` and `DataStory` text on the page.