### PR TITLE
Debuggable core tinker

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,33 @@
           "${workspaceFolder}/packages/ds-ext/dist/**/*.js"
         ],
         "preLaunchTask": "${defaultBuildTask}"
-      }
+      },
+      {
+        "name": "Debug Tinker",
+        "type": "node",
+        "request": "launch",
+        "runtimeExecutable": "npx",
+        "runtimeArgs": [
+          "ts-node",
+          "--transpile-only",
+          "--files",
+          "--project",
+          "tsconfig.json"
+        ],
+        "sourceMaps": true,
+        "resolveSourceMapLocations": [
+          "${workspaceFolder}/**",
+          "!**/node_modules/**"
+        ],
+        "args": [
+          "${workspaceFolder}/packages/core/src/tinker.ts"
+        ],
+        "cwd": "${workspaceFolder}/packages/core",
+        "internalConsoleOptions": "openOnSessionStart",
+        "skipFiles": [
+          "<node_internals>/**",
+          "node_modules/**"
+        ]
+      },      
     ]
   }


### PR DESCRIPTION
Adds ability to Debug `core/src/tinker.ts`. Note this file is ignored, intended as a private scratchboard.

Tip: To persist any (expandable) logs in vs code/windsurf integrated Debug console, do keep a last final breakpoint. This will keep debugger alive and prevent "No debugger available, can not send 'variables'" message.