### PR TITLE
Automatically load .env if present

### DIFF
--- a/packages/ds-ext/package.json
+++ b/packages/ds-ext/package.json
@@ -153,6 +153,7 @@
     "@data-story/core": "workspace:*",
     "@data-story/nodejs": "workspace:*",
     "@data-story/ui": "workspace:*",
+    "dotenv": "^16.4.0",
     "duckdb-async": "^1.1.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/packages/ds-ext/src/extension.ts
+++ b/packages/ds-ext/src/extension.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import * as fs from 'fs';
 import { JsonReadonlyProvider } from './JsonReadonlyProvider';
 import { DiagramDocument } from './DiagramDocument';
+import { loadWorkspaceEnv } from './utils/loadWorkspaceEnv';
 
 let diagramEditorProvider: DiagramEditorProvider;
 let jsonReadonlyProvider: JsonReadonlyProvider | undefined;
@@ -19,6 +20,8 @@ function createReadonlyUri(args: vscode.Uri): vscode.Uri {
 }
 
 export function activate(context: vscode.ExtensionContext) {
+  loadWorkspaceEnv();
+
   let disposable = vscode.commands.registerCommand('ds-ext.createDemos', async () => {
     await createDemosDirectory();
   });

--- a/packages/ds-ext/src/messageHandlers/onRun.ts
+++ b/packages/ds-ext/src/messageHandlers/onRun.ts
@@ -3,6 +3,7 @@ import { Application, coreNodeProvider, Diagram, InMemoryStorage, ReportCallback
 import { MessageHandler } from '../MessageHandler';
 import { nodeJsProvider } from '@data-story/nodejs';
 import { createAndBootApp } from '../app/createAndBootApp';
+import { loadWorkspaceEnv } from '../utils/loadWorkspaceEnv';
 
 /**
  * Set the workspace folder path in `process.env.WORKSPACE_FOLDER_PATH`
@@ -22,6 +23,9 @@ function setWorkspaceFolderPath() {
 }
 
 export const onRun: MessageHandler = async ({ event, postMessage, inputObserverController }) => {
+  // Load latest .env file contents before running
+  const envVars = loadWorkspaceEnv();
+
   const app = await createAndBootApp();
 
   const diagram = new Diagram({

--- a/packages/ds-ext/src/utils/loadWorkspaceEnv.ts
+++ b/packages/ds-ext/src/utils/loadWorkspaceEnv.ts
@@ -1,0 +1,41 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+import * as fs from 'fs';
+
+/**
+ * Load environment variables from .env file in workspace root.
+ */
+export function loadWorkspaceEnv() {
+  try {
+    // Get the first workspace folder (VS Code workspace root)
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+
+    if (!workspaceFolder) {
+      console.log('No workspace folder found');
+      return null;
+    }
+
+    const envPath = path.join(workspaceFolder.uri.fsPath, '.env');
+
+    // Check if .env file exists
+    if (fs.existsSync(envPath)) {
+      // Load .env file
+      const result = dotenv.config({ path: envPath, override: true });
+
+      if (result.error) {
+        console.error('Error loading .env file:', result.error);
+        return null;
+      }
+
+      console.log('.env file loaded successfully from workspace root');
+      return result.parsed;
+    } else {
+      console.log('No .env file found in workspace root');
+      return null;
+    }
+  } catch (error) {
+    console.error('Error loading .env file:', error);
+    return null;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5931,6 +5931,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv@npm:^16.4.0":
+  version: 16.4.7
+  resolution: "dotenv@npm:16.4.7"
+  checksum: 10/f13bfe97db88f0df4ec505eeffb8925ec51f2d56a3d0b6d916964d8b4af494e6fb1633ba5d09089b552e77ab2a25de58d70259b2c5ed45ec148221835fc99a0c
+  languageName: node
+  linkType: hard
+
 "ds-ext@workspace:packages/ds-ext":
   version: 0.0.0-use.local
   resolution: "ds-ext@workspace:packages/ds-ext"
@@ -5949,6 +5956,7 @@ __metadata:
     "@vscode/test-cli": "npm:^0.0.10"
     "@vscode/test-electron": "npm:^2.4.1"
     autoprefixer: "npm:^10.4.20"
+    dotenv: "npm:^16.4.0"
     duckdb-async: "npm:^1.1.3"
     eslint: "npm:^9.9.1"
     postcss: "npm:^8.4.47"


### PR DESCRIPTION
Automatically load .env if present

### Note
Since the vs-code extension backend is "always up running", _removing_ a env entry will have no effect as dotenv only adds/overwrites the keys. This _might_ have side effects. If removal of keys is needed, currently a restart of vscode is needed.