### PR TITLE
feat: persist running state and results when opening different diagrams in VSCode extension

### DIFF
--- a/packages/ds-ext/src/extension.ts
+++ b/packages/ds-ext/src/extension.ts
@@ -85,14 +85,13 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.window.registerCustomEditorProvider(
       'ds-ext.diagramEditor',
       diagramEditorProvider,
-      // todo: During testing, I encountered several issues, so we decided to develop the implementation of the execution termination feature separately.
-      // {
-      //   webviewtptions: {
-      //     // ✔️ Enable context retention
-      //     retainContextWhenHidden: true,
-      //   },
-      //   supportsMultipleEditorsPerDocument: false
-      // }
+      {
+        webviewOptions: {
+          // ✔️ Enable context retention
+          retainContextWhenHidden: true,
+        },
+        supportsMultipleEditorsPerDocument: true,
+      },
     ),
   );
 


### PR DESCRIPTION
The running state and results persist when switching between different *.ds files. 

https://github.com/user-attachments/assets/68408d71-4495-43d3-9cb0-9ef7b27670c6

closing a *.ds file and then reopening it does not persist the running state and results.

https://github.com/user-attachments/assets/71236d39-0ad3-4dc7-a909-85214f4b003b