### PR TITLE
feat: handle empty diagram data in preview and add watch core and ui in dev:ext

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
     "watch:test": "yarn run -T vitest",
     "build:esm": "vite build --config vite.config.esm.ts",
     "build:cjs": "tsc -p tsconfig.build.json",
-    "watch": "yarn build:esm --watch && yarn build:cjs --watch",
+    "watch": "yarn build:esm --watch & yarn build:cjs --watch",
     "build": "yarn build:esm && yarn build:cjs && yarn build-vite",
     "release": "yarn run -T release-it"
   },

--- a/packages/ds-ext/src/extension.ts
+++ b/packages/ds-ext/src/extension.ts
@@ -55,8 +55,8 @@ export function activate(context: vscode.ExtensionContext) {
 
   vscode.commands.registerCommand('ds-ext.showDiagramPreview', async (args: vscode.Uri) => {
     const diagramDocument = diagramEditorProvider.provideDiagramContent(args);
-    const diagramData = diagramDocument?.data;
-    const dataString = JSON.stringify(JSON.parse(new TextDecoder().decode(diagramData)), null, 2);
+    const diagramData = new TextDecoder().decode(diagramDocument?.data) || '{}';
+    const dataString = JSON.stringify(JSON.parse(diagramData), null, 2);
     const readOnlyUri = createReadonlyUri(args);
 
     jsonReadonlyProvider!.updateContent(readOnlyUri, dataString);

--- a/packages/ds-ext/src/extension.ts
+++ b/packages/ds-ext/src/extension.ts
@@ -55,8 +55,11 @@ export function activate(context: vscode.ExtensionContext) {
 
   vscode.commands.registerCommand('ds-ext.showDiagramPreview', async (args: vscode.Uri) => {
     const diagramDocument = diagramEditorProvider.provideDiagramContent(args);
-    const diagramData = new TextDecoder().decode(diagramDocument?.data) || '{}';
-    const dataString = JSON.stringify(JSON.parse(diagramData), null, 2);
+    const diagramData = new TextDecoder().decode(diagramDocument?.data);
+    let dataString = '';
+    if (diagramData) {
+      dataString = JSON.stringify(JSON.parse(diagramData), null, 2);
+    }
     const readOnlyUri = createReadonlyUri(args);
 
     jsonReadonlyProvider!.updateContent(readOnlyUri, dataString);

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,9 @@
       "dependsOn": [
         "watch:extension", 
         "watch:app", 
-        "watch"
+        "watch",
+        "watch:webpack",
+        "watch:css"
       ],
       "cache": false,
       "persistent": true


### PR DESCRIPTION
- fix: gracefully handle empty diagram data in preview 

https://github.com/user-attachments/assets/9033ba48-2148-428e-9fa5-15452d2825b5

- feat: add watch core and ui in dev:ext

https://github.com/user-attachments/assets/351a0d23-162c-4b3d-abfd-88c00042190e

