### PR TITLE
Allow keyless aggregation

### DIFF
--- a/packages/core/src/computers/Aggregate.ts
+++ b/packages/core/src/computers/Aggregate.ts
@@ -43,7 +43,7 @@ export const Aggregate: Computer = {
 
     const groups = new Map();
     for (const item of all) {
-      const key = get(item.value, property);
+      const key = property ? get(item.value, property) : null;
 
       if (!groups.has(key)) groups.set(key, []);
 


### PR DESCRIPTION
Allow usage of Aggregate node with no key specified. The result is all incoming items are aggregated with a key `null`.

<img width="1594" alt="image" src="https://github.com/user-attachments/assets/7a8841c9-0664-4408-a1d4-0c2b64e95a5d" />

Note the "opposite" of this operation: _FlatMap_, which can be used to unpack aggregate (or any other aggregate-like structure) to individual items