### PR TITLE
feat: rename `watch:tsc` script to `watch:nodejs` and run it during `ext:dev`

### DIFF
--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -11,7 +11,7 @@
     "dist"
   ],
   "scripts": {
-    "watch:tsc": "tsc --watch",
+    "watch:nodejs": "tsc --watch",
     "tinker": "npx ts-node ./src/tinker.ts",
     "test": "yarn run -T vitest",
     "build": "tsc",

--- a/turbo.json
+++ b/turbo.json
@@ -16,7 +16,8 @@
         "watch:app", 
         "watch",
         "watch:webpack",
-        "watch:css"
+        "watch:css",
+        "watch:nodejs"
       ],
       "cache": false,
       "persistent": true
@@ -42,6 +43,10 @@
       "persistent": true
     },
     "watch:server": {
+      "cache": false,
+      "persistent": true
+    },
+    "watch:nodejs": {
       "cache": false,
       "persistent": true
     },

--- a/turbo.json
+++ b/turbo.json
@@ -47,7 +47,7 @@
     },
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist"],
+      "outputs": ["dist/**"],
       "cache": true
     },
     "lint": {},


### PR DESCRIPTION
feat: rename `watch:tsc` script to `watch:nodejs` and run it during `ext:dev`

https://github.com/user-attachments/assets/59dde164-ed22-434d-b52a-d61dfc19e6e9


fix: Update build outputs to include all files in dist

| Before | After |
| ------ | ----- |
| ❌      | ✅    |
| ![image](https://github.com/user-attachments/assets/838b4516-7d19-4a59-a668-d4443aa14d78)| ![image](https://github.com/user-attachments/assets/ed09ee84-5137-4b98-9bd0-93cd067ca198)|

![image](https://github.com/user-attachments/assets/776acb83-7a7c-495d-ae91-7214679df735)
