### PR TITLE
 feat: ensure Run response waits for completion of ObserveLinkCounts link count update before returning

### DIFF
--- a/packages/core/src/InputObserverController.ts
+++ b/packages/core/src/InputObserverController.ts
@@ -130,8 +130,15 @@ export class InputObserverController {
       filter(payload => observer.linkIds.includes(payload.linkId)),
       map(payload => payload),
       bufferTime(observer.throttleMs ?? ThrottleMS),
-      filter(it=>it.length > 0),
-      map(bufferedCounts => bufferedCounts.flat(1)),
+      filter(it=> it.length > 0),
+      map(counts => {
+        // Group by linkId and keep only the latest entry for each linkId
+        const latestByLinkId = new Map<string, LinksCountParam>();
+        counts.forEach(count => {
+          latestByLinkId.set(count.linkId, count);
+        });
+        return Array.from(latestByLinkId.values());
+      }),
       tap(counts => {
         observer.onReceive({
           links: counts,

--- a/packages/core/src/InputObserverController.ts
+++ b/packages/core/src/InputObserverController.ts
@@ -33,8 +33,8 @@ export class InputObserverController {
    * When we invoke `reportItems`, it triggers the `notifyObservers` callback and forwards the `items` and `inputObserver` parameters
    */
   async reportItems(memoryObserver: LinkItemsParam): Promise<void> {
-    await this.storage.appendLinkItems(memoryObserver.linkId, memoryObserver.items);
     this.items$.next(memoryObserver);
+    await this.storage.appendLinkItems(memoryObserver.linkId, memoryObserver.items);
   }
 
   setItems(linkId: LinkId, items: ItemValue[]): void {
@@ -42,8 +42,8 @@ export class InputObserverController {
   }
 
   async reportLinksCount(memoryObserver: LinksCountParam): Promise<void> {
-    await this.storage.setLinkCount(memoryObserver.linkId, memoryObserver.count);
     this.links$.next(memoryObserver);
+    await this.storage.setLinkCount(memoryObserver.linkId, memoryObserver.count);
   }
 
   // The current requirement only needs to retain 'BUSY' and 'COMPLETE' in NodeStatus.
@@ -51,8 +51,8 @@ export class InputObserverController {
     if (status === 'AVAILABLE') {
       return;
     }
-    await this.storage.setNodeStatus(nodeId, status);
     this.nodeStatus$.next({ nodeId, status });
+    await this.storage.setNodeStatus(nodeId, status);
   }
 
   async getDataFromStorage({
@@ -161,14 +161,15 @@ export class InputObserverController {
       filter(payload => observer.nodeIds.includes(payload.nodeId)),
       bufferTime(observer.throttleMs ?? ThrottleMS),
       filter(it=> it.length > 0),
-      tap(async (_) => {
-        const nodes = await Promise.all(observer.nodeIds.map(async (nodeId) => {
-          const status = await this.storage.getNodeStatus(nodeId);
-          return {
-            nodeId,
-            status: status ?? 'COMPLETE',
-          }
-        }));
+      map(statuses => {
+        // Group by nodeId and keep only the latest entry for each nodeId
+        const latestByNodeId = new Map<string, { nodeId: string; status: NodeStatus }>();
+        statuses.forEach(status => {
+          latestByNodeId.set(status.nodeId, status);
+        });
+        return Array.from(latestByNodeId.values());
+      }),
+      tap(async (nodes) => {
         observer.onReceive({
           nodes: nodes as NodesStatusInfo[],
         });


### PR DESCRIPTION
 feat: ensure only the latest entry for each `linkId` is sent in the `observeLinkCounts` request
 | Before | After |
| ------ | ----- |
| ❌      | ✅    |
| ![image](https://github.com/user-attachments/assets/8c2d61bf-8a81-42ec-bf06-e4b9d4511957)| ![image](https://github.com/user-attachments/assets/33527859-60b6-4d31-8116-b1f11f25a931)  |
 
 feat: ensure Run response waits for completion of ObserveLinkCounts link count update before returning
 
https://github.com/user-attachments/assets/a352c85d-46ed-4a2d-9de0-073d682dae33

