### PR TITLE
feat: optimize dependencies management

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     "typescript": "5.6.2",
     "vitest": "^1.6.0",
     "webpack": "^5.88.1",
-    "webpack-cli": "^5.1.4",
-    "webpack-bundle-analyzer": "^4.10.1"
+    "webpack-bundle-analyzer": "^4.10.1",
+    "webpack-cli": "^5.1.4"
   },
   "resolutions": {
     "@uiw/codemirror-extensions-basic-setup@npm:4.23.10": "patch:@uiw/codemirror-extensions-basic-setup@npm%3A4.23.10#~/.yarn/patches/@uiw-codemirror-extensions-basic-setup-npm-4.23.10-953e998a73.patch"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@stylistic/eslint-plugin": "^0.1.2",
     "@types/mocha": "^10.0.6",
+    "@types/node": "^18.14.2",
     "@typescript-eslint/parser": "^6.9.0",
     "cypress": "^13.6.1",
     "eslint": "^8.52.0",
@@ -78,6 +79,8 @@
     "turbo": "<1.11.0",
     "typescript": "5.6.2",
     "vitest": "^1.6.0",
+    "webpack": "^5.88.1",
+    "webpack-cli": "^5.1.4",
     "webpack-bundle-analyzer": "^4.10.1"
   },
   "resolutions": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,11 +63,8 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "@types/node": "18.14.2",
     "vite": "^5.0.10",
     "vite-plugin-externalize-deps": "^0.8.0",
-    "webpack": "^5.88.1",
-    "webpack-cli": "^5.1.4",
     "webpack-shebang-plugin": "^1.1.8"
   },
   "peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,6 @@
     }
   },
   "dependencies": {
-    "axios": "^1.3.4",
     "nanoid": "3",
     "rxjs": "^7.8.1",
     "zod": "^3.24.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,15 +57,13 @@
   },
   "dependencies": {
     "axios": "^1.3.4",
-    "dotenv": "^16.0.3",
     "nanoid": "3",
     "rxjs": "^7.8.1",
     "zod": "^3.24.1"
   },
   "devDependencies": {
     "vite": "^5.0.10",
-    "vite-plugin-externalize-deps": "^0.8.0",
-    "webpack-shebang-plugin": "^1.1.8"
+    "vite-plugin-externalize-deps": "^0.8.0"
   },
   "peerDependencies": {
     "vitest": "^1.6.0"

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -38,7 +38,6 @@
     "@types/react": "^18",
     "autoprefixer": "^10.4.16",
     "cross-env": "^7.0.3",
-    "postcss": "^8.4.31",
     "source-map-loader": "^4.0.1",
     "tailwindcss": "^3.3.3"
   }

--- a/packages/ds-ext/package.json
+++ b/packages/ds-ext/package.json
@@ -133,7 +133,6 @@
   },
   "devDependencies": {
     "@types/mocha": "^10.0.7",
-    "@types/node": "20.x",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@types/vscode": "^1.80.0",
@@ -145,9 +144,7 @@
     "autoprefixer": "^10.4.20",
     "eslint": "^9.9.1",
     "postcss": "^8.4.47",
-    "vite": "^5.4.7",
-    "webpack": "^5.94.0",
-    "webpack-cli": "^5.1.4"
+    "vite": "^5.4.7"
   },
   "dependencies": {
     "@data-story/core": "workspace:*",

--- a/packages/ds-ext/package.json
+++ b/packages/ds-ext/package.json
@@ -109,10 +109,10 @@
   },
   "scripts": {
     "vscode:prepublish": "yarn run package",
-    "build": "webpack && vite build",
-    "watch:extension": "webpack --watch",
+    "build": "yarn run -T webpack && vite build",
+    "watch:extension": "yarn run -T webpack --watch",
     "watch:app": "vite build -w",
-    "package": "webpack --mode production --devtool hidden-source-map",
+    "package": "yarn run -T webpack --mode production --devtool hidden-source-map",
     "compile-tests": "tsc -p . --outDir out",
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "yarn run compile-tests && yarn run build && yarn run lint",

--- a/packages/ds-ext/package.json
+++ b/packages/ds-ext/package.json
@@ -137,7 +137,6 @@
     "@types/react-dom": "^18",
     "@types/vscode": "^1.80.0",
     "@typescript-eslint/eslint-plugin": "^8.3.0",
-    "@typescript-eslint/parser": "^8.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.4.1",
@@ -154,8 +153,7 @@
     "duckdb-async": "^1.1.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "rxjs": "^7.8.1",
-    "ts-loader": "^9.5.1"
+    "rxjs": "^7.8.1"
   },
   "repository": {
     "type": "git",

--- a/packages/hubspot/package.json
+++ b/packages/hubspot/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@types/glob": "^8.1.0",
-    "@types/ws": "^8.5.4",
-    "webpack-shebang-plugin": "^1.1.8"
+    "@types/ws": "^8.5.4"
   }
 }

--- a/packages/hubspot/package.json
+++ b/packages/hubspot/package.json
@@ -36,8 +36,6 @@
   "devDependencies": {
     "@types/glob": "^8.1.0",
     "@types/ws": "^8.5.4",
-    "webpack": "^5.88.1",
-    "webpack-cli": "^5.1.4",
     "webpack-shebang-plugin": "^1.1.8"
   }
 }

--- a/packages/hubspot/package.json
+++ b/packages/hubspot/package.json
@@ -27,14 +27,10 @@
   "dependencies": {
     "@data-story/core": "workspace:*",
     "@hubspot/api-client": "^10.2.0",
-    "@types/node": "18.14.2",
-    "axios": "^1.3.4",
-    "dotenv": "^16.0.3",
-    "openai": "^3.2.1",
     "ws": "^8.12.1"
   },
   "devDependencies": {
-    "@types/glob": "^8.1.0",
+    "@types/node": "^22.14.0",
     "@types/ws": "^8.5.4"
   }
 }

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -40,7 +40,6 @@
   },
   "devDependencies": {
     "@types/glob": "^8.1.0",
-    "@types/ws": "^8.5.4",
-    "webpack-shebang-plugin": "^1.1.8"
+    "@types/ws": "^8.5.4"
   }
 }

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -40,10 +40,7 @@
   },
   "devDependencies": {
     "@types/glob": "^8.1.0",
-    "@types/node": "18.14.2",
     "@types/ws": "^8.5.4",
-    "webpack": "^5.88.1",
-    "webpack-cli": "^5.1.4",
     "webpack-shebang-plugin": "^1.1.8"
   }
 }

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -30,12 +30,10 @@
   },
   "dependencies": {
     "@data-story/core": "workspace:*",
-    "axios": "^1.3.4",
     "csv-parse": "^5.6.0",
     "csv-stringify": "^6.5.2",
     "dotenv": "^16.0.3",
     "glob": "^11.0.0",
-    "openai": "^3.2.1",
     "ws": "^8.12.1"
   },
   "devDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -51,7 +51,7 @@
     "@tanstack/react-table": "^8.11.7",
     "@tanstack/react-virtual": "^3.5.0",
     "@uiw/react-codemirror": "patch:@uiw/react-codemirror@npm%3A4.23.10#~/.yarn/patches/@uiw-react-codemirror-npm-4.23.10-2db625ca86.patch",
-    "@xyflow/react": "^12.0.2",
+    "@xyflow/react": "12.5.5",
     "ahooks": "^3.7.10",
     "allotment": "^1.20.2",
     "clsx": "^2.0.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -58,12 +58,12 @@
     "markdown-it": "^13.0.2",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
+    "react-hook-form": "^7.43.8",
     "rxjs": "^7.8.1",
     "zustand": "^4.3.9"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.10",
-    "@types/glob": "^8.1.0",
     "@types/markdown-it": "^13.0.6",
     "@types/react": "^18",
     "@types/react-dom": "*",
@@ -72,7 +72,6 @@
     "css-loader": "^6.8.1",
     "postcss": "^8.4.21",
     "postcss-loader": "^7.3.3",
-    "react-hook-form": "^7.43.8",
     "style-loader": "^3.3.3",
     "tailwindcss": "^3.2.7"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -65,22 +65,17 @@
     "@tailwindcss/typography": "^0.5.10",
     "@types/glob": "^8.1.0",
     "@types/markdown-it": "^13.0.6",
-    "@types/node": "18.14.2",
     "@types/react": "^18",
     "@types/react-dom": "*",
     "@types/ws": "^8.5.4",
     "autoprefixer": "^10.4.13",
-    "axios": "^1.3.4",
     "css-loader": "^6.8.1",
     "postcss": "^8.4.21",
     "postcss-loader": "^7.3.3",
     "react-hook-form": "^7.43.8",
     "style-loader": "^3.3.3",
     "tailwindcss": "^3.2.7",
-    "webpack": "^5.88.1",
-    "webpack-cli": "^5.1.4",
-    "ws": "^8.12.1",
-    "zod": "^3.24.1"
+    "ws": "^8.12.1"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,11 +18,11 @@
     "/src"
   ],
   "scripts": {
-    "analyze": "webpack --profile --json > stats.json && yarn run -T webpack-bundle-analyzer stats.json",
-    "build": "echo _____RUNNING_UI_BUILD_____ && webpack && yarn run build:css",
+    "analyze": "yarn run -T webpack --profile --json > stats.json && yarn run -T webpack-bundle-analyzer stats.json",
+    "build": "echo _____RUNNING_UI_BUILD_____ && yarn run -T webpack && yarn run build:css",
     "build:css": "yarn run -T postcss ./src/styles/globals.css -o ./dist/data-story.css",
     "watch:css": "yarn run build:css --watch",
-    "watch:webpack": "webpack --watch",
+    "watch:webpack": "yarn run -T webpack --watch",
     "release": "yarn run -T release-it",
     "ci:unit": "yarn run -T vitest run --config vitest.config.ts --passWithNoTests",
     "test": "yarn run ci:unit && yarn run test:component",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -74,8 +74,7 @@
     "postcss-loader": "^7.3.3",
     "react-hook-form": "^7.43.8",
     "style-loader": "^3.3.3",
-    "tailwindcss": "^3.2.7",
-    "ws": "^8.12.1"
+    "tailwindcss": "^3.2.7"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/packages/ui/src/components/Node/ConsoleNodeComponent.tsx
+++ b/packages/ui/src/components/Node/ConsoleNodeComponent.tsx
@@ -5,7 +5,7 @@ import { useStore } from '../DataStory/store/store';
 import { shallow } from 'zustand/shallow';
 import { createDataStoryId, ObserveLinkItems, RequestObserverType } from '@data-story/core';
 import { StoreSchema } from '../DataStory/types';
-import { useHandleConnections } from '@xyflow/react';
+import { useNodeConnections } from '@xyflow/react';
 
 const ConsoleNodeComponent = ({ id, data, selected }: {
   id: string,
@@ -23,7 +23,7 @@ const useObserverConsole = ({ id }: { id: string }) => {
   });
   const { toDiagram, client } = useStore(selector, shallow);
 
-  const connections = useHandleConnections({ type: 'target', id: `${id}.input` });
+  const connections = useNodeConnections({ handleType: 'target', id: `${id}.input` });
 
   // Add the node to the inputObservers when the node is mounted
   useEffect(() => {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,5 @@
+import './withResolversPolyfill';
+
 export { DataStory } from './components/DataStory';
 export { DataStoryCanvas } from './components/DataStory/DataStoryCanvas';
 export { DataStoryCanvasProvider } from './components/DataStory/store/store';

--- a/packages/ui/src/withResolversPolyfill.ts
+++ b/packages/ui/src/withResolversPolyfill.ts
@@ -1,0 +1,11 @@
+if (typeof Promise.withResolvers === 'undefined') {
+  Promise.withResolvers = <T>() => {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -592,7 +592,7 @@ __metadata:
     "@types/react-dom": "npm:*"
     "@types/ws": "npm:^8.5.4"
     "@uiw/react-codemirror": "patch:@uiw/react-codemirror@npm%3A4.23.10#~/.yarn/patches/@uiw-react-codemirror-npm-4.23.10-2db625ca86.patch"
-    "@xyflow/react": "npm:^12.0.2"
+    "@xyflow/react": "npm:12.5.5"
     ahooks: "npm:^3.7.10"
     allotment: "npm:^1.20.2"
     autoprefixer: "npm:^10.4.13"
@@ -3293,23 +3293,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xyflow/react@npm:^12.0.2":
-  version: 12.3.1
-  resolution: "@xyflow/react@npm:12.3.1"
+"@xyflow/react@npm:12.5.5":
+  version: 12.5.5
+  resolution: "@xyflow/react@npm:12.5.5"
   dependencies:
-    "@xyflow/system": "npm:0.0.43"
+    "@xyflow/system": "npm:0.0.55"
     classcat: "npm:^5.0.3"
     zustand: "npm:^4.4.0"
   peerDependencies:
     react: ">=17"
     react-dom: ">=17"
-  checksum: 10/a55a4ffa4916fad294793ef141a8b53c109037db9425ff3707395086d8326a3a7c08809920e331741f3607161d3b6ecd3ad7ba50c47833c63e4c9b29e9905dd9
+  checksum: 10/64a7977779ecd4290dd09163c336a69ea976adbb08644dda20be6f356a9519386b195713a090f43c9ebe77cc52c136857a8456ebe8680b6e48be918bcd87f36b
   languageName: node
   linkType: hard
 
-"@xyflow/system@npm:0.0.43":
-  version: 0.0.43
-  resolution: "@xyflow/system@npm:0.0.43"
+"@xyflow/system@npm:0.0.55":
+  version: 0.0.55
+  resolution: "@xyflow/system@npm:0.0.55"
   dependencies:
     "@types/d3-drag": "npm:^3.0.7"
     "@types/d3-selection": "npm:^3.0.10"
@@ -3318,7 +3318,7 @@ __metadata:
     d3-drag: "npm:^3.0.0"
     d3-selection: "npm:^3.0.0"
     d3-zoom: "npm:^3.0.0"
-  checksum: 10/180de23bc8303580d4e2da5d9130f3a89df14e841531717e02d5fe7db770824015446c2606d38cfa3c9ad413a1ca1f782bf8830e5625dfc952828baa69d1f803
+  checksum: 10/6135462949901015a47f4013ee7e98fde709314ec0eb301f071c7394db5887ec18c5edff386b6ec8c14de87b792e2d2a3bbe35aae87a60d876acde4026b4bfd3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -501,7 +501,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@data-story/core@workspace:packages/core"
   dependencies:
-    axios: "npm:^1.3.4"
     nanoid: "npm:3"
     rxjs: "npm:^7.8.1"
     vite: "npm:^5.0.10"
@@ -528,7 +527,6 @@ __metadata:
     next: "npm:^13.0.6"
     nextra: "npm:latest"
     nextra-theme-docs: "npm:latest"
-    postcss: "npm:^8.4.31"
     react: "npm:^18.2.0"
     react-chartjs-2: "npm:^5.2.0"
     react-dom: "npm:^18.2.0"
@@ -544,12 +542,8 @@ __metadata:
   dependencies:
     "@data-story/core": "workspace:*"
     "@hubspot/api-client": "npm:^10.2.0"
-    "@types/glob": "npm:^8.1.0"
-    "@types/node": "npm:18.14.2"
+    "@types/node": "npm:^22.14.0"
     "@types/ws": "npm:^8.5.4"
-    axios: "npm:^1.3.4"
-    dotenv: "npm:^16.0.3"
-    openai: "npm:^3.2.1"
     ws: "npm:^8.12.1"
   languageName: unknown
   linkType: soft
@@ -561,12 +555,10 @@ __metadata:
     "@data-story/core": "workspace:*"
     "@types/glob": "npm:^8.1.0"
     "@types/ws": "npm:^8.5.4"
-    axios: "npm:^1.3.4"
     csv-parse: "npm:^5.6.0"
     csv-stringify: "npm:^6.5.2"
     dotenv: "npm:^16.0.3"
     glob: "npm:^11.0.0"
-    openai: "npm:^3.2.1"
     ws: "npm:^8.12.1"
   bin:
     server: dist/server.js
@@ -586,7 +578,6 @@ __metadata:
     "@tailwindcss/typography": "npm:^0.5.10"
     "@tanstack/react-table": "npm:^8.11.7"
     "@tanstack/react-virtual": "npm:^3.5.0"
-    "@types/glob": "npm:^8.1.0"
     "@types/markdown-it": "npm:^13.0.6"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:*"
@@ -2588,19 +2579,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:18.14.2":
-  version: 18.14.2
-  resolution: "@types/node@npm:18.14.2"
-  checksum: 10/d1f335e776394cb4e665ff738c8c32cd420952f5b54fbb03e538c5d091ed49d872e5aa741c60d13c9f7e370b8fe0bdc87fad56bc3bc4a85b24681bcf4994b362
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:^18.14.2":
   version: 18.19.86
   resolution: "@types/node@npm:18.19.86"
   dependencies:
     undici-types: "npm:~5.26.4"
   checksum: 10/83e8f07305b102776c1970c2fbe2347eba15f6cca3d50cf8991d5f4e463ee7e204fbb3dec599892d25e613ed3b93f7fb5794b0de874ea6ba884affbe99670cc2
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^22.14.0":
+  version: 22.14.0
+  resolution: "@types/node@npm:22.14.0"
+  dependencies:
+    undici-types: "npm:~6.21.0"
+  checksum: 10/d0669a8a37a18532c886ccfa51eb3fe1e46088deb4d3d27ebcd5d7d68bd6343ad1c7a3fcb85164780a57629359c33a6c917ecff748ea232bceac7692acc96537
   languageName: node
   linkType: hard
 
@@ -3829,7 +3822,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"autoprefixer@npm:^10.4.13, autoprefixer@npm:^10.4.16, autoprefixer@npm:^10.4.20":
+"autoprefixer@npm:^10.4.13":
+  version: 10.4.21
+  resolution: "autoprefixer@npm:10.4.21"
+  dependencies:
+    browserslist: "npm:^4.24.4"
+    caniuse-lite: "npm:^1.0.30001702"
+    fraction.js: "npm:^4.3.7"
+    normalize-range: "npm:^0.1.2"
+    picocolors: "npm:^1.1.1"
+    postcss-value-parser: "npm:^4.2.0"
+  peerDependencies:
+    postcss: ^8.1.0
+  bin:
+    autoprefixer: bin/autoprefixer
+  checksum: 10/5d7aeee78ef362a6838e12312908516a8ac5364414175273e5cff83bbff67612755b93d567f3aa01ce318342df48aeab4b291847b5800c780e58c458f61a98a6
+  languageName: node
+  linkType: hard
+
+"autoprefixer@npm:^10.4.16, autoprefixer@npm:^10.4.20":
   version: 10.4.20
   resolution: "autoprefixer@npm:10.4.20"
   dependencies:
@@ -3870,16 +3881,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.26.0":
-  version: 0.26.1
-  resolution: "axios@npm:0.26.1"
-  dependencies:
-    follow-redirects: "npm:^1.14.8"
-  checksum: 10/02863f4a4fd4e43ad6e0c8bc9d1359a0863c43cc57bda42ea21dfce34681e3211df193b2bf2e8ee10b2c3870ab8d6bed38a3cf80cd6e8ee17749b7d73ccd4752
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.3.4, axios@npm:^1.7.7":
+"axios@npm:^1.7.7":
   version: 1.7.7
   resolution: "axios@npm:1.7.7"
   dependencies:
@@ -4073,6 +4075,20 @@ __metadata:
   bin:
     browserslist: cli.js
   checksum: 10/26c1b8ba257a0b51b102080ba9d42945af2abaa8c4cf6da21cd47b3f123fc1e81640203b293214356c2c17d9d265bb3a5ed428b6d302f383576dd6ce8fd5036c
+  languageName: node
+  linkType: hard
+
+"browserslist@npm:^4.24.4":
+  version: 4.24.4
+  resolution: "browserslist@npm:4.24.4"
+  dependencies:
+    caniuse-lite: "npm:^1.0.30001688"
+    electron-to-chromium: "npm:^1.5.73"
+    node-releases: "npm:^2.0.19"
+    update-browserslist-db: "npm:^1.1.1"
+  bin:
+    browserslist: cli.js
+  checksum: 10/11fda105e803d891311a21a1f962d83599319165faf471c2d70e045dff82a12128f5b50b1fcba665a2352ad66147aaa248a9d2355a80aadc3f53375eb3de2e48
   languageName: node
   linkType: hard
 
@@ -4276,6 +4292,13 @@ __metadata:
   version: 1.0.30001664
   resolution: "caniuse-lite@npm:1.0.30001664"
   checksum: 10/ff237f6bbb59564d2a7219fe9a799a59692403115500f7548a77f1f6b82e33fd136375003f80c8df88a64048f699f9f917292ca4cac0dd8a789d2d35fba6269b
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001702":
+  version: 1.0.30001713
+  resolution: "caniuse-lite@npm:1.0.30001713"
+  checksum: 10/0c1b97320d08cf87c73883fe9a7b9d8037b7c24aa027641e75cce3dee74c9ad538cf17725fdcb46e6ec86be8efedf6edd0848db07c5f8110936ccf0185e2ff68
   languageName: node
   linkType: hard
 
@@ -6008,6 +6031,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"electron-to-chromium@npm:^1.5.73":
+  version: 1.5.136
+  resolution: "electron-to-chromium@npm:1.5.136"
+  checksum: 10/bc1d5c2b7b231560c085d300d92a3ba4e4c751506dc9e0380bf8655d08af71372e935580bf687268f4dcc3cc37ab475cad70f462cd53e7b2f8d7c60f1985c0d3
+  languageName: node
+  linkType: hard
+
 "emoji-regex@npm:^10.2.1, emoji-regex@npm:^10.3.0":
   version: 10.4.0
   resolution: "emoji-regex@npm:10.4.0"
@@ -7149,7 +7179,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.14.8, follow-redirects@npm:^1.15.6":
+"follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.15.6":
   version: 1.15.9
   resolution: "follow-redirects@npm:1.15.9"
   peerDependenciesMeta:
@@ -11223,6 +11253,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-releases@npm:^2.0.19":
+  version: 2.0.19
+  resolution: "node-releases@npm:2.0.19"
+  checksum: 10/c2b33b4f0c40445aee56141f13ca692fa6805db88510e5bbb3baadb2da13e1293b738e638e15e4a8eb668bb9e97debb08e7a35409b477b5cc18f171d35a83045
+  languageName: node
+  linkType: hard
+
 "nopt@npm:^5.0.0":
   version: 5.0.0
   resolution: "nopt@npm:5.0.0"
@@ -11473,16 +11510,6 @@ __metadata:
     is-inside-container: "npm:^1.0.0"
     is-wsl: "npm:^3.1.0"
   checksum: 10/a9c4105243a1b3c5312bf2aeb678f78d31f00618b5100088ee01eed2769963ea1f2dd464ac8d93cef51bba2d911e1a9c0c34a753ec7b91d6b22795903ea6647a
-  languageName: node
-  linkType: hard
-
-"openai@npm:^3.2.1":
-  version: 3.3.0
-  resolution: "openai@npm:3.3.0"
-  dependencies:
-    axios: "npm:^0.26.0"
-    form-data: "npm:^4.0.0"
-  checksum: 10/613fb92552b68dbe915b98eb7d3c0a60a9cc6b6d109ff7ad8d05cca149b8511f2a2cd57fd990bea84bd5bc324e23a5401f635ad7b66976cb0bc6edcc32425ba9
   languageName: node
   linkType: hard
 
@@ -11957,6 +11984,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picocolors@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "picocolors@npm:1.1.1"
+  checksum: 10/e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
+  languageName: node
+  linkType: hard
+
 "picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
@@ -12354,7 +12388,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.21, postcss@npm:^8.4.23, postcss@npm:^8.4.31, postcss@npm:^8.4.33, postcss@npm:^8.4.43, postcss@npm:^8.4.47":
+"postcss@npm:^8.4.21, postcss@npm:^8.4.23, postcss@npm:^8.4.33, postcss@npm:^8.4.43, postcss@npm:^8.4.47":
   version: 8.4.47
   resolution: "postcss@npm:8.4.47"
   dependencies:
@@ -15005,6 +15039,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~6.21.0":
+  version: 6.21.0
+  resolution: "undici-types@npm:6.21.0"
+  checksum: 10/ec8f41aa4359d50f9b59fa61fe3efce3477cc681908c8f84354d8567bb3701fafdddf36ef6bff307024d3feb42c837cf6f670314ba37fc8145e219560e473d14
+  languageName: node
+  linkType: hard
+
 "unicorn-magic@npm:^0.1.0":
   version: 0.1.0
   resolution: "unicorn-magic@npm:0.1.0"
@@ -15248,6 +15289,20 @@ __metadata:
   bin:
     update-browserslist-db: cli.js
   checksum: 10/7678dd8609750588d01aa7460e8eddf2ff9d16c2a52fb1811190e0d056390f1fdffd94db3cf8fb209cf634ab4fa9407886338711c71cc6ccade5eeb22b093734
+  languageName: node
+  linkType: hard
+
+"update-browserslist-db@npm:^1.1.1":
+  version: 1.1.3
+  resolution: "update-browserslist-db@npm:1.1.3"
+  dependencies:
+    escalade: "npm:^3.2.0"
+    picocolors: "npm:^1.1.1"
+  peerDependencies:
+    browserslist: ">= 4.21.0"
+  bin:
+    update-browserslist-db: cli.js
+  checksum: 10/87af2776054ffb9194cf95e0201547d041f72ee44ce54b144da110e65ea7ca01379367407ba21de5c9edd52c74d95395366790de67f3eb4cc4afa0fe4424e76f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -501,16 +501,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@data-story/core@workspace:packages/core"
   dependencies:
-    "@types/node": "npm:18.14.2"
     axios: "npm:^1.3.4"
-    dotenv: "npm:^16.0.3"
     nanoid: "npm:3"
     rxjs: "npm:^7.8.1"
     vite: "npm:^5.0.10"
     vite-plugin-externalize-deps: "npm:^0.8.0"
-    webpack: "npm:^5.88.1"
-    webpack-cli: "npm:^5.1.4"
-    webpack-shebang-plugin: "npm:^1.1.8"
     zod: "npm:^3.24.1"
   peerDependencies:
     vitest: ^1.6.0
@@ -555,9 +550,6 @@ __metadata:
     axios: "npm:^1.3.4"
     dotenv: "npm:^16.0.3"
     openai: "npm:^3.2.1"
-    webpack: "npm:^5.88.1"
-    webpack-cli: "npm:^5.1.4"
-    webpack-shebang-plugin: "npm:^1.1.8"
     ws: "npm:^8.12.1"
   languageName: unknown
   linkType: soft
@@ -568,7 +560,6 @@ __metadata:
   dependencies:
     "@data-story/core": "workspace:*"
     "@types/glob": "npm:^8.1.0"
-    "@types/node": "npm:18.14.2"
     "@types/ws": "npm:^8.5.4"
     axios: "npm:^1.3.4"
     csv-parse: "npm:^5.6.0"
@@ -576,9 +567,6 @@ __metadata:
     dotenv: "npm:^16.0.3"
     glob: "npm:^11.0.0"
     openai: "npm:^3.2.1"
-    webpack: "npm:^5.88.1"
-    webpack-cli: "npm:^5.1.4"
-    webpack-shebang-plugin: "npm:^1.1.8"
     ws: "npm:^8.12.1"
   bin:
     server: dist/server.js
@@ -600,7 +588,6 @@ __metadata:
     "@tanstack/react-virtual": "npm:^3.5.0"
     "@types/glob": "npm:^8.1.0"
     "@types/markdown-it": "npm:^13.0.6"
-    "@types/node": "npm:18.14.2"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:*"
     "@types/ws": "npm:^8.5.4"
@@ -609,7 +596,6 @@ __metadata:
     ahooks: "npm:^3.7.10"
     allotment: "npm:^1.20.2"
     autoprefixer: "npm:^10.4.13"
-    axios: "npm:^1.3.4"
     clsx: "npm:^2.0.0"
     css-loader: "npm:^6.8.1"
     markdown-it: "npm:^13.0.2"
@@ -621,10 +607,6 @@ __metadata:
     rxjs: "npm:^7.8.1"
     style-loader: "npm:^3.3.3"
     tailwindcss: "npm:^3.2.7"
-    webpack: "npm:^5.88.1"
-    webpack-cli: "npm:^5.1.4"
-    ws: "npm:^8.12.1"
-    zod: "npm:^3.24.1"
     zustand: "npm:^4.3.9"
   peerDependencies:
     react: ^18.2.0
@@ -2613,12 +2595,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:20.x":
-  version: 20.16.10
-  resolution: "@types/node@npm:20.16.10"
+"@types/node@npm:^18.14.2":
+  version: 18.19.86
+  resolution: "@types/node@npm:18.19.86"
   dependencies:
-    undici-types: "npm:~6.19.2"
-  checksum: 10/f0832d16fed07737c2c3edd6cb6414a22e8379173e56e701ab8890b8798c8f9bc37337332631818f813ff7f8c0e168e9900e8f44cdfd2406d15150289c813acc
+    undici-types: "npm:~5.26.4"
+  checksum: 10/83e8f07305b102776c1970c2fbe2347eba15f6cca3d50cf8991d5f4e463ee7e204fbb3dec599892d25e613ed3b93f7fb5794b0de874ea6ba884affbe99670cc2
   languageName: node
   linkType: hard
 
@@ -2746,24 +2728,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 10/4d51cdbc170e72275efc5ef5fce48a81ec431e4edde8374f4d0213d8d370a06823e1a61ae31d502a5f1b0d1f48fc4d29a1b1b5c2dcf809d66d3872ccf6e46ac7
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/parser@npm:^8.3.0":
-  version: 8.7.0
-  resolution: "@typescript-eslint/parser@npm:8.7.0"
-  dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.7.0"
-    "@typescript-eslint/types": "npm:8.7.0"
-    "@typescript-eslint/typescript-estree": "npm:8.7.0"
-    "@typescript-eslint/visitor-keys": "npm:8.7.0"
-    debug: "npm:^4.3.4"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/896ac60f8426f9e5c23198c89555f6f88f7957c5b16bb7b966dac45c5f5e7076c1a050bcee2e0eddff88055b9c0d7bdfaef9c64889e3bdf3356d20356b0daa04
   languageName: node
   linkType: hard
 
@@ -5564,6 +5528,7 @@ __metadata:
   dependencies:
     "@stylistic/eslint-plugin": "npm:^0.1.2"
     "@types/mocha": "npm:^10.0.6"
+    "@types/node": "npm:^18.14.2"
     "@typescript-eslint/parser": "npm:^6.9.0"
     cypress: "npm:^13.6.1"
     eslint: "npm:^8.52.0"
@@ -5581,7 +5546,9 @@ __metadata:
     turbo: "npm:<1.11.0"
     typescript: "npm:5.6.2"
     vitest: "npm:^1.6.0"
+    webpack: "npm:^5.88.1"
     webpack-bundle-analyzer: "npm:^4.10.1"
+    webpack-cli: "npm:^5.1.4"
   languageName: unknown
   linkType: soft
 
@@ -5971,12 +5938,10 @@ __metadata:
     "@data-story/nodejs": "workspace:*"
     "@data-story/ui": "workspace:*"
     "@types/mocha": "npm:^10.0.7"
-    "@types/node": "npm:20.x"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"
     "@types/vscode": "npm:^1.80.0"
     "@typescript-eslint/eslint-plugin": "npm:^8.3.0"
-    "@typescript-eslint/parser": "npm:^8.3.0"
     "@vitejs/plugin-react": "npm:^4.3.1"
     "@vscode/test-cli": "npm:^0.0.10"
     "@vscode/test-electron": "npm:^2.4.1"
@@ -5988,10 +5953,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     rxjs: "npm:^7.8.1"
-    ts-loader: "npm:^9.5.1"
     vite: "npm:^5.4.7"
-    webpack: "npm:^5.94.0"
-    webpack-cli: "npm:^5.1.4"
   languageName: unknown
   linkType: soft
 
@@ -15029,6 +14991,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 10/0097779d94bc0fd26f0418b3a05472410408877279141ded2bd449167be1aed7ea5b76f756562cb3586a07f251b90799bab22d9019ceba49c037c76445f7cddd
+  languageName: node
+  linkType: hard
+
 "undici-types@npm:~6.19.2":
   version: 6.19.8
   resolution: "undici-types@npm:6.19.8"
@@ -15748,13 +15717,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-shebang-plugin@npm:^1.1.8":
-  version: 1.1.8
-  resolution: "webpack-shebang-plugin@npm:1.1.8"
-  checksum: 10/1fb1863d44daef6565717b394bdd537b8cd574b9991be14b2a9a13d0c920f19f0a923ffeb42f8aa796049e032dac710d0ad063dc1cab3eab213fb7b22e8136ff
-  languageName: node
-  linkType: hard
-
 "webpack-sources@npm:^3.2.3":
   version: 3.2.3
   resolution: "webpack-sources@npm:3.2.3"
@@ -15762,7 +15724,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:^5.88.1, webpack@npm:^5.94.0":
+"webpack@npm:^5.88.1":
   version: 5.95.0
   resolution: "webpack@npm:5.95.0"
   dependencies:


### PR DESCRIPTION
- refactor: move commonly used devDependencies into the root package.json.

- refactor: remove unnecessary dependencies from each package.json.

- fix: correct the misuse of devDependencies and dependencies

- feat: upgrade @xyflow/react from version 12.0.2 to 12.5.5

todo:
- Use audit to assess dependency risks. Upgrade dependencies that are either risky or outdated.

- Use webpack-bundle-analyzer to check package sizes and confirm if we need to optimize any overly large dependencies.

- Ensure the dependencies not managed in the root package.json have consistent versions.  For instance, both nodejs and core are using nanoid. We can leverage Yarn Berry's constraints feature to maintain a common version of nanoid across these two different packages.