### PR TITLE
feat: set input.pull batch limit to 20000

### DIFF
--- a/packages/core/src/InputDevice.ts
+++ b/packages/core/src/InputDevice.ts
@@ -21,7 +21,7 @@ export class InputDevice {
   /**
    * Shorthand to pull items at 'input'
    */
-  pull(count: number = 20000) {
+  pull(count?: number) {
     return this.pullFrom('input', count)
   }
 

--- a/packages/core/src/InputDevice.ts
+++ b/packages/core/src/InputDevice.ts
@@ -21,7 +21,7 @@ export class InputDevice {
   /**
    * Shorthand to pull items at 'input'
    */
-  pull(count?: number) {
+  pull(count: number = 20000) {
     return this.pullFrom('input', count)
   }
 

--- a/packages/core/src/InputDevice.ts
+++ b/packages/core/src/InputDevice.ts
@@ -37,7 +37,7 @@ export class InputDevice {
       const batch = this.memory.pullLinkItems(link.id, remaining)
 
       if(batch.length < 1000) {
-        pulled.push.apply(pulled, batch)
+        pulled.push(...batch)
       } else {
         for(const item of batch) pulled.push(item)
       }

--- a/packages/core/src/ItemWithParams/JSTransform.ts
+++ b/packages/core/src/ItemWithParams/JSTransform.ts
@@ -1,0 +1,17 @@
+const functionCache = new Map<string, WeakRef<Function>>();
+export const createJSTransformFunction = (code: string) => {
+  const cachedFn = functionCache.get(code)?.deref();
+  if (cachedFn) return cachedFn;
+
+  const fn = new Function('item', `return (${code})(item)`);
+  functionCache.set(code, new WeakRef(fn));
+  return fn;
+};
+const expressionCache = new Map<string, WeakRef<Function>>();
+export const createJSTransformExpression = (code: string) => {
+  const cachedFn = expressionCache.get(code)?.deref();
+  if (cachedFn) return cachedFn;
+  const fn = new Function(`return ${code}`);
+  expressionCache.set(code, new WeakRef(fn));
+  return fn();
+};

--- a/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
+++ b/packages/core/src/ItemWithParams/StringableParamEvaluator.ts
@@ -92,7 +92,7 @@ export class StringableParamEvaluator implements ParamsValueEvaluator<Stringable
     }
 
     if (selectedEvaluation?.type === 'JS_FUNCTION') {
-      const fn = eval(transformedValue);
+      const fn = createJSTransformFunction(transformedValue);
       transformedValue = fn(itemValue);
     }
 
@@ -129,3 +129,13 @@ export class StringableParamEvaluator implements ParamsValueEvaluator<Stringable
     return param.type === this.type;
   }
 }
+
+const functionCache = new Map<string, WeakRef<Function>>();
+const createJSTransformFunction = (code: string) => {
+  const cachedFn = functionCache.get(code)?.deref();
+  if (cachedFn) return cachedFn;
+
+  const fn = new Function('item', `return (${code})(item)`);
+  functionCache.set(code, new WeakRef(fn));
+  return fn;
+};

--- a/packages/core/src/computers/Anonymize.ts
+++ b/packages/core/src/computers/Anonymize.ts
@@ -1,6 +1,7 @@
 import { ItemValue } from '../types/ItemValue';
 import { Computer } from '../types/Computer';
 import { anonymize } from '../utils/anonymize';
+import { BatchLimit } from '../utils/batchLimit';
 
 export const Anonymize: Computer = {
   name: 'Anonymize',
@@ -17,7 +18,7 @@ export const Anonymize: Computer = {
 
   async *run({ input, output, params }) {
     while(true) {
-      const incoming = input.pull()
+      const incoming = input.pull(BatchLimit)
 
       const replacers = incoming.map(item => anonymize(item.value)) as ItemValue[]
 

--- a/packages/core/src/computers/Await.ts
+++ b/packages/core/src/computers/Await.ts
@@ -49,6 +49,7 @@ export const Await: Computer = {
     let hasPulledAny = false
 
     while(true) {
+      // not set the batch limit, because the param has number_of_items
       const incoming = input.pull()
 
       const pulledCount = incoming.length

--- a/packages/core/src/computers/Clone.ts
+++ b/packages/core/src/computers/Clone.ts
@@ -1,6 +1,7 @@
 import { num } from '../Param';
 import { Computer } from '../types/Computer';
 import { ItemValue } from '../types/ItemValue';
+import { BatchLimit } from '../utils/batchLimit';
 
 export const Clone: Computer = {
   name: 'Clone',
@@ -31,7 +32,7 @@ export const Clone: Computer = {
 
   async *run({ input, output, params }) {
     while (true) {
-      const incoming = input.pull();
+      const incoming = input.pull(BatchLimit);
       output.pushTo('original', incoming);
 
       const count = Number(params.count);

--- a/packages/core/src/computers/FlatMap.ts
+++ b/packages/core/src/computers/FlatMap.ts
@@ -1,5 +1,6 @@
 import { json_ } from '../Param';
 import { Computer } from '../types/Computer';
+import { BatchLimit } from '../utils/batchLimit';
 
 export const FlatMap: Computer = {
   name: 'FlatMap',
@@ -22,7 +23,7 @@ export const FlatMap: Computer = {
 
   async *run({ input, output, params }) {
     while(true) {
-      const incoming = input.pull()
+      const incoming = input.pull(BatchLimit)
 
       const replacers = incoming.flatMap(item => {
         return item.params.json as Object;

--- a/packages/core/src/computers/If.ts
+++ b/packages/core/src/computers/If.ts
@@ -1,6 +1,7 @@
 import { jsFn } from '../Param';
 import { multiline } from '../utils/multiline';
 import { Computer } from '../types/Computer';
+import { BatchLimit } from '../utils/batchLimit';
 
 export const If: Computer = {
   name: 'If',
@@ -31,7 +32,7 @@ export const If: Computer = {
 
   async *run({ input, output, params }) {
     while(true) {
-      const items = input.pull()
+      const items = input.pull(BatchLimit)
 
       for (const item of items) {
         output.pushTo(

--- a/packages/core/src/computers/Ignore.ts
+++ b/packages/core/src/computers/Ignore.ts
@@ -1,4 +1,5 @@
 import { Computer } from '../types/Computer';
+import { BatchLimit } from '../utils/batchLimit';
 
 export const Ignore: Computer = {
   name: 'Ignore',
@@ -12,7 +13,7 @@ export const Ignore: Computer = {
 
   async *run({ input }) {
     while(true) {
-      input.pull()
+      input.pull(BatchLimit)
       yield;
     }
   },

--- a/packages/core/src/computers/Log.ts
+++ b/packages/core/src/computers/Log.ts
@@ -1,4 +1,5 @@
 import { Computer } from '../types/Computer';
+import { BatchLimit } from '../utils/batchLimit';
 
 export const Log: Computer = {
   name: 'Log',
@@ -13,7 +14,7 @@ export const Log: Computer = {
   async *run({ input, output }) {
     while(true) {
       // log the *item* - not ItemWithParams
-      const incoming = input.pull().map(i => i.value)
+      const incoming = input.pull(BatchLimit).map(i => i.value)
       console.log(JSON.stringify(incoming, null, 2))
 
       yield;

--- a/packages/core/src/computers/MakeSet.ts
+++ b/packages/core/src/computers/MakeSet.ts
@@ -1,5 +1,6 @@
 import { str } from '../Param';
 import { Computer } from '../types/Computer';
+import { BatchLimit } from '../utils/batchLimit';
 
 export const MakeSet: Computer = {
   name: 'MakeSet',
@@ -26,7 +27,7 @@ export const MakeSet: Computer = {
     const seen = new Set();
 
     while (true) {
-      const items = input.pull();
+      const items = input.pull(BatchLimit);
 
       for (let item of items) {
         const property = params.property as string;

--- a/packages/core/src/computers/Map.ts
+++ b/packages/core/src/computers/Map.ts
@@ -18,15 +18,18 @@ export const Map: Computer = {
     jsFn({
       name: 'mapper',
       value: multiline`
-        item => Object.assign({}, item)
+        item => ({
+          ...item
+        })
       `,
       help: '',
     }),
   ],
 
   async *run({ input, output, params }) {
+    const mapTestingBatchLimit = 20000;
     while(true) {
-      const incoming = input.pull()
+      const incoming = input.pull(mapTestingBatchLimit)
       const replacers = incoming.map(item => item.params.mapper) as ItemValue[]
       output.push(replacers)
 

--- a/packages/core/src/computers/Map.ts
+++ b/packages/core/src/computers/Map.ts
@@ -2,6 +2,7 @@ import { jsFn } from '../Param';
 import { ItemValue } from '../types/ItemValue';
 import { multiline } from '../utils/multiline';
 import { Computer } from '../types/Computer';
+import { BatchLimit } from '../utils/batchLimit';
 
 export const Map: Computer = {
   name: 'Map',
@@ -27,9 +28,8 @@ export const Map: Computer = {
   ],
 
   async *run({ input, output, params }) {
-    const mapTestingBatchLimit = 20000;
     while(true) {
-      const incoming = input.pull(mapTestingBatchLimit)
+      const incoming = input.pull(BatchLimit)
       const replacers = incoming.map(item => item.params.mapper) as ItemValue[]
       output.push(replacers)
 

--- a/packages/core/src/computers/Map.ts
+++ b/packages/core/src/computers/Map.ts
@@ -18,9 +18,7 @@ export const Map: Computer = {
     jsFn({
       name: 'mapper',
       value: multiline`
-        item => ({
-          ...item
-        })
+        item => Object.assign({}, item)
       `,
       help: '',
     }),

--- a/packages/core/src/computers/Map.ts
+++ b/packages/core/src/computers/Map.ts
@@ -27,9 +27,7 @@ export const Map: Computer = {
   async *run({ input, output, params }) {
     while(true) {
       const incoming = input.pull()
-
       const replacers = incoming.map(item => item.params.mapper) as ItemValue[]
-
       output.push(replacers)
 
       yield;

--- a/packages/core/src/computers/Output.ts
+++ b/packages/core/src/computers/Output.ts
@@ -1,5 +1,6 @@
 import { createDefaultStringable, str } from '../Param';
 import { Computer } from '../types/Computer';
+import { BatchLimit } from '../utils/batchLimit';
 
 export const Output: Computer = {
   name: 'Output',
@@ -28,7 +29,7 @@ export const Output: Computer = {
       const [ portName, ...other ] = output.getPortNames()
       if (!portName || other.length > 0) throw new Error('Output computer must have exactly one output port.')
 
-      const incoming = input.pull()
+      const incoming = input.pull(BatchLimit)
 
       output.pushTo(portName, incoming)
 

--- a/packages/core/src/computers/Pass.ts
+++ b/packages/core/src/computers/Pass.ts
@@ -1,4 +1,5 @@
 import { Computer } from '../types/Computer';
+import { BatchLimit } from '../utils/batchLimit';
 
 export const Pass: Computer = {
   name: 'Pass',
@@ -15,7 +16,7 @@ export const Pass: Computer = {
 
   async *run({ input, output }) {
     while(true) {
-      const incoming = input.pull()
+      const incoming = input.pull(BatchLimit)
       output.push(incoming)
 
       yield;

--- a/packages/core/src/computers/RemoveProperties.ts
+++ b/packages/core/src/computers/RemoveProperties.ts
@@ -1,6 +1,7 @@
 import { str } from '../Param';
 import { ItemWithParams } from '../ItemWithParams';
 import { Computer } from '../types/Computer';
+import { BatchLimit } from '../utils/batchLimit';
 
 export const RemoveProperties: Computer = {
   name: 'RemoveProperties',
@@ -31,7 +32,7 @@ export const RemoveProperties: Computer = {
   ],
 
   async* run({ input, output, params }) {
-    const items = input.pull();
+    const items = input.pull(BatchLimit);
     const param = (params.remove_properties ?? []) as unknown as {
       property: string,
     }[];

--- a/packages/core/src/computers/Table.ts
+++ b/packages/core/src/computers/Table.ts
@@ -1,5 +1,6 @@
 import { num, str, strList } from '../Param';
 import { Computer } from '../types/Computer';
+import { BatchLimit } from '../utils/batchLimit';
 
 export const Table: Computer = {
   name: 'Table',
@@ -29,7 +30,7 @@ export const Table: Computer = {
 
   async* run({ input }) {
     while(true) {
-      input.pull()
+      input.pull(BatchLimit)
       yield;
     }
   },

--- a/packages/core/src/utils/batchLimit.ts
+++ b/packages/core/src/utils/batchLimit.ts
@@ -1,0 +1,2 @@
+// After testing, we've set the maximum testing batch limit in the `input.pull()` parameter to 20,000 for enhanced safety.
+export const BatchLimit = 20000;

--- a/packages/ui/src/components/Node/table/UseObserverTable.tsx
+++ b/packages/ui/src/components/Node/table/UseObserverTable.tsx
@@ -4,7 +4,6 @@ import { createDataStoryId, ItemValue, ObserveLinkUpdate, RequestObserverType } 
 import { useLatest } from 'ahooks';
 import { shallow } from 'zustand/shallow';
 import { MutableRefObject, useEffect, useLayoutEffect, useRef } from 'react';
-import { Subscription } from 'rxjs';
 
 const initialScreenCount: number = 15;
 const tableThrottleMs: number = 100;

--- a/packages/ui/src/components/Node/table/UseObserverTable.tsx
+++ b/packages/ui/src/components/Node/table/UseObserverTable.tsx
@@ -77,8 +77,6 @@ export function useObserverTable({ id, setIsDataFetched, setItems, items, parent
   useEffect(() => {
     if (!client?.observeLinkUpdate || !linkIds) return;
 
-    let subscription: Subscription | undefined;
-
     const tableUpdate: ObserveLinkUpdate = {
       observerId: createDataStoryId(),
       linkIds: linkIds,
@@ -88,7 +86,6 @@ export function useObserverTable({ id, setIsDataFetched, setItems, items, parent
       onReceive: (linkIds) => {
         // If we have enough initial items, attempt unsubscribe
         if (itemsRef.current.length >= initialScreenCount) {
-          subscription?.unsubscribe();
           return;
         }
 
@@ -96,7 +93,7 @@ export function useObserverTable({ id, setIsDataFetched, setItems, items, parent
         loadMore.current();
       },
     }
-    subscription = client?.observeLinkUpdate?.(tableUpdate);
+    const subscription = client?.observeLinkUpdate?.(tableUpdate);
     return () => {
       subscription?.unsubscribe();
     };


### PR DESCRIPTION
- feat: set `input.pull` batch limit to 20000

- feat: replace eval with createJSTransformFunction/createJSTransformExpression to enhance performance for large datasets [link](https://jsbenchmark.com/#eyJjYXNlcyI6W3siaWQiOiJIRDVyWmZLVEdJeWpWNVotaGdDc2MiLCJjb2RlIjoiZXZhbCgnaXRlbSA9PiBPYmplY3QuYXNzaWduKHt9LCBpdGVtKScpKHtCOiAyLCBDOiAzLCBhOiAxfSk7IiwibmFtZSI6ImV2YWwiLCJkZXBlbmRlbmNpZXMiOltdfSx7ImlkIjoiSVFmN2JadlJIOFhLdG1RVEtaQmtEIiwiY29kZSI6IkRBVEEoJ2l0ZW0gPT4gT2JqZWN0LmFzc2lnbih7fSwgaXRlbSknKSh7QjogMiwgQzogMyxhOjF9KSIsIm5hbWUiOiJuZXcgRnVuY3Rpb24iLCJkZXBlbmRlbmNpZXMiOltdfV0sImNvbmZpZyI6eyJuYW1lIjoiQmFzaWMgZXhhbXBsZSIsInBhcmFsbGVsIjp0cnVlLCJnbG9iYWxUZXN0Q29uZmlnIjp7ImRlcGVuZGVuY2llcyI6W119LCJkYXRhQ29kZSI6ImNvbnN0IGZ1bmN0aW9uQ2FjaGUgPSBuZXcgTWFwPHN0cmluZywgV2Vha1JlZjxGdW5jdGlvbj4-KCk7XG5jb25zdCBjcmVhdGVKU1RyYW5zZm9ybUZ1bmN0aW9uID0gKGNvZGU6IHN0cmluZykgPT4ge1xuICBjb25zdCBjYWNoZWRGbiA9IGZ1bmN0aW9uQ2FjaGUuZ2V0KGNvZGUpPy5kZXJlZigpO1xuICBpZiAoY2FjaGVkRm4pIHJldHVybiBjYWNoZWRGbjtcblxuICBjb25zdCBmbiA9IG5ldyBGdW5jdGlvbignaXRlbScsIGByZXR1cm4gKCR7Y29kZX0pKGl0ZW0pYCk7XG4gIGZ1bmN0aW9uQ2FjaGUuc2V0KGNvZGUsIG5ldyBXZWFrUmVmKGZuKSk7XG4gIHJldHVybiBmbjtcbn07XG5yZXR1cm4gY3JlYXRlSlNUcmFuc2Zvcm1GdW5jdGlvbjsifX0)

- fix: resolve issue where the table Node fails to load data except on the first run

before：

https://github.com/user-attachments/assets/40053208-f35b-4047-aeac-212881e202a5

after:

https://github.com/user-attachments/assets/874709dd-c45d-4c46-8c8b-5f5cedaf19be
