### PR TITLE
fix: stop the event from bubbling up to the VSCode iframe event handler

### DIFF
--- a/packages/ds-ext/src/app/DiagramApp.tsx
+++ b/packages/ds-ext/src/app/DiagramApp.tsx
@@ -14,8 +14,14 @@ export default function DiagramApp() {
     }, 100), // Debounced with 100ms delay
     [client]);
 
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    // Stop the event from bubbling up to the VSCode iframe event handler
+    e.stopPropagation();
+  }, []);
+
   return (
-    <div style={{ width: '100%', height: '100vh' }}>
+    <div onKeyDown={handleKeyDown}
+      style={{ width: '100%', height: '100vh' }}>
       <DataStory
         client={client}
         hideSidebar={false}
@@ -24,7 +30,7 @@ export default function DiagramApp() {
         key={'abc'}
         onChange={handleChange}
         onDrop={onDrop}
-        controls={[<RunControl/>, <AddNodeControl/>, <CopyAsJsonControl/>]}
+        controls={[<RunControl />, <AddNodeControl />, <CopyAsJsonControl />]}
       />
       <VsCodeToast postMessage={window.vscode.postMessage} />
     </div>

--- a/packages/ds-ext/src/app/DiagramApp.tsx
+++ b/packages/ds-ext/src/app/DiagramApp.tsx
@@ -14,14 +14,8 @@ export default function DiagramApp() {
     }, 100), // Debounced with 100ms delay
     [client]);
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    // Stop the event from bubbling up to the VSCode iframe event handler
-    e.stopPropagation();
-  }, []);
-
   return (
-    <div onKeyDown={handleKeyDown}
-      style={{ width: '100%', height: '100vh' }}>
+    <div style={{ width: '100%', height: '100vh' }}>
       <DataStory
         client={client}
         hideSidebar={false}

--- a/packages/ui/src/components/DataStory/Form/StringListInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/StringListInput.tsx
@@ -25,7 +25,12 @@ function StringListInputComponent({
     setValue(value);
   }, [setValue]);
 
-  return (<div className="group flex flex-col-reverse bg-gray-50 h-full border-gray-50 border-2">
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    // Stop the event from bubbling up to the VSCode iframe event handler
+    e.stopPropagation();
+  }, []);
+
+  return (<div onKeyDown={handleKeyDown} className="group flex flex-col-reverse bg-gray-50 h-full border-gray-50 border-2">
     <div className="flex w-full text-gray-500 max-h-64 overflow-y-auto">
       <CodeMirror
         className="text-xs h-full w-full bg-white font-mono"

--- a/packages/ui/src/components/DataStory/Form/StringableInput.tsx
+++ b/packages/ui/src/components/DataStory/Form/StringableInput.tsx
@@ -62,8 +62,13 @@ export function StringableInputComponent({
     setValue(value);
   }, [setValue]);
 
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    // Stop the event from bubbling up to the VSCode iframe event handler
+    e.stopPropagation();
+  }, []);
+
   return (
-    <div className="flex w-full text-gray-500 max-h-64 overflow-y-auto">
+    <div onKeyDown={handleKeyDown} className="flex w-full text-gray-500 max-h-64 overflow-y-auto">
       <CodeMirror
         className="text-xs h-full w-full bg-white font-mono"
         value={(getValues() ?? '').toString()}

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,13 @@
 ## DataStory :dizzy:
 
-![tests](https://github.com/ajthinking/data-story/actions/workflows/test.yml/badge.svg)
+[![tests](https://github.com/ajthinking/data-story/actions/workflows/test.yml/badge.svg)](https://github.com/ajthinking/data-story/actions/workflows/test.yml)
 ![status](https://img.shields.io/badge/status-unstable-yellow)
-![npm version](https://img.shields.io/npm/v/@data-story/core?label=core&color=green)
-![npm version](https://img.shields.io/npm/v/@data-story/ui?label=ui&color=green)
-![npm version](https://img.shields.io/npm/v/@data-story/nodejs?label=nodejs&color=green)
-![vs code extension](https://vsmarketplacebadges.dev/version/ajthinking.ds-ext.svg)
+[![npm version](https://img.shields.io/npm/v/@data-story/core?label=core&color=green)](https://www.npmjs.com/package/@data-story/core)
+[![npm version](https://img.shields.io/npm/v/@data-story/ui?label=ui&color=green)](https://www.npmjs.com/package/@data-story/ui)
+[![npm version](https://img.shields.io/npm/v/@data-story/nodejs?label=nodejs&color=green)](https://www.npmjs.com/package/@data-story/nodejs)
+[![vs code extension](https://vsmarketplacebadges.dev/version/ajthinking.ds-ext.svg)](https://marketplace.visualstudio.com/items?itemName=ajthinking.ds-ext)
+[![MIT](https://img.shields.io/badge/license-MIT-blue)](https://opensource.org/license/mit)
+
 
 🛠️ Real-time, observable, [Flow-based programming](http://en.wikipedia.org/wiki/Flow-based_programming) for React, Node.js and VS Code. <a href="https://datastory.dev" target="_blank">Docs</a>
 | <a href="https://datastory.dev/playground" target="_blank">Playground</a>
@@ -49,6 +51,3 @@ yarn cy:open
 
 # test on ci, only run @data-story/ui,  @data-story/core and e2e tests
 ````
-
-## License
-[MIT](https://opensource.org/license/mit)


### PR DESCRIPTION
The global event handler listening in the VSCode iframe causes the CodeMirror-based component to not respond to common shortcuts like Ctrl + C/V.

![image](https://github.com/user-attachments/assets/bcb8d532-3e5e-451f-b15f-ac07f7376e61)


https://github.com/user-attachments/assets/cd29dee1-ad08-4288-aae5-0b4cf4f9c06e


[fix: update badge links and add license badge in README.md](https://github.com/ajthinking/data-story/pull/423/commits/c9b5a3d3b44b971b8ac5837ac660cd4851400b93)

https://github.com/user-attachments/assets/7bc2d26b-78de-4fe2-b36f-42029f1df575

