### PR TITLE
Deprecate createDefaultStringable

### DIFF
--- a/packages/core/src/InputDevice.test.ts
+++ b/packages/core/src/InputDevice.test.ts
@@ -1,7 +1,7 @@
 import { Diagram } from './Diagram'
 import { ExecutionMemory } from './ExecutionMemory'
 import { InputDevice } from './InputDevice'
-import { createDefaultStringable } from './Param'
+import { str } from './Param'
 import { UnfoldedDiagramFactory } from './UnfoldedDiagramFactory'
 import { Node } from './types/Node'
 
@@ -222,7 +222,7 @@ describe('params', () => {
       name: 'node-type',
       inputs: [{ id: 'target-input-id', name: 'input', schema: {} }],
       outputs: [],
-      params: [createDefaultStringable({
+      params: [str({
         name: 'greeting',
         label: 'Greeting',
         help: 'The greeting to use',

--- a/packages/core/src/Param/Param.ts
+++ b/packages/core/src/Param/Param.ts
@@ -54,61 +54,6 @@ export type Param =
 
 export type ParamValue = Param['input']
 
-type StringableConfigType = Omit<StringableParam, 'input' | 'type'> & {
-  value: StringableInputValue['rawValue']
-}
-
-export const strList = ({
-  name,
-  label,
-  help,
-  value,
-}: {
-  name: string,
-  label?: string,
-  help?: string,
-  value?: unknown,
-}): StringListParam => {
-  return {
-    name,
-    type: 'StringListParam',
-    label: label ?? name,
-    help: help ?? '',
-    input: {
-      rawValue: value ?? undefined,
-    },
-  }
-}
-
-export const createDefaultStringable = ({
-  name,
-  label,
-  help,
-  multiline,
-  canInterpolate,
-  interpolate,
-  evaluations,
-  casts,
-  interpolationsFromPort,
-  value,
-}:StringableConfigType): StringableParam => {
-  return {
-    name,
-    type: 'StringableParam',
-    label,
-    help,
-    multiline,
-    canInterpolate,
-    interpolate,
-    evaluations,
-    casts,
-    interpolationsFromPort,
-    input: {
-      rawValue: value ?? '',
-    },
-  }
-}
-
 export const str = ({
   name,
   label,

--- a/packages/core/src/computers/Comment.ts
+++ b/packages/core/src/computers/Comment.ts
@@ -1,5 +1,5 @@
 import { multiline } from '../utils/multiline';
-import { createDefaultStringable } from '../Param';
+import { str } from '../Param';
 import { Computer } from '../types/Computer';
 
 export const Comment: Computer = {
@@ -8,7 +8,7 @@ export const Comment: Computer = {
   inputs: [],
   outputs: [],
   params: [
-    createDefaultStringable( {
+    str( {
       name: 'content',
       label: 'Content',
       help: 'Markdown content',
@@ -16,7 +16,6 @@ export const Comment: Computer = {
       canInterpolate: false,
       interpolate: false,
       evaluations: [],
-      casts: [],
       value: multiline`
         ### Comment
         paragraph

--- a/packages/core/src/computers/ConsoleLog.ts
+++ b/packages/core/src/computers/ConsoleLog.ts
@@ -2,7 +2,7 @@ import { numberCast } from '../Param/casts/numberCast';
 import { stringCast } from '../Param/casts/stringCast';
 import { jsFunctionEvaluation } from '../Param/evaluations/jsFunctionEvaluation';
 import { jsonEvaluation } from '../Param/evaluations/jsonEvaluation';
-import { createDefaultStringable } from '../Param';
+import { str } from '../Param';
 import { Computer } from '../types/Computer';
 
 export const ConsoleLog: Computer = {
@@ -16,7 +16,7 @@ export const ConsoleLog: Computer = {
   ],
   outputs: [],
   params: [
-    createDefaultStringable( {
+    str( {
       name: 'message',
       label: 'message',
       help: 'What to log. Leave blank to log the whole item.',
@@ -26,10 +26,6 @@ export const ConsoleLog: Computer = {
       evaluations: [
         jsFunctionEvaluation,
         jsonEvaluation,
-      ],
-      casts: [
-        numberCast,
-        stringCast,
       ],
       value: '',
     }),

--- a/packages/core/src/computers/Input.ts
+++ b/packages/core/src/computers/Input.ts
@@ -1,4 +1,4 @@
-import { createDefaultStringable, str } from '../Param';
+import { str } from '../Param';
 import { Computer } from '../types/Computer';
 
 export const Input: Computer = {
@@ -13,7 +13,7 @@ export const Input: Computer = {
     schema: {},
   }],
   params: [
-    createDefaultStringable({
+    str({
       name: 'port_name',
       label: 'Port Name',
       value: 'input',

--- a/packages/core/src/computers/Output.ts
+++ b/packages/core/src/computers/Output.ts
@@ -1,4 +1,4 @@
-import { createDefaultStringable, str } from '../Param';
+import { str } from '../Param';
 import { Computer } from '../types/Computer';
 import { BatchLimit } from '../utils/batchLimit';
 
@@ -14,7 +14,7 @@ export const Output: Computer = {
     schema: {},
   }],
   params: [
-    createDefaultStringable({
+    str({
       name: 'port_name',
       label: 'Port Name',
       value: 'output',

--- a/packages/core/src/computers/Sleep.ts
+++ b/packages/core/src/computers/Sleep.ts
@@ -1,6 +1,5 @@
 import { sleep } from '../utils/sleep';
-import { numberCast } from '../Param/casts/numberCast';
-import { createDefaultStringable } from '../Param';
+import { num } from '../Param';
 import { Computer } from '../types/Computer';
 
 export const Sleep: Computer = {
@@ -15,17 +14,14 @@ export const Sleep: Computer = {
     schema: {},
   }],
   params: [
-    createDefaultStringable({
+    num({
       name: 'duration',
       label: 'Duration',
       help: 'How many ms to sleep?',
       multiline: false,
       canInterpolate: true,
       interpolate: true,
-      casts: [
-        { ...numberCast, selected: true },
-      ],
-      value: String(100),
+      value: 100,
     }),
   ],
 

--- a/packages/core/src/computers/Table.ts
+++ b/packages/core/src/computers/Table.ts
@@ -1,4 +1,4 @@
-import { num, str, strList } from '../Param';
+import { str } from '../Param';
 import { Computer } from '../types/Computer';
 import { BatchLimit } from '../utils/batchLimit';
 

--- a/packages/core/src/computers/Throw.ts
+++ b/packages/core/src/computers/Throw.ts
@@ -3,7 +3,7 @@ import { numberCast } from '../Param/casts/numberCast';
 import { stringCast } from '../Param/casts/stringCast';
 import { jsFunctionEvaluation } from '../Param/evaluations/jsFunctionEvaluation';
 import { jsonEvaluation } from '../Param/evaluations/jsonEvaluation';
-import { createDefaultStringable } from '../Param';
+import { str } from '../Param';
 import { Computer } from '../types/Computer';
 
 export const Throw: Computer = {
@@ -15,7 +15,7 @@ export const Throw: Computer = {
   }],
   outputs: [],
   params: [
-    createDefaultStringable({
+    str({
       name: 'message',
       label: 'message',
       help: 'What to throw',
@@ -25,10 +25,6 @@ export const Throw: Computer = {
       evaluations: [
         jsFunctionEvaluation,
         jsonEvaluation,
-      ],
-      casts: [
-        numberCast,
-        stringCast,
       ],
       value: 'Some error',
     }),

--- a/packages/nodejs/src/computers/ListFiles/ListFiles.ts
+++ b/packages/nodejs/src/computers/ListFiles/ListFiles.ts
@@ -1,4 +1,4 @@
-import { Computer, createDefaultStringable } from '@data-story/core';
+import { Computer, str } from '@data-story/core';
 import { promises as fs } from 'fs'
 import * as nodePath from 'path'
 
@@ -19,7 +19,7 @@ export const ListFiles: Computer = {
     },
   }],
   params: [
-    createDefaultStringable({
+    str({
       name: 'path',
       label: 'Path',
       help: 'Dir to list',
@@ -27,7 +27,6 @@ export const ListFiles: Computer = {
       canInterpolate: false,
       interpolate: false,
       evaluations: [],
-      casts: [],
       value: '/',
     }),
   ],

--- a/packages/nodejs/src/computers/ReadFiles/ReadFiles.ts
+++ b/packages/nodejs/src/computers/ReadFiles/ReadFiles.ts
@@ -1,6 +1,6 @@
 import * as glob from 'glob';
 import { promises as fs } from 'fs';
-import { Computer, createDefaultStringable } from '@data-story/core';
+import { Computer, str } from '@data-story/core';
 
 export const ReadFiles: Computer = {
   name: 'ReadFiles',
@@ -18,7 +18,7 @@ export const ReadFiles: Computer = {
     },
   }],
   params: [
-    createDefaultStringable({
+    str({
       name: 'include',
       label: 'Include',
       help: 'Glob pattern to include',
@@ -26,10 +26,9 @@ export const ReadFiles: Computer = {
       canInterpolate: true,
       interpolate: true,
       evaluations: [],
-      casts: [],
       value: '${path}/**/*.ts',
     }),
-    createDefaultStringable(    {
+    str({
       name: 'ignore',
       label: 'Ignore',
       help: 'Glob pattern to ignore',
@@ -37,10 +36,8 @@ export const ReadFiles: Computer = {
       canInterpolate: true,
       interpolate: true,
       evaluations: [],
-      casts: [],
       value: '**/node_modules/**',
-    },
-    ),
+    }),
   ],
 
   async *run({ input, output }) {

--- a/packages/ui/src/components/DataStory/modals/runModal/DefineMode.tsx
+++ b/packages/ui/src/components/DataStory/modals/runModal/DefineMode.tsx
@@ -1,7 +1,7 @@
-import { createDefaultStringable } from '@data-story/core';
+import { str } from '@data-story/core';
 
 const DefineMode = ({ params, setParams, setDefineMode }) => {
-  const sampleParam = createDefaultStringable({
+  const sampleParam = str({
     name: 'sampleParam',
     label: 'sampleParam',
     help: '',
@@ -9,7 +9,6 @@ const DefineMode = ({ params, setParams, setDefineMode }) => {
     canInterpolate: true,
     interpolate: true,
     evaluations: [],
-    casts: [],
     value: 'default value',
   })
 


### PR DESCRIPTION
Deprecates `createDefaultStringable` as it is virtually the same as `str` param helper