### PR TITLE
Allow SHIFT+R to control RunControl icon

### DIFF
--- a/packages/ui/src/components/DataStory/controls/useRunControl.ts
+++ b/packages/ui/src/components/DataStory/controls/useRunControl.ts
@@ -5,8 +5,10 @@ import { DataStoryEvents, DataStoryEventType } from '../events/dataStoryEventTyp
 import { useDataStoryEvent } from '../events/eventManager';
 
 export function useRunControl() {
-  const [isRunning, setIsRunning] = useState(false);
-  const [executionId, setExecutionId] = useState('');
+  const isRunning = useStore((state) => state.isRunning);
+  const setIsRunning = useStore((state) => state.setIsRunning);
+  const executionId = useStore((state) => state.executionId);
+  const setExecutionId = useStore((state) => state.setExecutionId);
   const onRun = useStore((state) => state.onRun);
   const abortExecution = useStore((state) => state.abortExecution);
 

--- a/packages/ui/src/components/DataStory/store/store.tsx
+++ b/packages/ui/src/components/DataStory/store/store.tsx
@@ -24,6 +24,11 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
   params: [],
   openNodeSidebarId: null,
   focusOnFlow: () => void 0,
+  isRunning: false,
+  setIsRunning: (running: boolean) => set({ isRunning: running }),
+
+  executionId: '',
+  setExecutionId: (id: string) => set({ executionId: id }),
 
   // METHODS
   toDiagram: () => {

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -115,6 +115,12 @@ export type StoreSchema = {
   params: Param[],
   setParams: (params: Param[]) => void;
 
+  /** Run State */
+  isRunning: boolean;
+  setIsRunning: (running: boolean) => void;
+  executionId: string;
+  setExecutionId: (id: string) => void;
+
   /** When DataStory component initializes */
   onInit: (options: StoreInitOptions) => void;
 


### PR DESCRIPTION
Before: running with SHIFT+R did not toggle the state of the RunControl icon
Now: it does