### PR TITLE
feat: include platform-specific @duckdb/node-bindings in install scripts

### DIFF
--- a/packages/ds-ext/README.md
+++ b/packages/ds-ext/README.md
@@ -29,5 +29,6 @@ Set [`datastory.additionalDsServerCliArgs`](vscode://settings/datastory.addition
 
 * run `yarn build` under `packages/nodejs`
 * then `cp packages/nodejs/dist/ds-server.min.js packages/ds-ext/install-scripts/` in root
+* run `yarn vscode:prepublish` under `packages/ds-ext`
 * run `vsce package --no-yarn --skip-license` under `packages/ds-ext`
 * run `vsce publish` under `packages/ds-ext`

--- a/packages/ds-ext/package.json
+++ b/packages/ds-ext/package.json
@@ -142,7 +142,7 @@
     "dependencies": false
   },
   "scripts": {
-    "vscode:prepublish": "yarn run package",
+    "vscode:prepublish": "node ./prepublish.js && yarn run package",
     "build": "yarn run -T set-env NODE_ENV=production && yarn run -T webpack && yarn run -T vite build",
     "watch:extension": "yarn run -T set-env NODE_ENV=development && yarn run -T webpack --watch",
     "watch:app": "yarn run -T set-env NODE_ENV=development && yarn run -T vite build -w",
@@ -170,7 +170,8 @@
     "@typescript-eslint/eslint-plugin": "^8.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "@vscode/test-cli": "^0.0.10",
-    "@vscode/test-electron": "^2.4.1"
+    "@vscode/test-electron": "^2.4.1",
+    "tar": "^7.4.3"
   },
   "dependencies": {
     "@data-story/core": "workspace:*",

--- a/packages/ds-ext/prepublish.js
+++ b/packages/ds-ext/prepublish.js
@@ -2,16 +2,16 @@ const { execSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const https = require('https');
-const tar = require('tar'); // 用于解压
+const tar = require('tar'); // for extraction
 
-const DUCKDB_BINDINGS_VERSION = '1.2.2-alpha.19'; // 确保版本正确
+const DUCKDB_BINDINGS_VERSION = '1.2.2-alpha.19';
 
 const bindingsToInstall = [
   { name: 'darwin-arm64', os: 'darwin', cpu: 'arm64' },
   { name: 'linux-arm64', os: 'linux', cpu: 'arm64' },
   { name: 'darwin-x64', os: 'darwin', cpu: 'x64' },
   { name: 'linux-x64', os: 'linux', cpu: 'x64' },
-  { name: 'win32-x64', os: 'win32', cpu: 'x64' } // 你当前的平台
+  { name: 'win32-x64', os: 'win32', cpu: 'x64' }
 ];
 
 const nodeModulesPath = path.resolve(__dirname, './install-scripts/node_modules');
@@ -19,7 +19,7 @@ const duckDBBaseDir = path.join(nodeModulesPath, '@duckdb');
 
 console.log('Installing all DuckDB Node.js bindings for universal package...');
 
-// 确保 @duckdb 目录存在
+// Ensure @duckdb directory exists
 if (!fs.existsSync(duckDBBaseDir)) {
   fs.mkdirSync(duckDBBaseDir, { recursive: true });
 }
@@ -27,7 +27,7 @@ if (!fs.existsSync(duckDBBaseDir)) {
 async function downloadAndExtract(packageName, version, targetDir) {
   return new Promise((resolve, reject) => {
     try {
-      // 1. 获取 tarball URL
+      // 1. Get tarball URL
       const tarballUrl = execSync(`npm view ${packageName}@${version} dist.tarball`, { encoding: 'utf8' }).trim();
       if (!tarballUrl) {
         reject(new Error(`Could not get tarball URL for ${packageName}@${version}`));
@@ -35,28 +35,21 @@ async function downloadAndExtract(packageName, version, targetDir) {
       }
       console.log(`  Downloading ${tarballUrl} for ${packageName}...`);
 
-      // 2. 下载 tarball
+      // 2. Download tarball
       https.get(tarballUrl, (response) => {
         if (response.statusCode !== 200) {
-          response.resume(); // 消费数据以释放内存
+          response.resume(); // Consume data to free memory
           reject(new Error(`Failed to download ${tarballUrl}. Status: ${response.statusCode}`));
           return;
         }
 
-        // 确保目标目录存在
-        if (fs.existsSync(targetDir)) {
-          // 如果目录已存在且非空，可能表示之前已成功安装或部分安装
-          // 为避免重复工作或潜在冲突，可以选择清空或跳过
-          // 这里简单地先确保它是空的，或者你可以添加更复杂的逻辑
-          // fs.rmSync(targetDir, { recursive: true, force: true });
-        }
         fs.mkdirSync(targetDir, { recursive: true });
 
-        // 3. 解压 tarball 到目标目录
+        // 3. Extract tarball to target directory
         response.pipe(
           tar.x({
-            strip: 1, // npm 包的 tarball 通常包含一个 'package/' 根目录，strip: 1 可以移除它
-            C: targetDir // 指定解压到的目录 (cwd)
+            strip: 1, // npm package tarballs usually contain a 'package/' root directory, strip: 1 removes it
+            C: targetDir // Specify extraction directory (cwd)
           })
         )
           .on('finish', () => {
@@ -70,7 +63,7 @@ async function downloadAndExtract(packageName, version, targetDir) {
         reject(new Error(`Error downloading tarball for ${packageName}: ${err.message}`));
       });
     } catch (error) {
-      // execSync 失败等
+      // Handle execSync failures etc.
       reject(new Error(`Error in downloadAndExtract for ${packageName}: ${error.message}\n${error.stderr ? error.stderr.toString() : ''}`));
     }
   });
@@ -79,10 +72,10 @@ async function downloadAndExtract(packageName, version, targetDir) {
 async function main() {
   for (const binding of bindingsToInstall) {
     const platformSpecificPackageName = `@duckdb/node-bindings-${binding.name}`;
-    // 目标路径应为 node_modules/@duckdb/node-bindings-platform-arch/
+    // Target path should be node_modules/@duckdb/node-bindings-platform-arch/
     const targetPackageDir = path.join(duckDBBaseDir, `node-bindings-${binding.name}`);
 
-    // 检查是否已存在且包含内容 (简单检查，可以根据需要改进)
+    // Check if directory already exists and contains content (simple check, can be improved if needed)
     if (fs.existsSync(targetPackageDir) && fs.readdirSync(targetPackageDir).length > 0) {
       console.log(`  Skipping ${platformSpecificPackageName}: directory already exists and is not empty.`);
       continue;
@@ -93,8 +86,7 @@ async function main() {
       await downloadAndExtract(platformSpecificPackageName, DUCKDB_BINDINGS_VERSION, targetPackageDir);
     } catch (error) {
       console.error(`  Failed to install ${platformSpecificPackageName}. Error: ${error.message}`);
-      // 你可以决定如果一个绑定失败是否要停止整个过程
-      // throw error; // 如果需要，取消注释以在失败时停止
+      throw error;
     }
   }
   console.log('All DuckDB Node.js bindings installation attempt completed.');

--- a/packages/ds-ext/prepublish.js
+++ b/packages/ds-ext/prepublish.js
@@ -1,0 +1,106 @@
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const https = require('https');
+const tar = require('tar'); // 用于解压
+
+const DUCKDB_BINDINGS_VERSION = '1.2.2-alpha.19'; // 确保版本正确
+
+const bindingsToInstall = [
+  { name: 'darwin-arm64', os: 'darwin', cpu: 'arm64' },
+  { name: 'linux-arm64', os: 'linux', cpu: 'arm64' },
+  { name: 'darwin-x64', os: 'darwin', cpu: 'x64' },
+  { name: 'linux-x64', os: 'linux', cpu: 'x64' },
+  { name: 'win32-x64', os: 'win32', cpu: 'x64' } // 你当前的平台
+];
+
+const nodeModulesPath = path.resolve(__dirname, './install-scripts/node_modules');
+const duckDBBaseDir = path.join(nodeModulesPath, '@duckdb');
+
+console.log('Installing all DuckDB Node.js bindings for universal package...');
+
+// 确保 @duckdb 目录存在
+if (!fs.existsSync(duckDBBaseDir)) {
+  fs.mkdirSync(duckDBBaseDir, { recursive: true });
+}
+
+async function downloadAndExtract(packageName, version, targetDir) {
+  return new Promise((resolve, reject) => {
+    try {
+      // 1. 获取 tarball URL
+      const tarballUrl = execSync(`npm view ${packageName}@${version} dist.tarball`, { encoding: 'utf8' }).trim();
+      if (!tarballUrl) {
+        reject(new Error(`Could not get tarball URL for ${packageName}@${version}`));
+        return;
+      }
+      console.log(`  Downloading ${tarballUrl} for ${packageName}...`);
+
+      // 2. 下载 tarball
+      https.get(tarballUrl, (response) => {
+        if (response.statusCode !== 200) {
+          response.resume(); // 消费数据以释放内存
+          reject(new Error(`Failed to download ${tarballUrl}. Status: ${response.statusCode}`));
+          return;
+        }
+
+        // 确保目标目录存在
+        if (fs.existsSync(targetDir)) {
+          // 如果目录已存在且非空，可能表示之前已成功安装或部分安装
+          // 为避免重复工作或潜在冲突，可以选择清空或跳过
+          // 这里简单地先确保它是空的，或者你可以添加更复杂的逻辑
+          // fs.rmSync(targetDir, { recursive: true, force: true });
+        }
+        fs.mkdirSync(targetDir, { recursive: true });
+
+        // 3. 解压 tarball 到目标目录
+        response.pipe(
+          tar.x({
+            strip: 1, // npm 包的 tarball 通常包含一个 'package/' 根目录，strip: 1 可以移除它
+            C: targetDir // 指定解压到的目录 (cwd)
+          })
+        )
+          .on('finish', () => {
+            console.log(`  Successfully downloaded and extracted ${packageName} to ${targetDir}`);
+            resolve();
+          })
+          .on('error', (err) => {
+            reject(new Error(`Error extracting tarball for ${packageName}: ${err.message}`));
+          });
+      }).on('error', (err) => {
+        reject(new Error(`Error downloading tarball for ${packageName}: ${err.message}`));
+      });
+    } catch (error) {
+      // execSync 失败等
+      reject(new Error(`Error in downloadAndExtract for ${packageName}: ${error.message}\n${error.stderr ? error.stderr.toString() : ''}`));
+    }
+  });
+}
+
+async function main() {
+  for (const binding of bindingsToInstall) {
+    const platformSpecificPackageName = `@duckdb/node-bindings-${binding.name}`;
+    // 目标路径应为 node_modules/@duckdb/node-bindings-platform-arch/
+    const targetPackageDir = path.join(duckDBBaseDir, `node-bindings-${binding.name}`);
+
+    // 检查是否已存在且包含内容 (简单检查，可以根据需要改进)
+    if (fs.existsSync(targetPackageDir) && fs.readdirSync(targetPackageDir).length > 0) {
+      console.log(`  Skipping ${platformSpecificPackageName}: directory already exists and is not empty.`);
+      continue;
+    }
+
+    console.log(`  Processing ${platformSpecificPackageName}...`);
+    try {
+      await downloadAndExtract(platformSpecificPackageName, DUCKDB_BINDINGS_VERSION, targetPackageDir);
+    } catch (error) {
+      console.error(`  Failed to install ${platformSpecificPackageName}. Error: ${error.message}`);
+      // 你可以决定如果一个绑定失败是否要停止整个过程
+      // throw error; // 如果需要，取消注释以在失败时停止
+    }
+  }
+  console.log('All DuckDB Node.js bindings installation attempt completed.');
+}
+
+main().catch(err => {
+  console.error('Installation script failed:', err);
+  process.exit(1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6160,6 +6160,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     rxjs: "npm:^7.8.1"
+    tar: "npm:^7.4.3"
     terminate: "npm:^2.8.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Package the different platforms of @duckdb/node-bindings into install scripts, so that users won't need to manually install DuckDB when they install ds-ext.