### PR TITLE
Run updateNodeInternals on port changes

### DIFF
--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -8,6 +8,7 @@ import {
   ReactFlow,
   ReactFlowProvider,
   useStoreApi,
+  useUpdateNodeInternals,
 } from '@xyflow/react';
 import NodeComponent from '../Node/NodeComponent';
 import { useGetStore, useStore } from './store/store';
@@ -78,6 +79,8 @@ const Flow = ({
     updateEdgeCounts: state.updateEdgeCounts,
     updateEdgeStatus: state.updateEdgeStatus,
     updateDiagram: state.updateDiagram,
+    updateNodeInternalsCallback: state.updateNodeInternalsCallback,
+    setUpdateNodeInternalsCallback: state.setUpdateNodeInternalsCallback,
   });
 
   const {
@@ -93,11 +96,20 @@ const Flow = ({
     updateEdgeCounts,
     updateEdgeStatus,
     updateDiagram,
+    setUpdateNodeInternalsCallback,
   } = useStore(selector, shallow);
 
   const id = useId()
   const reactFlowStore = useStoreApi();
   const { addSelectedNodes, setNodes } = reactFlowStore.getState();
+
+  const updateNodeInternals = useUpdateNodeInternals();
+
+  useEffect(() => {
+    setUpdateNodeInternalsCallback((nodeId: string) => {
+      updateNodeInternals(nodeId);
+    });
+  }, [updateNodeInternals, setUpdateNodeInternalsCallback]);
 
   const flowRef = useRef<HTMLDivElement>(null);
 

--- a/packages/ui/src/components/DataStory/Form/nodeSettingsForm.tsx
+++ b/packages/ui/src/components/DataStory/Form/nodeSettingsForm.tsx
@@ -18,9 +18,10 @@ export const NodeSettingsForm: React.FC<NodeSettingsFormProps> = ({ node, onClos
   const selector = (state: StoreSchema) => ({
     toDiagram: state.toDiagram,
     updateNode: state.updateNode,
+    updateNodeInternalsCallback: state.updateNodeInternalsCallback,
   });
 
-  const { updateNode, toDiagram } = useStore(selector);
+  const { updateNode, toDiagram, updateNodeInternalsCallback } = useStore(selector);
 
   const defaultValues = useMemo(() => {
     return  {
@@ -90,6 +91,8 @@ export const NodeSettingsForm: React.FC<NodeSettingsFormProps> = ({ node, onClos
         ...node,
         data: newData,
       })
+
+      updateNodeInternalsCallback?.(node.id);
 
       onSave?.(toDiagram());
     })()

--- a/packages/ui/src/components/DataStory/store/store.tsx
+++ b/packages/ui/src/components/DataStory/store/store.tsx
@@ -135,6 +135,10 @@ export const createStore = () => createWithEqualityFn<StoreSchema>((set, get) =>
       }),
     })
   },
+  updateNodeInternalsCallback: null,
+  setUpdateNodeInternalsCallback: (callback: (nodeId: string) => void) => {
+    set({ updateNodeInternalsCallback: callback })
+  },
   setNodes: (nodes: ReactFlowNode[]) => {
     set({
       nodes: [...nodes],

--- a/packages/ui/src/components/DataStory/types.ts
+++ b/packages/ui/src/components/DataStory/types.ts
@@ -96,6 +96,8 @@ export type StoreSchema = {
   /** The Nodes */
   nodes: ReactFlowNode[];
   updateNode: (node: ReactFlowNode) => void;
+  updateNodeInternalsCallback: ((nodeId: string) => void) | null;
+  setUpdateNodeInternalsCallback: (callback: (nodeId: string) => void) => void;
   addNode: (node: ReactFlowNode) => void;
   addNodeFromDescription: (nodeDescription: NodeDescription) => void;
   onNodesChange: OnNodesChange;


### PR DESCRIPTION
Continuation of: #437
Before: reordered output ports in node settings did not take effect in terms of port positions
After: ports and connected links get new positions on save.

### Background
Since reordering ports do not constitute a DOM change in terms of IDs etc, we had to tell react flow to rerender.
For this we can use `updateNodeInternals`.
However, this function can only be called by children of the react flow provider.
In our case the change was coming from the _sidebar_ which is not below the react flow provider.

Component Tree:
```
DataStory
  DataStoryCanvasProvider (with our store)
    DataStoryCanvas
      ReactFlowProvider
        // updateNodeInternals usage only allowed here
    Sidebar
```
However, since Sidebar have access to our store, it is given access to a function `updateNodeInternalsCallback`
That callback is registered when DataStoryCanvas renders.