### PR TITLE
Add dedicated Loop nodes

### DIFF
--- a/packages/core/src/computers/LoopBack.ts
+++ b/packages/core/src/computers/LoopBack.ts
@@ -1,0 +1,38 @@
+import { str } from '../Param';
+import { Computer } from '../types/Computer';
+import { BatchLimit } from '../utils/batchLimit';
+
+export const LoopBack: Computer = {
+  name: 'LoopBack',
+  label: 'Loop Back',
+  inputs: [{
+    name: 'input',
+    schema: {},
+  }],
+  outputs: [{
+    name: 'output',
+    schema: {},
+  }],
+  params: [
+    str({
+      name: 'port_name',
+      label: 'Port Name',
+      value: 'has-more',
+      help: 'The name of the loop back port.',
+      multiline: false,
+      canInterpolate: true,
+    }),
+  ],
+  async *run({ input, output }) {
+    while(true) {
+      const [ portName, ...other ] = output.getPortNames()
+      if (!portName || other.length > 0) throw new Error('LoopBack computer must have exactly one output port.')
+
+      const incoming = input.pull(BatchLimit)
+
+      output.pushTo(portName, incoming)
+
+      yield;
+    }
+  },
+};

--- a/packages/core/src/computers/LoopStart.ts
+++ b/packages/core/src/computers/LoopStart.ts
@@ -1,0 +1,38 @@
+import { str } from '../Param';
+import { Computer } from '../types/Computer';
+
+export const LoopStart: Computer = {
+  name: 'LoopStart',
+  label: 'Loop Start',
+  inputs: [{
+    name: 'input',
+    schema: {},
+  }],
+  outputs: [{
+    name: 'output',
+    schema: {},
+  }],
+  params: [
+    str({
+      name: 'port_name',
+      label: 'Port Name',
+      value: 'has-more',
+      help: 'The name of the loop start port.',
+      multiline: false,
+      canInterpolate: true,
+    }),
+  ],
+  async *run({ input, output }) {
+    while(true) {
+      const [ portName, ...other ] = input.getPortNames()
+
+      if (!portName || other.length > 0) throw new Error('LoopStart computer must have exactly one input port.')
+
+      const incoming = input.pullFrom(portName)
+
+      output.push(incoming)
+
+      yield;
+    }
+  },
+};

--- a/packages/core/src/computers/index.ts
+++ b/packages/core/src/computers/index.ts
@@ -11,12 +11,14 @@ export { FlatMap } from './FlatMap';
 export { If } from './If';
 export { Ignore } from './Ignore'
 export { Input } from './Input';
+export { LoopStart } from './LoopStart';
 export { InstantThrow } from './InstantThrow';
 export { Log } from './Log';
 export { MakeSet } from './MakeSet';
 export { Map } from './Map'
 export { Merge } from './Merge'
 export { Output } from './Output';
+export { LoopBack } from './LoopBack';
 export { Pass } from './Pass';
 export { RemoveProperties } from './RemoveProperties';
 export { Request } from './Request'

--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -30,11 +30,15 @@ import { useDragNode } from './useDragNode';
 import { ReactFlowNode } from '../Node/ReactFlowNode';
 import { useCopyPaste } from './useCopyPaste';
 import '../../styles/dataStoryCanvasStyle.css';
+import LoopBackComponent from '../Node/LoopBackComponent';
+import LoopStartComponent from '../Node/LoopStartComponent';
 
 const nodeTypes = {
   commentNodeComponent: CommentNodeComponent,
   nodeComponent: NodeComponent,
   inputNodeComponent: InputNodeComponent,
+  loopBackComponent: LoopBackComponent,
+  loopStartComponent: LoopStartComponent,
   outputNodeComponent: OutputNodeComponent,
   tableNodeComponent: TableNodeComponent,
   consoleNodeComponent: ConsoleNodeComponent,

--- a/packages/ui/src/components/Node/LoopBackComponent.tsx
+++ b/packages/ui/src/components/Node/LoopBackComponent.tsx
@@ -1,0 +1,62 @@
+import React, { memo } from 'react';
+import { useStore } from '../DataStory/store/store';
+import { shallow } from 'zustand/shallow';
+import { DataStoryNodeData } from './ReactFlowNode';
+import { Handle, Position } from '@xyflow/react';
+import { PortIcon } from '../DataStory/icons/portIcon';
+import { StringableParam } from '@data-story/core';
+import { StoreSchema } from '../DataStory/types';
+
+const LoopBackComponent = ({ id, data, selected }: { id: string; data: DataStoryNodeData; selected: boolean }) => {
+  const selector = (state: StoreSchema) => ({
+    setOpenNodeSidebarId: state.setOpenNodeSidebarId,
+  });
+
+  const { setOpenNodeSidebarId } = useStore(selector, shallow);
+
+  const portName = (data?.params?.[0] as StringableParam)
+    .input.rawValue
+
+  const inputPort = data.inputs[0]
+  const outputPort = data.outputs[0]
+
+  return (
+    <div
+      className={'text-xs' + (selected ? ' shadow-xl' : '')}
+      onDoubleClick={() => {
+        setOpenNodeSidebarId(id);
+      }}
+    >
+      <div className="flex w-full items-left justify-start">
+        <div className="flex flex-col items-center justify-center">
+          <div className="absolute my-0.5"><PortIcon /></div>
+          <Handle
+            className="relative"
+            type="target"
+            position={Position.Left}
+            style={{ opacity: 0, backgroundColor: '', position: 'relative', height: 12, width: 12, top: 6, left: 6 }}
+            id={inputPort.id}
+            isConnectable={true}
+          />
+        </div>
+        <div className={'rounded-r rounded-full py-1 text-xs font-bold font-mono tracking-wide border border-gray-400 rounded bg-green-700 text-gray-100 px-2' + (selected ? ' bg-green-800 shadow-xl' : '')}>
+          <div className="w-24" />
+          <div className="flex w-full whitespace-nowrap">
+            Loop Back: { portName }
+          </div>
+        </div>
+        {/* INVISIBLE PORT. ONLY USED WHEN SHOWING AN UNFOLDED DIAGRAM */}
+        <Handle
+          className="relative"
+          type="source"
+          position={Position.Right}
+          style={{ opacity: 0, backgroundColor: '', position: 'relative', height: 1, width: 1, top: 0, right: 0 }}
+          id={outputPort.id}
+          isConnectable={false}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default memo(LoopBackComponent);

--- a/packages/ui/src/components/Node/LoopStartComponent.tsx
+++ b/packages/ui/src/components/Node/LoopStartComponent.tsx
@@ -1,0 +1,62 @@
+import React, { memo } from 'react';
+import { useStore } from '../DataStory/store/store';
+import { shallow } from 'zustand/shallow';
+import { DataStoryNodeData } from './ReactFlowNode';
+import { Handle, Position } from '@xyflow/react';
+import { PortIcon } from '../DataStory/icons/portIcon';
+import { StringableParam } from '@data-story/core';
+import { StoreSchema } from '../DataStory/types';
+
+const LoopStartComponent = ({ id, data, selected }: { id: string; data: DataStoryNodeData; selected: boolean }) => {
+  const selector = (state: StoreSchema) => ({
+    setOpenNodeSidebarId: state.setOpenNodeSidebarId,
+  });
+
+  const { setOpenNodeSidebarId } = useStore(selector, shallow);
+
+  const portName = (data?.params?.[0] as StringableParam)
+    .input.rawValue
+
+  const inputPort = data.inputs[0]
+  const outputPort = data.outputs[0]
+
+  return (
+    <div
+      className={'text-xs' + (selected ? ' shadow-xl' : '')}
+      onDoubleClick={() => {
+        setOpenNodeSidebarId(id);
+      }}
+    >
+      <div className="flex w-full items-right justify-end -mx-4">
+        {/* INVISIBLE PORT. ONLY USED WHEN SHOWING AN UNFOLDED DIAGRAM */}
+        <Handle
+          className="relative"
+          type="target"
+          position={Position.Left}
+          style={{ opacity: 0, backgroundColor: '', position: 'relative', height: 1, width: 1, top: 0, right: 0 }}
+          id={inputPort.id}
+          isConnectable={true}
+        />
+        <div className={'rounded-l rounded-full py-1 text-xs font-bold font-mono tracking-wide border border-gray-400 rounded bg-green-700 text-gray-100 px-2' + (selected ? ' bg-green-800 shadow-xl' : '') }>
+          <div className="w-24" />
+          <div className="flex w-full whitespace-nowrap">
+            Loop Start: { portName }
+          </div>
+        </div>
+        <div className="flex flex-col items-center justify-center">
+          <div className="absolute my-0.5"><PortIcon /></div>
+          <Handle
+            className="relative"
+            type="source"
+            position={Position.Right}
+            style={{ opacity: 0, backgroundColor: '', position: 'relative', height: 12, width: 12, top: 6, right: 11 }}
+            id={outputPort.id}
+            isConnectable={true}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default memo(LoopStartComponent);

--- a/packages/ui/src/factories/ReactFlowFactory.ts
+++ b/packages/ui/src/factories/ReactFlowFactory.ts
@@ -23,6 +23,8 @@ export const ReactFlowFactory = {
           type: (() => {
             if (node.name === 'Comment') return 'commentNodeComponent';
             if (node.name === 'Input') return 'inputNodeComponent';
+            if (node.name === 'LoopBack') return 'loopBackComponent';
+            if (node.name === 'LoopStart') return 'loopStartComponent';
             if (node.name === 'Output') return 'outputNodeComponent';
             if (node.name === 'Table') return 'tableNodeComponent';
             if (node.name === 'ConsoleLog') return 'consoleNodeComponent';


### PR DESCRIPTION
<img width="888" alt="image" src="https://github.com/user-attachments/assets/b0e538f4-51b4-419b-aa07-72fc43fdf556" />
* Adds LoopStart and LoopBack nodes
* Experimental implementation in UnfoldedDiagram adds a runtime-only link between matching loop nodes.

### Considerations
* Wont scale if many loops are used in the same workfow
* UnfoldedDiagram now has more responsibilities and the name does not communicate that


