### PR TITLE
Rename UnfoldedDiagram -> ExecutableDiagram

### DIFF
--- a/packages/core/src/ExecutableDiagram.ts
+++ b/packages/core/src/ExecutableDiagram.ts
@@ -2,7 +2,7 @@ import { Diagram } from './Diagram'
 import { Param } from './Param'
 import { NodeId } from './types/Node'
 
-export type UnfoldedDiagram = {
+export type ExecutableDiagram = {
   diagram: Diagram
   unfoldedGlobalParams: Record<NodeId, Param[]>
 }

--- a/packages/core/src/ExecutableDiagramFactory.test.ts
+++ b/packages/core/src/ExecutableDiagramFactory.test.ts
@@ -1,4 +1,4 @@
-import { UnfoldedDiagramFactory, core, nodes } from '.';
+import { ExecutableDiagramFactory, core, nodes } from '.';
 import { DiagramQuery } from './DiagramQuery';
 import { str } from './Param'
 const { Create, Table, Input, Map, Output, ConsoleLog, Ignore } = nodes;
@@ -12,7 +12,7 @@ describe('unfold', () => {
       .connect()
       .get();
 
-    const unfolded = new UnfoldedDiagramFactory(diagram, {}).unfold();
+    const unfolded = new ExecutableDiagramFactory(diagram, {}).unfold();
 
     expect(unfolded.diagram).toEqual(diagram);
   })
@@ -39,7 +39,7 @@ describe('unfold', () => {
       .connect()
       .get()
 
-    const { diagram: unfoldedDiagram, unfoldedGlobalParams } = UnfoldedDiagramFactory.create(diagram, {
+    const { diagram: unfoldedDiagram, unfoldedGlobalParams } = ExecutableDiagramFactory.create(diagram, {
       'NestedNode': nestedNode,
     });
 
@@ -80,7 +80,7 @@ describe('unfold', () => {
       .connect()
       .get()
 
-    const { diagram: unfoldedDiagram } = UnfoldedDiagramFactory.create(diagram, {
+    const { diagram: unfoldedDiagram } = ExecutableDiagramFactory.create(diagram, {
       'NestedNode': nestedNode,
     });
 

--- a/packages/core/src/ExecutableDiagramFactory.ts
+++ b/packages/core/src/ExecutableDiagramFactory.ts
@@ -1,11 +1,11 @@
 import { Diagram } from './Diagram'
 import { Param, StringableInputValue } from './Param'
 import { NestedNodes } from './Registry'
-import { UnfoldedDiagram } from './UnfoldedDiagram'
+import { ExecutableDiagram } from './ExecutableDiagram'
 import { Node, NodeId } from './types/Node'
 import { isStringableParam } from './utils/isStringableParam';
 
-export class UnfoldedDiagramFactory {
+export class ExecutableDiagramFactory {
   public unfoldedGlobalParams: Record<NodeId, Param[]> = {}
   constructor(
     public diagram: Diagram,
@@ -15,7 +15,7 @@ export class UnfoldedDiagramFactory {
   static create(
     diagram: Diagram,
     nestedNodes: NestedNodes,
-  ): UnfoldedDiagram {
+  ): ExecutableDiagram {
     const instance = new this(diagram, nestedNodes)
     instance.unfold()
 
@@ -62,7 +62,7 @@ export class UnfoldedDiagramFactory {
     }
   }
 
-  unfold(): UnfoldedDiagram {
+  unfold(): ExecutableDiagram {
     const replacables = this.diagram.nodes.filter(node => node.name in this.nestedNodes)
 
     for(const node of replacables) {

--- a/packages/core/src/ExecutionMemoryFactory.test.ts
+++ b/packages/core/src/ExecutionMemoryFactory.test.ts
@@ -1,7 +1,7 @@
 import { ComputerFactory } from './ComputerFactory';
 import { ExecutionMemoryFactory } from './ExecutionMemoryFactory';
 import { Registry } from './Registry';
-import { UnfoldedDiagramFactory } from './UnfoldedDiagramFactory';
+import { ExecutableDiagramFactory } from './ExecutableDiagramFactory';
 import { ConsoleLog, Create } from './computers'
 import { core } from './core';
 
@@ -14,7 +14,7 @@ describe('create', () => {
       .connect()
       .get();
 
-    const unfoldedDiagram = new UnfoldedDiagramFactory(diagram, {}). unfold()
+    const unfoldedDiagram = new ExecutableDiagramFactory(diagram, {}). unfold()
 
     const registry = new Registry({
       Create: new ComputerFactory().getInstance(Create),
@@ -37,7 +37,7 @@ describe('create', () => {
       .add('ConsoleLog')
       .get();
 
-    const unfoldedDiagram = new UnfoldedDiagramFactory(diagram, {}). unfold()
+    const unfoldedDiagram = new ExecutableDiagramFactory(diagram, {}). unfold()
 
     const registry = new Registry({
       Create: new ComputerFactory().getInstance(Create),
@@ -60,7 +60,7 @@ describe('create', () => {
       .connect()
       .get();
 
-    const unfoldedDiagram = new UnfoldedDiagramFactory(diagram, {}). unfold()
+    const unfoldedDiagram = new ExecutableDiagramFactory(diagram, {}). unfold()
 
     const registry = new Registry({
       Create: new ComputerFactory().getInstance(Create),
@@ -86,7 +86,7 @@ describe('create', () => {
       .add('ConsoleLog')
       .get();
 
-    const unfoldedDiagram = new UnfoldedDiagramFactory(diagram, {}). unfold()
+    const unfoldedDiagram = new ExecutableDiagramFactory(diagram, {}). unfold()
 
     const registry = new Registry({
       Create: new ComputerFactory().getInstance(Create),

--- a/packages/core/src/ExecutionMemoryFactory.ts
+++ b/packages/core/src/ExecutionMemoryFactory.ts
@@ -6,7 +6,7 @@ import { ParamEvaluator } from './ItemWithParams/ParamEvaluator'
 import { NodeRunnerContext } from './NodeRunnerContext'
 import { OutputDevice, PortLinkMap } from './OutputDevice'
 import { Registry } from './Registry'
-import { UnfoldedDiagram } from './UnfoldedDiagram'
+import { ExecutableDiagram } from './ExecutableDiagram'
 import { Computer } from './types/Computer'
 import { Hook } from './types/Hook'
 import { ItemValue } from './types/ItemValue'
@@ -15,7 +15,7 @@ import { Node, NodeId } from './types/Node'
 
 export class ExecutionMemoryFactory {
   constructor(
-    public unfoldedDiagram: UnfoldedDiagram,
+    public unfoldedDiagram: ExecutableDiagram,
     public registry: Registry,
     public observerController?: ObserverController,
   ) {}

--- a/packages/core/src/ExecutorFactory.ts
+++ b/packages/core/src/ExecutorFactory.ts
@@ -3,7 +3,7 @@ import { ExecutionMemoryFactory } from './ExecutionMemoryFactory';
 import { Executor } from './Executor';
 import { ObserverController } from './ObserverController';
 import { Registry } from './Registry';
-import { UnfoldedDiagramFactory } from './UnfoldedDiagramFactory';
+import { ExecutableDiagramFactory } from './ExecutableDiagramFactory';
 
 export const ExecutorFactory = {
   create({
@@ -15,7 +15,7 @@ export const ExecutorFactory = {
     registry: Registry;
     observerController?: ObserverController;
   }) {
-    const unfolded = UnfoldedDiagramFactory.create(
+    const unfolded = ExecutableDiagramFactory.create(
       diagram,
       registry.nestedNodes,
     )

--- a/packages/core/src/InputDevice.test.ts
+++ b/packages/core/src/InputDevice.test.ts
@@ -2,7 +2,7 @@ import { Diagram } from './Diagram'
 import { ExecutionMemory } from './ExecutionMemory'
 import { InputDevice } from './InputDevice'
 import { str } from './Param'
-import { UnfoldedDiagramFactory } from './UnfoldedDiagramFactory'
+import { ExecutableDiagramFactory } from './ExecutableDiagramFactory'
 import { Node } from './types/Node'
 
 describe('pull', () => {
@@ -25,7 +25,7 @@ describe('pull', () => {
       links,
     })
 
-    const unfoldedDiagram = new UnfoldedDiagramFactory(diagram, {}). unfold()
+    const unfoldedDiagram = new ExecutableDiagramFactory(diagram, {}). unfold()
 
     const memory = new ExecutionMemory({
       linkItems: new Map()
@@ -59,7 +59,7 @@ describe('pull', () => {
         nodes: [node],
       })
 
-      const unfoldedDiagram = new UnfoldedDiagramFactory(diagram, {}). unfold()
+      const unfoldedDiagram = new ExecutableDiagramFactory(diagram, {}). unfold()
 
       const memory = new ExecutionMemory()
 
@@ -92,7 +92,7 @@ describe('pull', () => {
         .set('link-2', [{ i: 3 }, { i: 4 }]),
     })
 
-    const unfoldedDiagram = new UnfoldedDiagramFactory(diagram, {}). unfold()
+    const unfoldedDiagram = new ExecutableDiagramFactory(diagram, {}). unfold()
 
     const input = new InputDevice(node, unfoldedDiagram, memory)
     input.pull()
@@ -129,7 +129,7 @@ describe('pull', () => {
         .set('link-2', [{ i: 3 }, { i: 4 }]),
     })
 
-    const unfoldedDiagram = new UnfoldedDiagramFactory(diagram, {}). unfold()
+    const unfoldedDiagram = new ExecutableDiagramFactory(diagram, {}). unfold()
 
     const input = new InputDevice(node, unfoldedDiagram, memory)
 
@@ -159,7 +159,7 @@ describe('pullFrom', () => {
       links,
     })
 
-    const unfoldedDiagram = new UnfoldedDiagramFactory(diagram, {}). unfold()
+    const unfoldedDiagram = new ExecutableDiagramFactory(diagram, {}). unfold()
 
     const memory = new ExecutionMemory({
       linkItems: new Map()
@@ -196,7 +196,7 @@ describe('pullFrom', () => {
       links,
     })
 
-    const unfoldedDiagram = new UnfoldedDiagramFactory(diagram, {}). unfold()
+    const unfoldedDiagram = new ExecutableDiagramFactory(diagram, {}). unfold()
 
     const memory = new ExecutionMemory({
       linkItems: new Map()
@@ -242,7 +242,7 @@ describe('params', () => {
       links,
     })
 
-    const unfoldedDiagram = new UnfoldedDiagramFactory(diagram, {}). unfold()
+    const unfoldedDiagram = new ExecutableDiagramFactory(diagram, {}). unfold()
 
     const memory = new ExecutionMemory({
       linkItems: new Map()

--- a/packages/core/src/InputDevice.ts
+++ b/packages/core/src/InputDevice.ts
@@ -4,7 +4,7 @@ import { ItemWithParams } from './ItemWithParams'
 import { Node } from './types/Node'
 import { ItemValue } from './types/ItemValue'
 import { ObserverController } from './ObserverController';
-import { UnfoldedDiagram } from './UnfoldedDiagram'
+import { ExecutableDiagram } from './ExecutableDiagram'
 import { PortName } from './types/Port'
 
 export class InputDevice {
@@ -12,7 +12,7 @@ export class InputDevice {
     // The node that is using this input device
     private node: Node,
     // The node topology
-    private unfoldedDiagram: UnfoldedDiagram,
+    private unfoldedDiagram: ExecutableDiagram,
     // Reference to the current execution state
     private memory: ExecutionMemory,
     protected readonly observerController?: ObserverController,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,7 +37,7 @@ export { stringifyError } from './utils/stringifyError'
 export { type Computer } from './types/Computer'
 export { type ExecutionResult } from './ExecutionResult'
 export { type InputObserveConfig, RequestObserverType } from './types/InputObserveConfig';
-export { UnfoldedDiagramFactory } from './UnfoldedDiagramFactory'
+export { ExecutableDiagramFactory as ExecutableDiagramFactory } from './ExecutableDiagramFactory'
 export * as nodes from './computers'
 export * from './Param'
 export type { AbortExecution, LinkCountInfo, ObserveLinkCounts, ExecutionObserver, ObserveLinkItems, ObserveNodeStatus, CancelObservation, ObserveLinkUpdate, NodesStatusInfo } from './types/ExecutionObserver'

--- a/packages/core/src/support/computerTester/ComputerTester.ts
+++ b/packages/core/src/support/computerTester/ComputerTester.ts
@@ -26,7 +26,7 @@ import { Hook } from '../../types/Hook';
 import { Param } from '../../Param';
 import { ParamEvaluator } from '../../ItemWithParams/ParamEvaluator';
 import { merge } from '../../utils/merge';
-import { UnfoldedDiagramFactory } from '../../UnfoldedDiagramFactory';
+import { ExecutableDiagramFactory } from '../../ExecutableDiagramFactory';
 import { NodeRunnerContext } from '../../NodeRunnerContext';
 
 export const when = (computer: Computer) => {
@@ -236,7 +236,7 @@ export class ComputerTester {
 
   protected makeInputDevice() {
     const diagramClone = this.diagram!.clone()
-    const unfoldedDiagram = new UnfoldedDiagramFactory(
+    const unfoldedDiagram = new ExecutableDiagramFactory(
       diagramClone,
       {},
     ).unfold()

--- a/packages/docs/components/demos/UnfoldingDemo.tsx
+++ b/packages/docs/components/demos/UnfoldingDemo.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { AddNodeControl, DataStory, RunControl } from '@data-story/ui';
-import { multiline, str, UnfoldedDiagramFactory } from '@data-story/core';
+import { multiline, str, ExecutableDiagramFactory } from '@data-story/core';
 import { CustomizeJSClient } from '../splash/CustomizeJSClient';
 import { useRequestApp } from '../hooks/useRequestApp';
 
@@ -71,7 +71,7 @@ export default ({ part }: { part: 'MAIN' | 'NESTED_NODE' | 'MAIN_UNFOLDED' }) =>
         FooBarStamper: nestedNode,
       };
 
-      const unfolded = new UnfoldedDiagramFactory(diagram.clone(), nestedNodes).unfold();
+      const unfolded = new ExecutableDiagramFactory(diagram.clone(), nestedNodes).unfold();
 
       console.log({
         msg: 'Main Client Diagram',

--- a/packages/docs/pages/Unfolding.mdx
+++ b/packages/docs/pages/Unfolding.mdx
@@ -7,7 +7,7 @@ Furthermore it will pass on any node params which will act as *global* params in
 
 ```ts
 // When creating the execution
-const { diagram } = UnfoldedDiagramFactory.create(original, definitions)
+const { diagram } = ExecutableDiagramFactory.create(original, definitions)
 ```
 Let's consider an example!
 


### PR DESCRIPTION
Since a `Diagram` now need to go through *two* pre-processing steps before it can be executed, it make more sense with a broader name `ExecutableDiagram` instead of `UnfoldedDiagram`. The steps as of now is:
* Unfolding
* Linking loop nodes