### PR TITLE
feat: implement in-memory JSON storage with debounced write and read

### DIFF
--- a/packages/core/src/ObserverController.ts
+++ b/packages/core/src/ObserverController.ts
@@ -204,6 +204,7 @@ export class ObserverController {
     this.observerMap.forEach((subscription) => subscription.unsubscribe());
     this.observerMap.clear();
 
+    this.storage.close();
     // Complete all subjects
     this.items$.complete();
     this.links$.complete();

--- a/packages/nodejs/src/computers/JsonFileWrite/JsonFileWrite.ts
+++ b/packages/nodejs/src/computers/JsonFileWrite/JsonFileWrite.ts
@@ -28,11 +28,7 @@ export const JsonFileWrite: Computer = {
     const incoming = input.pull();
     const filePath = params.file_path as string;
     const content = JSON.stringify(incoming.map(i => i.value), null, 2);
-
-    // Determine if the path is absolute
     const isAbsolutePath = path.isAbsolute(filePath);
-
-    // Resolve the full path based on whether it's absolute or relative
     const fullPath = isAbsolutePath
       ? filePath // Use the absolute path directly
       : path.join(getWorkingDirConfig().workingDir, filePath); // Prepend the workspace root for relative paths

--- a/packages/nodejs/src/server/getWorkingDirConfig.ts
+++ b/packages/nodejs/src/server/getWorkingDirConfig.ts
@@ -16,7 +16,6 @@ export interface WorkingDirDsServerConfig extends DsServerConfig {
 export function getWorkingDirConfig(): WorkingDirDsServerConfig {
   const workingDir = process.cwd();
   const configPath = path.join(workingDir, 'datastory.config.json');
-  console.log('Using config path', configPath);
   try {
     const raw = fs.readFileSync(configPath, 'utf-8');
     const config = JSON.parse(raw);

--- a/packages/nodejs/src/storage/createStorage.ts
+++ b/packages/nodejs/src/storage/createStorage.ts
@@ -8,7 +8,7 @@ import { JsonObserverStorage } from './jsonObserverStorage';
 export const createStorage = (): ObserverStorage => {
   const config = getWorkingDirConfig();
   if (config.storage === 'JSON') {
-    const filePath = createDataStoryJSONPath({ config, diagramId: 'todo-diagramId' });
+    const filePath = createDataStoryJSONPath({ config, diagramId: `storage-json-${Date.now()}` });
     return new JsonObserverStorage(filePath);
   } else if (config.storage === 'DUCK_DB') {
     const dbPath = createDataStoryDBPath({ config });

--- a/packages/nodejs/src/storage/jsonObserverStorage.ts
+++ b/packages/nodejs/src/storage/jsonObserverStorage.ts
@@ -1,5 +1,7 @@
 import { GetLinkItemsParams, ItemValue, LinkId, NodeId, ObserverStorage } from '@data-story/core';
+import { promises as fsPromises } from 'fs';
 import * as fs from 'fs';
+import * as path from 'path';
 
 type JsonObserverStorageData = {
   linkCounts: Record<string, number>;
@@ -7,67 +9,159 @@ type JsonObserverStorageData = {
   nodes: Record<string, 'BUSY' | 'COMPLETE'>;
 }
 
+/**
+ * JSON Observer Storage implementation
+ * Uses in-memory caching and debounced writes for improved performance
+ */
 export class JsonObserverStorage implements ObserverStorage {
-  constructor(private filePath: string) {
-  }
+  // In-memory cache
+  private cache: JsonObserverStorageData | null = null;
+  // Flag indicating if cache has unsaved changes
+  private isDirty = false;
+  private writeDebounceTimeout: NodeJS.Timeout | null = null;
+  private readonly DEBOUNCE_TIME = 1000;
 
+  constructor(private filePath: string) {}
+
+  /**
+   * Creates necessary directories and loads data into memory
+   */
   async init(): Promise<void> {
-    // Initialize storage file if it doesn't exist
+    // 确保目录存在 / Ensure directory exists
+    await fsPromises.mkdir(path.dirname(this.filePath), { recursive: true });
+
+    // 初始化时加载数据到内存 / Load data into memory during initialization
     if (!fs.existsSync(this.filePath)) {
-      this.write({
+      this.cache = {
         linkCounts: {},
         linkItems: {},
         nodes: {},
-      });
+      };
+      await this.persistCache();
+    } else {
+      await this.loadCache();
     }
   }
 
-  async close() {}
+  /**
+   * Close storage and ensure all changes are saved
+   */
+  async close(): Promise<void> {
+    // Cancel any pending write operations
+    if (this.writeDebounceTimeout) {
+      clearTimeout(this.writeDebounceTimeout);
+      this.writeDebounceTimeout = null;
+    }
+
+    // If there are unsaved changes, save immediately
+    if (this.isDirty && this.cache) {
+      await this.persistCache();
+    }
+  }
+
+  private async ensureCache(): Promise<JsonObserverStorageData> {
+    if (!this.cache) await this.loadCache();
+    if (!this.cache) throw new Error('Failed to initialize cache');
+    return this.cache;
+  }
 
   async getLinkCount(linkId: LinkId): Promise<number | undefined> {
-    const data = this.read();
-    return data.linkCounts[linkId];
+    const cache = await this.ensureCache();
+    return cache.linkCounts[linkId];
   }
 
   async setLinkCount(linkId: LinkId, count: number): Promise<void> {
-    const data = this.read();
-    data.linkCounts[linkId] = count;
-    this.write(data);
+    const cache = await this.ensureCache();
+    cache.linkCounts[linkId] = count;
+    this.scheduleWrite();
   }
 
   async getLinkItems({ linkId, offset, limit }: GetLinkItemsParams): Promise<ItemValue[] | undefined> {
-    const data = this.read();
-    return data.linkItems[linkId].slice(offset, offset + limit);
+    const cache = await this.ensureCache();
+    if (!cache.linkItems[linkId]) return undefined;
+    return cache.linkItems[linkId].slice(offset, offset + limit);
   }
 
   async setLinkItems(linkId: LinkId, items: ItemValue[]): Promise<void> {
-    const data = this.read();
-    data.linkItems[linkId] = items;
-    this.write(data);
+    const cache = await this.ensureCache();
+    cache.linkItems[linkId] = items;
+    this.scheduleWrite();
   }
 
   async appendLinkItems(linkId: LinkId, items: ItemValue[]): Promise<void> {
-    const data = this.read();
-    data.linkItems[linkId].push(...items);
-    this.write(data);
+    const cache = await this.ensureCache();
+
+    if (!cache.linkItems[linkId]) {
+      cache.linkItems[linkId] = [];
+    }
+
+    cache.linkItems[linkId].push(...items);
+    this.scheduleWrite();
   }
 
   async getNodeStatus(nodeId: NodeId): Promise<'BUSY' | 'COMPLETE' | undefined> {
-    const data = this.read();
-    return data.nodes[nodeId];
+    const cache = await this.ensureCache();
+    return cache.nodes[nodeId];
   }
 
   async setNodeStatus(nodeId: NodeId, status: 'BUSY' | 'COMPLETE'): Promise<void> {
-    const data = this.read();
-    data.nodes[nodeId] = status;
-    this.write(data);
+    const cache = await this.ensureCache();
+    cache.nodes[nodeId] = status;
+    this.scheduleWrite();
   }
 
-  private read(): JsonObserverStorageData {
-    return JSON.parse(fs.readFileSync(this.filePath, 'utf-8'));
+  /**
+   * Load data from file into memory cache
+   */
+  private async loadCache(): Promise<void> {
+    try {
+      const data = await fsPromises.readFile(this.filePath, 'utf-8');
+      this.cache = JSON.parse(data);
+    } catch (error) {
+      console.error('Error loading cache:', error);
+      this.cache = {
+        linkCounts: {},
+        linkItems: {},
+        nodes: {},
+      };
+    }
   }
 
-  private write(data: JsonObserverStorageData) {
-    fs.writeFileSync(this.filePath, JSON.stringify(data, null, 2));
+  /**
+   * Persist memory cache to file
+   * Only writes when cache is marked as dirty (has changes)
+   */
+  private async persistCache(): Promise<void> {
+    if (!this.isDirty || !this.cache) return;
+
+    try {
+      // 异步写入文件，使用格式化的JSON以便于调试
+      // Asynchronously write to file using formatted JSON for easier debugging
+      await fsPromises.writeFile(
+        this.filePath,
+        JSON.stringify(this.cache, null, 2),
+      );
+      this.isDirty = false;
+    } catch (error) {
+      console.error('Error persisting cache:', error);
+    }
+  }
+
+  /**
+   * Schedule a debounced write operation
+   * Multiple rapid calls are coalesced into a single write, reducing disk I/O
+   */
+  private scheduleWrite(): void {
+    if (this.writeDebounceTimeout) {
+      clearTimeout(this.writeDebounceTimeout);
+    }
+
+    // Mark cache as dirty (has changes)
+    this.isDirty = true;
+
+    this.writeDebounceTimeout = setTimeout(async () => {
+      await this.persistCache();
+      this.writeDebounceTimeout = null;
+    }, this.DEBOUNCE_TIME);
   }
 }

--- a/packages/nodejs/src/storage/jsonObserverStorage.ts
+++ b/packages/nodejs/src/storage/jsonObserverStorage.ts
@@ -27,10 +27,7 @@ export class JsonObserverStorage implements ObserverStorage {
    * Creates necessary directories and loads data into memory
    */
   async init(): Promise<void> {
-    // 确保目录存在 / Ensure directory exists
     await fsPromises.mkdir(path.dirname(this.filePath), { recursive: true });
-
-    // 初始化时加载数据到内存 / Load data into memory during initialization
     if (!fs.existsSync(this.filePath)) {
       this.cache = {
         linkCounts: {},
@@ -135,7 +132,6 @@ export class JsonObserverStorage implements ObserverStorage {
     if (!this.isDirty || !this.cache) return;
 
     try {
-      // 异步写入文件，使用格式化的JSON以便于调试
       // Asynchronously write to file using formatted JSON for easier debugging
       await fsPromises.writeFile(
         this.filePath,


### PR DESCRIPTION
I noticed that when setting `"storage": "JSON"`, the diagram execution becomes very slow and often throws warnings. There are two main reasons:

1. The local JSON file is about 1GB in size, and as the file grows, read/write operations slow down significantly.
2. The previous implementation performs read and write operations directly on the JSON file every time, causing a performance bottleneck.

before:
approximately a 4x speedup：

https://github.com/user-attachments/assets/c324c287-0f9e-4e3e-adcb-ff858d484c8e

after: 

https://github.com/user-attachments/assets/b8091347-084a-413b-a2ac-15c185003c73

