### PR TITLE
Prevent bad auto-connect scenario

### DIFF
--- a/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
+++ b/packages/ui/src/components/DataStory/DataStoryCanvas.tsx
@@ -221,6 +221,9 @@ const Flow = ({
       // For each incoming edge, connect it to all outgoing edges
       incomingEdges.forEach(inEdge => {
         outgoingEdges.forEach(outEdge => {
+          // Ensure the source and target are not targeted for deletion
+          if (nodesToDelete.some(n => n.id === inEdge.source) || nodesToDelete.some(n => n.id === outEdge.target)) return;
+
           // Create a connection that will be handled by the store's connect method
           connect({
             source: inEdge.source,


### PR DESCRIPTION
Prevents connection to nodes no longer present.

### Background
When deleting intermediate nodes links will automatically reconnect to new source/target ports in the link chain:
```
// Diagram
A --> B --> C
// After deleting B
A --> C 
```
This feature combined with deleting *many* nodes at once caused bad links to be created, which in turned caused hydration errors appearing when adding new nodes.

### Example:
Diagram: A --> B --> C
Actions: CTRL+A, DELETE.
Outcome: When B is deleted we attempted to reconnect: A --> C even though these were just deleted !
Fix: Now we confirm A and C are still present before auto-reconnecting.
