### PR TITLE
Allow alias on nested nodes

### DIFF
--- a/packages/core/src/Registry.ts
+++ b/packages/core/src/Registry.ts
@@ -1,8 +1,13 @@
 import { Diagram } from './Diagram';
 import { Computer, ComputerType } from './types/Computer';
+import { NodeDescription } from './types/NodeDescription';
 
 export type ComputerRecord = Record<ComputerType, Computer>
-export type ConfiguredComputerAliases = Computer[]
+export type ConfiguredComputerAlias = {
+  type: string,
+  aliasFactory: (original: NodeDescription) => NodeDescription,
+}
+export type ConfiguredComputerAliases = ConfiguredComputerAlias[]
 export type NestedNodesRecord = Record<string, Diagram>
 
 export class Registry {

--- a/packages/core/src/coreNodeProvider.ts
+++ b/packages/core/src/coreNodeProvider.ts
@@ -13,20 +13,12 @@ export const coreNodeProvider: ServiceProvider = {
     // ************************************************
     // Add configured aliases demo: Photos node
     // ************************************************
-    const photosComputer: Computer = {
-      // Clonables
-      ...structuredClone({
-        ...computers.Request,
-        run: undefined,
-      }),
-      // Non-clonables
-      label: 'Photos',
-      run: computers.Request.run,
-    }
-
-    const [ urlParam ] = photosComputer.params
-    urlParam.input.rawValue = 'https://jsonplaceholder.typicode.com/photos'
-
-    app.addConfiguredComputerAlias(photosComputer);
+    app.addConfiguredComputerAlias('Request', (original) => {
+      const clone = structuredClone(original)
+      clone.label = 'Photos'
+      const [ urlParam ] = clone.params
+      urlParam.input.rawValue = 'https://jsonplaceholder.typicode.com/photos'
+      return clone
+    });
   },
 }

--- a/packages/core/src/remoteNodeProvider.ts
+++ b/packages/core/src/remoteNodeProvider.ts
@@ -1003,18 +1003,13 @@ const addDownloadEntity = (app: Application) => {
   app.addNestedNode('DownloadEntity', node);
 
   for(const entity of entities) {
-    const computer = structuredClone({
-      type: 'DownloadEntity',
-      label: entity,
-      run: undefined as any,
-      params: node.params,
-      inputs: node.inputs,
-      outputs: node.outputs,
-    })
+    app.addConfiguredComputerAlias('DownloadEntity', (original => {
+      const clone = structuredClone(original)
+      const [entityParam] = clone.params
+      entityParam.input.rawValue = entity
+      clone.label = entity
 
-    const [entityParam] = computer.params
-    entityParam.input.rawValue = entity
-
-    app.addConfiguredComputerAlias(computer)
+      return clone
+    }))
   }
 }

--- a/packages/nodejs/ds-server.ts
+++ b/packages/nodejs/ds-server.ts
@@ -38,7 +38,7 @@ const startServer = async () => {
   app.register([
     coreNodeProvider,
     nodeJsProvider,
-    hubspotProvider,
+    // hubspotProvider,
     remoteNodeProvider,
   ]);
 


### PR DESCRIPTION
* Modifies `app.addConfiguredComputerAlias` to allow _configured alias nodes_ being based on both "primitive" and "nested" nodes.
* Updates Core::Photos node (configured alias of Request node)
* Updates contact, companies, deals, tickets nodes. Based on nested node `DownloadEntity`.

### Follow ups
- [ ] keep Photos in core as a feature documentation
- [ ] in addition, move fooBarStamper from remoteNodeProvider to coreNodeProvider to showcase nodes created with DiagramBuilder
- [ ] remove hubspot specifics from remoteNodeProvider
- [ ] loading via configuration / http
- [ ] ensure failing providers errors are propagated and catched
