### PR TITLE
Reserved type property for Computer and NodeDescription

### DIFF
--- a/packages/core/src/Application.test.ts
+++ b/packages/core/src/Application.test.ts
@@ -63,7 +63,7 @@ describe('addComputers', () => {
   it('adds computers to the application', () => {
     const app = new Application()
     const computer = {
-      type: 'Signal',
+      computerType: 'Signal',
       run: async function*(_) {},
     } as Computer;
 
@@ -82,7 +82,10 @@ describe('descriptions', ()  => {
     app.addComputers([ Signal ])
 
     expect(app.descriptions()).toMatchObject([
-      { type: 'Signal' },
+      {
+        type: 'NodeDescription',
+        computerType: 'Signal',
+      },
     ])
   })
 })

--- a/packages/core/src/Application.ts
+++ b/packages/core/src/Application.ts
@@ -35,7 +35,7 @@ export class Application {
 
   addComputers(computers: Computer[]) {
     for (const computer of computers) {
-      this.registry.computers[computer.type] = computer;
+      this.registry.computers[computer.computerType] = computer;
     }
   }
 
@@ -96,7 +96,7 @@ export class Application {
     ]
 
     return configurations.map(({ type, aliasFactory }) => {
-      const original = originalDescriptions.find(description => description.type === type)
+      const original = originalDescriptions.find(description => description.computerType === type)
       if (!original) throw new Error(`No original description found for type ${type}`)
 
       return aliasFactory(original)

--- a/packages/core/src/ComputerFactory.test.ts
+++ b/packages/core/src/ComputerFactory.test.ts
@@ -4,13 +4,15 @@ import { Computer } from './types/Computer'
 describe('get', () => {
   it('creates a computer from a sparse config', () => {
     const config = {
-      type: 'test computer',
+      type: 'Computer',
+      computerType: 'test computer',
     } as Computer
 
     const computer = new ComputerFactory().getInstance(config)
 
     expect(computer).toMatchObject({
-      type: 'test computer',
+      type: 'Computer',
+      computerType: 'test computer',
       label: 'test computer',
       category: undefined,
       inputs: [],
@@ -23,7 +25,7 @@ describe('get', () => {
 
   it('upgrades simple string inputs and outputs to Port', () => {
     const config = {
-      type: 'test computer',
+      computerType: 'test computer',
       inputs: [
         {
           name: 'input1',
@@ -49,7 +51,8 @@ describe('get', () => {
     const computer = new ComputerFactory().getInstance(config)
 
     expect(computer).toMatchObject({
-      type: 'test computer',
+      type: 'Computer',
+      computerType: 'test computer',
       inputs: [
         { name: 'input1', schema: {} },
         { name: 'input2', schema: {} },

--- a/packages/core/src/ComputerFactory.ts
+++ b/packages/core/src/ComputerFactory.ts
@@ -15,8 +15,9 @@ export class ComputerFactory {
     return {
       // Properties
       ...structuredClone({
-        type: template.type ?? 'unnamed',
-        label: template.label ?? template.type ?? 'unlabeled',
+        type: 'Computer',
+        computerType: template.computerType ?? 'unnamed',
+        label: template.label ?? template.computerType ?? 'unlabeled',
         category: template.category,
         inputs: template.inputs?.map(portableToPort) ?? [],
         outputs: template.outputs?.map(portableToPort) ?? [],

--- a/packages/core/src/Diagram.ts
+++ b/packages/core/src/Diagram.ts
@@ -5,6 +5,7 @@ import { Param } from './Param'
 import { PortName } from './types/Port';
 
 export class Diagram {
+  type = 'Diagram'
   nodes: Node[]
   links: Link[]
   params: Param[]

--- a/packages/core/src/DiagramBuilder.ts
+++ b/packages/core/src/DiagramBuilder.ts
@@ -25,7 +25,7 @@ export class DiagramBuilder {
   constructor(private nodeDescriptions: NodeDescription[]) {}
 
   add(nodeName: string, config?: AddNodeConfig) {
-    const description = this.nodeDescriptions.find(e => e.type === nodeName)
+    const description = this.nodeDescriptions.find(e => e.computerType === nodeName)
 
     if (!description) throw new Error(`Description for a Node ${nodeName} not found`)
 
@@ -223,11 +223,11 @@ export class DiagramBuilder {
   }
 
   private nodeDescriptionToDiagramNode(nodeDescription: NodeDescription): Node {
-    const id = `${nodeDescription.type}.${this.getScopedId(nodeDescription.type)}`;
+    const id = `${nodeDescription.computerType}.${this.getScopedId(nodeDescription.computerType)}`;
 
     return structuredClone({
       id,
-      type: nodeDescription.type,
+      type: nodeDescription.computerType,
       label: nodeDescription.label,
       inputs: nodeDescription.inputs.map(input => {
         return {

--- a/packages/core/src/Executor.test.ts
+++ b/packages/core/src/Executor.test.ts
@@ -180,7 +180,7 @@ describe('execute', () => {
     const order: string[] = []
 
     const createComputer = {
-      type: 'Create',
+      computerType: 'Create',
       async *run({ output }: RunArgs) {
         order.push('running create')
         output.push([{ i: 1 }])
@@ -188,7 +188,7 @@ describe('execute', () => {
     } as Computer
 
     const logComputer = {
-      type: 'Log',
+      computerType: 'Log',
       async *run({ input }: RunArgs) {
         // console.log ... or something
 

--- a/packages/core/src/NodeDescriptionFactory.test.ts
+++ b/packages/core/src/NodeDescriptionFactory.test.ts
@@ -5,7 +5,7 @@ import { Computer } from './types/Computer'
 describe('fromComputer', () => {
   it('returns a NodeDescription', () => {
     const config = {
-      type: 'test',
+      computerType: 'ComputerX',
       inputs: [{
         name: 'input1',
         schema: {},
@@ -17,8 +17,9 @@ describe('fromComputer', () => {
     const nodeDescription = NodeDescriptionFactory.fromComputer(computer)
 
     expect(nodeDescription).toMatchObject({
-      type: 'test',
-      label: 'test',
+      type: 'NodeDescription',
+      computerType: 'ComputerX',
+      label: 'ComputerX',
       inputs: [{
         name: 'input1',
         schema: {},

--- a/packages/core/src/NodeDescriptionFactory.ts
+++ b/packages/core/src/NodeDescriptionFactory.ts
@@ -6,7 +6,8 @@ import { NodeDescription } from './types/NodeDescription';
 export const NodeDescriptionFactory = {
   fromComputer: (computer: Computer): NodeDescription => {
     return {
-      type: computer.type,
+      type: 'NodeDescription',
+      computerType: computer.computerType,
       label: computer.label,
       category: computer.category,
       inputs: computer.inputs,
@@ -17,7 +18,8 @@ export const NodeDescriptionFactory = {
 
   fromDiagram: (name: string, diagram: Diagram): NodeDescription => {
     return {
-      type: name,
+      type: 'NodeDescription',
+      computerType: name,
       label: name,
       category: undefined,
       inputs: diagram.nodes

--- a/packages/core/src/PositionGuesser.ts
+++ b/packages/core/src/PositionGuesser.ts
@@ -22,7 +22,7 @@ export class PositionGuesser {
     const maxY = this.diagram.nodes.map((node) => node.position!.y).reduce((max, y) => Math.max(max, y), 0)
 
     const isStarterNode = node.inputs.length === 0;
-    const name = (node as Node).type ?? (node as NodeDescription).type;
+    const name = (node as Node).type ?? (node as NodeDescription).computerType;
     const isInputNode = name === 'Input';
 
     if(isStarterNode || isInputNode) {

--- a/packages/core/src/computers/Aggregate.ts
+++ b/packages/core/src/computers/Aggregate.ts
@@ -5,7 +5,8 @@ import { Computer } from '../types/Computer';
 import { get } from '../utils/get';
 
 export const Aggregate: Computer = {
-  type: 'Aggregate',
+  type: 'Computer',
+  computerType: 'Aggregate',
   label: 'Aggregate',
   inputs: [
     {

--- a/packages/core/src/computers/Anonymize.ts
+++ b/packages/core/src/computers/Anonymize.ts
@@ -4,7 +4,8 @@ import { anonymize } from '../utils/anonymize';
 import { BatchLimit } from '../utils/batchLimit';
 
 export const Anonymize: Computer = {
-  type: 'Anonymize',
+  type: 'Computer',
+  computerType: 'Anonymize',
   label: 'Anonymize',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/Await.ts
+++ b/packages/core/src/computers/Await.ts
@@ -2,7 +2,8 @@ import { num, StringableInputValue } from '../Param';
 import { Computer } from '../types/Computer';
 
 export const Await: Computer = {
-  type: 'Await',
+  type: 'Computer',
+  computerType: 'Await',
   label: 'Await',
   inputs: [
     {

--- a/packages/core/src/computers/Clone.ts
+++ b/packages/core/src/computers/Clone.ts
@@ -4,7 +4,8 @@ import { ItemValue } from '../types/ItemValue';
 import { BatchLimit } from '../utils/batchLimit';
 
 export const Clone: Computer = {
-  type: 'Clone',
+  type: 'Computer',
+  computerType: 'Clone',
   label: 'Clone',
   inputs: [
     {

--- a/packages/core/src/computers/Comment.ts
+++ b/packages/core/src/computers/Comment.ts
@@ -3,7 +3,8 @@ import { str } from '../Param';
 import { Computer } from '../types/Computer';
 
 export const Comment: Computer = {
-  type: 'Comment',
+  type: 'Computer',
+  computerType: 'Comment',
   label: 'Comment',
   inputs: [],
   outputs: [],

--- a/packages/core/src/computers/ConsoleLog.ts
+++ b/packages/core/src/computers/ConsoleLog.ts
@@ -6,7 +6,8 @@ import { str } from '../Param';
 import { Computer } from '../types/Computer';
 
 export const ConsoleLog: Computer = {
-  type: 'ConsoleLog',
+  type: 'Computer',
+  computerType: 'ConsoleLog',
   label: 'Console.log',
   inputs: [
     {

--- a/packages/core/src/computers/Create.ts
+++ b/packages/core/src/computers/Create.ts
@@ -2,7 +2,8 @@ import { jsExpression } from '../Param';
 import { Computer } from '../types/Computer';
 
 export const Create: Computer = {
-  type: 'Create',
+  type: 'Computer',
+  computerType: 'Create',
   label: 'Create',
   inputs: [],
   outputs: [

--- a/packages/core/src/computers/Describe.ts
+++ b/packages/core/src/computers/Describe.ts
@@ -6,7 +6,8 @@ import { num, str } from '../Param';
 import { Computer } from '../types/Computer';
 
 export const Describe: Computer = {
-  type: 'Describe',
+  type: 'Computer',
+  computerType: 'Describe',
   label: 'Describe',
   inputs: [
     {

--- a/packages/core/src/computers/Fake.ts
+++ b/packages/core/src/computers/Fake.ts
@@ -3,7 +3,8 @@ import { multiline } from '../utils/multiline';
 import { sleep } from '../utils/sleep';
 
 export const Fake: Computer = {
-  type: 'Fake',
+  type: 'Computer',
+  computerType: 'Fake',
   label: 'Fake',
   inputs: [],
   outputs: [],

--- a/packages/core/src/computers/FilterMap.ts
+++ b/packages/core/src/computers/FilterMap.ts
@@ -4,7 +4,8 @@ import { Computer } from '../types/Computer';
 import { BatchLimit } from '../utils/batchLimit';
 
 export const FilterMap: Computer = {
-  type: 'FilterMap',
+  type: 'Computer',
+  computerType: 'FilterMap',
   label: 'FilterMap',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/FlatMap.ts
+++ b/packages/core/src/computers/FlatMap.ts
@@ -3,7 +3,8 @@ import { Computer } from '../types/Computer';
 import { BatchLimit } from '../utils/batchLimit';
 
 export const FlatMap: Computer = {
-  type: 'FlatMap',
+  type: 'Computer',
+  computerType: 'FlatMap',
   label: 'FlatMap',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/If.ts
+++ b/packages/core/src/computers/If.ts
@@ -4,7 +4,8 @@ import { Computer } from '../types/Computer';
 import { BatchLimit } from '../utils/batchLimit';
 
 export const If: Computer = {
-  type: 'If',
+  type: 'Computer',
+  computerType: 'If',
   label: 'If',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/Ignore.ts
+++ b/packages/core/src/computers/Ignore.ts
@@ -2,7 +2,8 @@ import { Computer } from '../types/Computer';
 import { BatchLimit } from '../utils/batchLimit';
 
 export const Ignore: Computer = {
-  type: 'Ignore',
+  type: 'Computer',
+  computerType: 'Ignore',
   label: 'Ignore',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/Input.ts
+++ b/packages/core/src/computers/Input.ts
@@ -2,7 +2,8 @@ import { str } from '../Param';
 import { Computer } from '../types/Computer';
 
 export const Input: Computer = {
-  type: 'Input',
+  type: 'Computer',
+  computerType: 'Input',
   label: 'Input',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/InstantThrow.ts
+++ b/packages/core/src/computers/InstantThrow.ts
@@ -1,7 +1,8 @@
 import { Computer } from '../types/Computer';
 
 export const InstantThrow: Computer = {
-  type: 'InstantThrow',
+  type: 'Computer',
+  computerType: 'InstantThrow',
   label: 'InstantThrow',
   inputs: [],
   outputs: [],

--- a/packages/core/src/computers/Log.ts
+++ b/packages/core/src/computers/Log.ts
@@ -2,7 +2,8 @@ import { Computer } from '../types/Computer';
 import { BatchLimit } from '../utils/batchLimit';
 
 export const Log: Computer = {
-  type: 'Log',
+  type: 'Computer',
+  computerType: 'Log',
   label: 'Log',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/LoopBack.ts
+++ b/packages/core/src/computers/LoopBack.ts
@@ -3,7 +3,8 @@ import { Computer } from '../types/Computer';
 import { BatchLimit } from '../utils/batchLimit';
 
 export const LoopBack: Computer = {
-  type: 'LoopBack',
+  type: 'Computer',
+  computerType: 'LoopBack',
   label: 'Loop Back',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/LoopStart.ts
+++ b/packages/core/src/computers/LoopStart.ts
@@ -2,7 +2,8 @@ import { str } from '../Param';
 import { Computer } from '../types/Computer';
 
 export const LoopStart: Computer = {
-  type: 'LoopStart',
+  type: 'Computer',
+  computerType: 'LoopStart',
   label: 'Loop Start',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/MakeSet.ts
+++ b/packages/core/src/computers/MakeSet.ts
@@ -3,7 +3,8 @@ import { Computer } from '../types/Computer';
 import { BatchLimit } from '../utils/batchLimit';
 
 export const MakeSet: Computer = {
-  type: 'MakeSet',
+  type: 'Computer',
+  computerType: 'MakeSet',
   label: 'MakeSet',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/Map.ts
+++ b/packages/core/src/computers/Map.ts
@@ -5,7 +5,8 @@ import { Computer } from '../types/Computer';
 import { BatchLimit } from '../utils/batchLimit';
 
 export const Map: Computer = {
-  type: 'Map',
+  type: 'Computer',
+  computerType: 'Map',
   label: 'Map',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/Merge.ts
+++ b/packages/core/src/computers/Merge.ts
@@ -5,7 +5,8 @@ import { buildNestedObject } from '../utils/buildNestedObject';
 import { merge } from '../utils/merge';
 
 export const Merge: Computer = {
-  type: 'Merge',
+  type: 'Computer',
+  computerType: 'Merge',
   label: 'Merge',
   inputs: [
     {

--- a/packages/core/src/computers/Output.ts
+++ b/packages/core/src/computers/Output.ts
@@ -3,7 +3,8 @@ import { Computer } from '../types/Computer';
 import { BatchLimit } from '../utils/batchLimit';
 
 export const Output: Computer = {
-  type: 'Output',
+  type: 'Computer',
+  computerType: 'Output',
   label: 'Output',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/Pass.ts
+++ b/packages/core/src/computers/Pass.ts
@@ -2,7 +2,8 @@ import { Computer } from '../types/Computer';
 import { BatchLimit } from '../utils/batchLimit';
 
 export const Pass: Computer = {
-  type: 'Pass',
+  type: 'Computer',
+  computerType: 'Pass',
   label: 'Pass',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/RemoveProperties.ts
+++ b/packages/core/src/computers/RemoveProperties.ts
@@ -2,7 +2,8 @@ import { Computer } from '../types/Computer';
 import { BatchLimit } from '../utils/batchLimit';
 
 export const RemoveProperties: Computer = {
-  type: 'RemoveProperties',
+  type: 'Computer',
+  computerType: 'RemoveProperties',
   label: 'RemoveProperties',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/Request.ts
+++ b/packages/core/src/computers/Request.ts
@@ -110,7 +110,8 @@ async function requestAndSerialize(
 }
 
 export const Request: Computer = {
-  type: 'Request',
+  type: 'Computer',
+  computerType: 'Request',
   label: 'Request',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/RequestLoopByOffset.ts
+++ b/packages/core/src/computers/RequestLoopByOffset.ts
@@ -4,7 +4,8 @@ import { get } from '../utils/get';
 import { Computer } from '../types/Computer';
 
 export const RequestLoopByOffset: Computer = {
-  type: 'RequestLoopByOffset',
+  type: 'Computer',
+  computerType: 'RequestLoopByOffset',
   label: 'RequestLoopByOffset',
   inputs: [],
   outputs: [

--- a/packages/core/src/computers/RequestLoopByToken.ts
+++ b/packages/core/src/computers/RequestLoopByToken.ts
@@ -4,7 +4,8 @@ import { json_, str } from '../Param';
 import { get } from '../utils/get';
 
 export const RequestLoopByToken: Computer = {
-  type: 'RequestLoopByToken',
+  type: 'Computer',
+  computerType: 'RequestLoopByToken',
   label: 'RequestLoopByToken',
   inputs: [],
   outputs: [

--- a/packages/core/src/computers/Router.ts
+++ b/packages/core/src/computers/Router.ts
@@ -5,7 +5,8 @@ import { Computer } from '../types/Computer';
 import { BatchLimit } from '../utils/batchLimit';
 
 export const Router: Computer = {
-  type: 'Router',
+  type: 'Computer',
+  computerType: 'Router',
   label: 'Router',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/Sample.ts
+++ b/packages/core/src/computers/Sample.ts
@@ -2,7 +2,8 @@ import { num } from '../Param';
 import { Computer } from '../types/Computer';
 
 export const Sample: Computer = {
-  type: 'Sample',
+  type: 'Computer',
+  computerType: 'Sample',
   label: 'Sample',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/Signal.ts
+++ b/packages/core/src/computers/Signal.ts
@@ -6,7 +6,8 @@ import { jsFunctionEvaluation } from '../Param/evaluations/jsFunctionEvaluation'
 import { jsonEvaluation } from '../Param/evaluations/jsonEvaluation';
 
 export const Signal: Computer = {
-  type: 'Signal',
+  type: 'Computer',
+  computerType: 'Signal',
   label: 'Signal',
   inputs: [],
   outputs: [{

--- a/packages/core/src/computers/Sleep.ts
+++ b/packages/core/src/computers/Sleep.ts
@@ -3,7 +3,8 @@ import { num } from '../Param';
 import { Computer } from '../types/Computer';
 
 export const Sleep: Computer = {
-  type: 'Sleep',
+  type: 'Computer',
+  computerType: 'Sleep',
   label: 'Sleep',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/Table.ts
+++ b/packages/core/src/computers/Table.ts
@@ -3,7 +3,8 @@ import { Computer } from '../types/Computer';
 import { BatchLimit } from '../utils/batchLimit';
 
 export const Table: Computer = {
-  type: 'Table',
+  type: 'Computer',
+  computerType: 'Table',
   label: 'Table',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/Throw.ts
+++ b/packages/core/src/computers/Throw.ts
@@ -7,7 +7,8 @@ import { str } from '../Param';
 import { Computer } from '../types/Computer';
 
 export const Throw: Computer = {
-  type: 'Throw',
+  type: 'Computer',
+  computerType: 'Throw',
   label: 'Throw',
   inputs: [{
     name: 'input',

--- a/packages/core/src/computers/Unique.ts
+++ b/packages/core/src/computers/Unique.ts
@@ -4,7 +4,8 @@ import { Computer } from '../types/Computer';
 import { get } from '../utils/get';
 
 export const Unique: Computer = {
-  type: 'Unique',
+  type: 'Computer',
+  computerType: 'Unique',
   label: 'Unique',
   inputs: [{
     name: 'input',

--- a/packages/core/src/support/computerTester/ComputerTester.ts
+++ b/packages/core/src/support/computerTester/ComputerTester.ts
@@ -193,11 +193,11 @@ export class ComputerTester {
 
   protected makeDiagram(): Diagram {
     // To make testing easier,replacing the dynamic id with a fixed value of 1
-    const nodeId = `${this.computer.type}.1`
+    const nodeId = `${this.computer.computerType}.1`
     // Create a new Node from the computer + params (TODO: this is a general need)
     const node: Node = {
       id: nodeId,
-      type: this.computer.type,
+      type: this.computer.computerType,
       inputs: (this.computer.inputs || []).map(input => ({
         id: `${nodeId}.${input.name}`,
         name: input.name,

--- a/packages/core/src/types/Computer.ts
+++ b/packages/core/src/types/Computer.ts
@@ -11,7 +11,8 @@ import { InputDevice } from '../InputDevice'
 import { OutputDevice } from '../OutputDevice'
 
 export interface Computer {
-  type: ComputerType
+  type: 'Computer',
+  computerType: ComputerType
   label: string
   category?: string
   inputs: AbstractPort[]

--- a/packages/core/src/types/NodeDescription.ts
+++ b/packages/core/src/types/NodeDescription.ts
@@ -4,7 +4,8 @@ import { AbstractPort } from './Port';
 import { ComputerType } from '../types/Computer';
 
 export type NodeDescription = {
-  type: ComputerType,
+  type: 'NodeDescription',
+  computerType: ComputerType,
   label?: string,
   category?: string,
   inputs: AbstractPort[],

--- a/packages/core/src/types/SerializedDiagram.ts
+++ b/packages/core/src/types/SerializedDiagram.ts
@@ -1,0 +1,11 @@
+import { Link } from './Link';
+import { Node } from './Node';
+import { Param } from '../Param';
+
+export type SerializedDiagram = {
+  type: 'Diagram',
+  nodes: Node[],
+  links: Link[],
+  params: Param[],
+  viewport: { x: number, y: number, zoom: number },
+}

--- a/packages/ds-ext/src/app/onDrop.ts
+++ b/packages/ds-ext/src/app/onDrop.ts
@@ -72,7 +72,7 @@ export const onDropFromExplorer = (event: any, addNodeFromDescription: any) => {
 
 export const createJsonFileReadDescription = (filename: string, path: string): NodeDescription => {
   return {
-    type: 'JsonFile.read',
+    computerType: 'JsonFile.read',
     label: filename,
     inputs: [],
     outputs: [

--- a/packages/hubspot/src/crm/entity/archive.ts
+++ b/packages/hubspot/src/crm/entity/archive.ts
@@ -4,7 +4,8 @@ import { EntityPage } from './EntityPage';
 import { CrmEntityName } from './CrmEntityName';
 
 const Template: Computer = {
-  type: 'NAME',
+  type: 'Computer',
+  computerType: 'NAME',
   label: 'LABEL',
   inputs: [
     {

--- a/packages/hubspot/src/crm/entity/batchArchive.ts
+++ b/packages/hubspot/src/crm/entity/batchArchive.ts
@@ -4,7 +4,8 @@ import { EntityPage } from './EntityPage';
 import { CrmEntityName } from './CrmEntityName';
 
 const Template: Computer = {
-  type: 'NAME',
+  type: 'Computer',
+  computerType: 'NAME',
   label: 'LABEL',
   inputs: [{
     name: 'incoming',

--- a/packages/hubspot/src/crm/entity/batchCreate.ts
+++ b/packages/hubspot/src/crm/entity/batchCreate.ts
@@ -4,7 +4,8 @@ import { EntityPage } from './EntityPage';
 import { CrmEntityName } from './CrmEntityName';
 
 const Template: Computer = {
-  type: 'NAME',
+  type: 'Computer',
+  computerType: 'NAME',
   label: 'LABEL',
   inputs: [{
     name: 'incoming',

--- a/packages/hubspot/src/crm/entity/batchUpdate.ts
+++ b/packages/hubspot/src/crm/entity/batchUpdate.ts
@@ -4,7 +4,8 @@ import { EntityPage } from './EntityPage';
 import { CrmEntityName } from './CrmEntityName';
 
 const Template: Computer = {
-  type: 'NAME',
+  type: 'Computer',
+  computerType: 'NAME',
   label: 'LABEL',
   inputs: [{
     name: 'input',

--- a/packages/hubspot/src/crm/entity/create.ts
+++ b/packages/hubspot/src/crm/entity/create.ts
@@ -4,7 +4,8 @@ import { EntityPage } from './EntityPage';
 import { CrmEntityName } from './CrmEntityName';
 
 const Template: Computer = {
-  type: 'NAME',
+  type: 'Computer',
+  computerType: 'NAME',
   label: 'LABEL',
   inputs: [{
     name: 'input',

--- a/packages/hubspot/src/crm/entity/getAll.ts
+++ b/packages/hubspot/src/crm/entity/getAll.ts
@@ -4,7 +4,8 @@ import { EntityPage } from './EntityPage';
 import { CrmEntityName } from './CrmEntityName';
 
 const Template: Computer = {
-  type: 'NAME',
+  type: 'Computer',
+  computerType: 'NAME',
   label: 'LABEL',
   inputs: [],
   outputs: [

--- a/packages/hubspot/src/crm/entity/update.ts
+++ b/packages/hubspot/src/crm/entity/update.ts
@@ -4,7 +4,8 @@ import { EntityPage } from './EntityPage';
 import { CrmEntityName } from './CrmEntityName';
 
 const Template: Computer = {
-  type: 'NAME',
+  type: 'Computer',
+  computerType: 'NAME',
   label: 'LABEL',
   inputs: [{
     name: 'input',

--- a/packages/nodejs/src/computers/CsvFileRead/CsvFileRead.ts
+++ b/packages/nodejs/src/computers/CsvFileRead/CsvFileRead.ts
@@ -6,7 +6,8 @@ import { Computer, serializeError, str } from '@data-story/core';
 import { getWorkingDirConfig } from '../../server/getWorkingDirConfig';
 
 export const CsvFileRead: Computer = {
-  type: 'CsvFile.read',
+  type: 'Computer',
+  computerType: 'CsvFile.read',
   label: 'CsvFile.read',
   category: 'NodeJs',
   inputs: [],

--- a/packages/nodejs/src/computers/CsvFileWrite/CsvFileWrite.ts
+++ b/packages/nodejs/src/computers/CsvFileWrite/CsvFileWrite.ts
@@ -5,7 +5,8 @@ import { stringify } from 'csv-stringify';
 import { getWorkingDirConfig } from '../../server/getWorkingDirConfig';
 
 export const CsvFileWrite: Computer = {
-  type: 'CsvFile.write',
+  type: 'Computer',
+  computerType: 'CsvFile.write',
   label: 'CsvFile.write',
   category: 'NodeJs',
   inputs: [{

--- a/packages/nodejs/src/computers/JsonFileRead/JsonFileRead.ts
+++ b/packages/nodejs/src/computers/JsonFileRead/JsonFileRead.ts
@@ -5,7 +5,8 @@ import { Computer, get, asArray, ItemValue, serializeError, str } from '@data-st
 import { getWorkingDirConfig } from '../../server/getWorkingDirConfig';
 
 export const JsonFileRead: Computer = {
-  type: 'JsonFile.read',
+  type: 'Computer',
+  computerType: 'JsonFile.read',
   label: 'JsonFile.read',
   category: 'NodeJs',
   inputs: [],

--- a/packages/nodejs/src/computers/JsonFileWrite/JsonFileWrite.ts
+++ b/packages/nodejs/src/computers/JsonFileWrite/JsonFileWrite.ts
@@ -4,7 +4,8 @@ import * as path from 'path';
 import { getWorkingDirConfig } from '../../server/getWorkingDirConfig';
 
 export const JsonFileWrite: Computer = {
-  type: 'JsonFile.write',
+  type: 'Computer',
+  computerType: 'JsonFile.write',
   label: 'JsonFile.write',
   category: 'NodeJs',
   inputs: [{

--- a/packages/nodejs/src/computers/ListFiles/ListFiles.ts
+++ b/packages/nodejs/src/computers/ListFiles/ListFiles.ts
@@ -3,7 +3,8 @@ import { promises as fs } from 'fs'
 import * as nodePath from 'path'
 
 export const ListFiles: Computer = {
-  type: 'ListFiles',
+  type: 'Computer',
+  computerType: 'ListFiles',
   label: 'ListFiles',
   category: 'NodeJs',
   inputs: [{

--- a/packages/nodejs/src/computers/ReadFiles/ReadFiles.ts
+++ b/packages/nodejs/src/computers/ReadFiles/ReadFiles.ts
@@ -3,7 +3,8 @@ import { promises as fs } from 'fs';
 import { Computer, str } from '@data-story/core';
 
 export const ReadFiles: Computer = {
-  type: 'ReadFiles',
+  type: 'Computer',
+  computerType: 'ReadFiles',
   label: 'ReadFiles',
   category: 'NodeJs',
   inputs: [{

--- a/packages/nodejs/src/computers/RunCommand/RunCommand.ts
+++ b/packages/nodejs/src/computers/RunCommand/RunCommand.ts
@@ -21,7 +21,8 @@ async function awaitableExec(command: string): Promise<{
 }
 
 export const RunCommand: Computer = {
-  type: 'RunCommand',
+  type: 'Computer',
+  computerType: 'RunCommand',
   label: 'RunCommand',
   category: 'NodeJs',
   inputs: [{

--- a/packages/nodejs/src/computers/WriteFile/WriteFile.ts
+++ b/packages/nodejs/src/computers/WriteFile/WriteFile.ts
@@ -2,7 +2,8 @@ import { promises as fs } from 'fs';
 import { Computer, str } from '@data-story/core';
 
 export const WriteFile: Computer = {
-  type: 'WriteFile',
+  type: 'Computer',
+  computerType: 'WriteFile',
   label: 'WriteFile',
   category: 'NodeJs',
   inputs: [{

--- a/packages/ui/src/components/DataStory/modals/addNodeForm.tsx
+++ b/packages/ui/src/components/DataStory/modals/addNodeForm.tsx
@@ -37,8 +37,8 @@ export const AddNodeFormContent = (props: AddNodeModalContentProps) => {
     .sort((a: NodeDescription, b: NodeDescription) => {
       // Prioritize sorting by type if either is "Input" or "Output"
       const typePriority = { Input: 1, Output: 2 }; // Define priority for types
-      const aTypePriority = typePriority[a.type] || Number.MAX_SAFE_INTEGER; // Default to a very high number if not "Input" or "Output"
-      const bTypePriority = typePriority[b.type] || Number.MAX_SAFE_INTEGER; // Same here
+      const aTypePriority = typePriority[a.computerType] || Number.MAX_SAFE_INTEGER; // Default to a very high number if not "Input" or "Output"
+      const bTypePriority = typePriority[b.computerType] || Number.MAX_SAFE_INTEGER; // Same here
 
       if (aTypePriority < bTypePriority) return -1; // Move "Input" or "Output" to the front
       if (aTypePriority > bTypePriority) return 1;
@@ -86,13 +86,13 @@ export const AddNodeFormContent = (props: AddNodeModalContentProps) => {
               onClick={() => doAddNode(nodeDescription)}
               draggable="true"
               onDragStart={(event) => {
-                event.dataTransfer.setData('application/reactflow', nodeDescription.type);
+                event.dataTransfer.setData('application/reactflow', nodeDescription.computerType);
                 event.dataTransfer.effectAllowed = 'move';
               }}
             >
               <div className='text-gray-500 text-xs overflow-hidden'>
                 <span className='text-indigo-500 font-mono'>{nodeDescription.category || 'Core'}::</span>
-                {nodeDescription.label || nodeDescription.type}
+                {nodeDescription.label || nodeDescription.computerType}
               </div>
             </button>
           );

--- a/packages/ui/src/components/DataStory/onDropDefault.ts
+++ b/packages/ui/src/components/DataStory/onDropDefault.ts
@@ -33,7 +33,8 @@ export const fileDropper = {
         // Furthermore, the definition of the Create node might change
         // Consider having datastory register DnD-ables?
         const description: NodeDescription = {
-          type: 'Create',
+          type: 'NodeDescription',
+          computerType: 'Create',
           label: file.name,
           inputs: [],
           outputs: [{

--- a/packages/ui/src/components/DataStory/useHotkeys.tsx
+++ b/packages/ui/src/components/DataStory/useHotkeys.tsx
@@ -74,7 +74,7 @@ export function useHotkeys({
   useEffect(() => {
     const addTableNode = () => {
       if (!nodeDescriptions || !addNodeFromDescription) return;
-      const tableNode = nodeDescriptions.find(nd => nd.type === 'Table');
+      const tableNode = nodeDescriptions.find(nd => nd.computerType === 'Table');
       if (tableNode) {
         addNodeFromDescription(tableNode);
       }

--- a/packages/ui/src/factories/NodeFactory.ts
+++ b/packages/ui/src/factories/NodeFactory.ts
@@ -30,11 +30,11 @@ export const NodeFactory = {
     nodeDescription: NodeDescription,
     diagram: Diagram,
   ): Node {
-    const id = `${nodeDescription.type}.${createDataStoryId()}`;
+    const id = `${nodeDescription.computerType}.${createDataStoryId()}`;
 
     return structuredClone({
       id,
-      type: nodeDescription.type,
+      type: nodeDescription.computerType,
       label: nodeDescription.label,
       inputs: nodeDescription.inputs.map(input => {
         return {


### PR DESCRIPTION
* adds reserved`type: 'NodeDescription'` on NodeDescription
* renames `type` to `computerType` on Computer and adds reserved `type`
* adds `type` on Diagram class
* adds type `SerializedDiagram`

### Example NodeDescription
```
{
  type: 'NodeDescrition',
  computerType: 'Signal',
  // ...
}
```

### Example Computer
```
{
  type: 'Computer',
  computerType: 'Signal',
}
```